### PR TITLE
Implement batch inference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 # general
 option(CLIP_STATIC                 "CLIP: static link libraries"                          OFF)
-option(CLIP_BUILD_TEST             "CLIP: build tests"                                    ${CLIP_STANDALONE})
+option(CLIP_BUILD_TESTS             "CLIP: build tests"                                    ${CLIP_STANDALONE})
 option(CLIP_BUILD_EXAMPLES         "CLIP: build examples"                                 ${CLIP_STANDALONE})
 option(CLIP_BUILD_IMAGE_SEARCH     "CLIP: build image-search"                             OFF)
 option(CLIP_NATIVE                 "CLIP: enable -march=native flag"                      ON)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This repo is aimed at powering useful applications based on such models on compu
 
 clip.cpp also has a short startup time compared to large ML frameworks, which makes it suitable for serverless deployments where the cold start is an issue.
 
+## Hot topics
+- 06/04/2023: Batch inference support for image encoding.
+
 ## Note about image preprocessing
 PIL uses a two-pass convolutions-based bicubic interpolation in resizing with antialiasing applied. In Pytorch, antialiasing is optional. It needs some extra attention to implement this preprocessing logic that matches their results numerically. However, I found that linear interpolation is also good enough for both comparison of different embeddings from this implementation and also comparison of an embedding from this implementation and another one from Transformers. So let's use it until we craft a proper bicubic interpolation.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo is aimed at powering useful applications based on such models on compu
 clip.cpp also has a short startup time compared to large ML frameworks, which makes it suitable for serverless deployments where the cold start is an issue.
 
 ## Hot topics
-- 06/04/2023: Batch inference support for image encoding.
+- 07/04/2023: Batch inference support for image encoding.
 
 ## Note about image preprocessing
 PIL uses a two-pass convolutions-based bicubic interpolation in resizing with antialiasing applied. In Pytorch, antialiasing is optional. It needs some extra attention to implement this preprocessing logic that matches their results numerically. However, I found that linear interpolation is also good enough for both comparison of different embeddings from this implementation and also comparison of an embedding from this implementation and another one from Transformers. So let's use it until we craft a proper bicubic interpolation.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This repo is aimed at powering useful applications based on such models on compu
 clip.cpp also has a short startup time compared to large ML frameworks, which makes it suitable for serverless deployments where the cold start is an issue.
 
 ## Hot topics
-- 07/04/2023: Batch inference support for image encoding.
+- 07/12/2023: Batch inference support for image encoding.
+- 07/11/2023: Semantic image search [example](examples/image-search/README.md) directly in C++.
 
 ## Note about image preprocessing
 PIL uses a two-pass convolutions-based bicubic interpolation in resizing with antialiasing applied. In Pytorch, antialiasing is optional. It needs some extra attention to implement this preprocessing logic that matches their results numerically. However, I found that linear interpolation is also good enough for both comparison of different embeddings from this implementation and also comparison of an embedding from this implementation and another one from Transformers. So let's use it until we craft a proper bicubic interpolation.

--- a/clip.cpp
+++ b/clip.cpp
@@ -1549,7 +1549,7 @@ bool clip_image_batch_encode(
 
     ggml_set_zero(embeddings);
 
-    // TODO: correct thisconcat op
+    // TODO: correct this concat op
     // for (int b = 0; b < batch_size; b++)
     {
         embeddings = ggml_acc(ctx0, embeddings, model.class_embedding, embeddings->nb[1], embeddings->nb[2], embeddings->nb[3], 0);

--- a/clip.cpp
+++ b/clip.cpp
@@ -913,7 +913,6 @@ bool clip_text_encode(
 
     struct ggml_context *ctx0 = ggml_init(params);
     struct ggml_cgraph gf = {};
-    gf.n_threads = n_threads;
 
     static size_t scr0_size = get_scr_buf_req_by_size(ctx->text_model.tensors.size() + ctx->vision_model.tensors.size(), N);
     static void *scr0 = malloc(scr0_size);
@@ -1064,7 +1063,7 @@ bool clip_text_encode(
 
     // run the computation
     ggml_build_forward_expand(&gf, embeddings);
-    ggml_graph_compute(ctx0, &gf);
+    ggml_graph_compute_with_ctx(ctx0, &gf, n_threads);
 
 // print
 #ifdef CLIP_DEBUG
@@ -1168,7 +1167,6 @@ bool clip_image_batch_encode(
 
     struct ggml_context *ctx0 = ggml_init(params);
     struct ggml_cgraph gf = {};
-    gf.n_threads = n_threads;
 
     static size_t scr0_size = get_scr_buf_req_by_size(ctx->text_model.tensors.size() + ctx->vision_model.tensors.size(), num_positions);
     static void *scr0 = malloc(scr0_size);
@@ -1380,7 +1378,7 @@ bool clip_image_batch_encode(
 
     // run the computation
     ggml_build_forward_expand(&gf, output);
-    ggml_graph_compute(ctx0, &gf);
+    ggml_graph_compute_with_ctx(ctx0, &gf, n_threads);
 
 // print
 #ifdef CLIP_DEBUG

--- a/clip.cpp
+++ b/clip.cpp
@@ -11,7 +11,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
-// #define CLIP_DEBUG
+#define CLIP_DEBUG
 
 // utility function for a workaround until https://github.com/ggerganov/ggml/issues/260 is resolved
 // after that, remove this and use the mechanism implemented in GGML directly

--- a/clip.cpp
+++ b/clip.cpp
@@ -277,9 +277,9 @@ void *preprocess_image(void *arg)
 }
 
 // Function to batch-preprocess multiple images i
-void clip_image_batch_preprocess(const clip_ctx *ctx, const std::vector<clip_image_u8 *> &img_inputs, std::vector<clip_image_f32> &img_resized, const int n_threads)
+void clip_image_batch_preprocess(const clip_ctx *ctx, const std::vector<clip_image_u8 *> &img_inputs, std::vector<clip_image_f32> &imgs_resized, const int n_threads)
 {
-    GGML_ASSERT(img_inputs.size() == img_resized.size());
+    GGML_ASSERT(img_inputs.size() == imgs_resized.size());
     int num_threads = std::min(n_threads, static_cast<int>(img_inputs.size()));
     int i, t;
 
@@ -291,7 +291,7 @@ void clip_image_batch_preprocess(const clip_ctx *ctx, const std::vector<clip_ima
         // Single-threaded case
         for (i = 0; i < img_inputs.size(); i++)
         {
-            clip_image_preprocess(ctx, img_inputs[i], &img_resized[i]);
+            clip_image_preprocess(ctx, img_inputs[i], &imgs_resized[i]);
         }
     }
     else
@@ -310,7 +310,7 @@ void clip_image_batch_preprocess(const clip_ctx *ctx, const std::vector<clip_ima
             for (i = start_index; i < end_index; i++)
             {
                 imageData[i].input = img_inputs[i];
-                imageData[i].resized = &img_resized[i];
+                imageData[i].resized = &imgs_resized[i];
                 imageData[i].ctx = ctx;
             }
 

--- a/clip.cpp
+++ b/clip.cpp
@@ -11,7 +11,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
-// #define CLIP_DEBUG
+#define CLIP_DEBUG
 
 // utility function for a workaround until https://github.com/ggerganov/ggml/issues/260 is resolved
 // after that, remove this and use the mechanism implemented in GGML directly
@@ -23,7 +23,7 @@ size_t get_mem_req_by_size(const size_t n_tensors, const int n_image_positions)
     case 397:                        // base
         if (n_image_positions == 50) // patch size = 32
         {
-            return 8 * mb;
+            return 16 * mb;
         }
         else // patch size = 16
         {
@@ -1236,7 +1236,6 @@ bool clip_image_encode(
 
         // residual 2
         cur = ggml_add(ctx0, embeddings, cur);
-        // ggml_set_name(cur, "check");
 
         embeddings = cur;
     }
@@ -1475,5 +1474,310 @@ bool image_normalize(clip_image_u8 *img, clip_image_f32 *res)
             }
         }
     }
+    return true;
+}
+
+bool clip_image_batch_encode(
+    const clip_ctx *ctx,
+    int n_threads,
+    const std::vector<clip_image_f32> &imgs,
+    float *vec)
+{
+    const auto &model = ctx->vision_model;
+    const auto &hparams = model.hparams;
+
+    const int image_size = hparams.image_size;
+    const int patch_size = hparams.patch_size;
+    const int num_patches = ((image_size / patch_size) * (image_size / patch_size));
+    const int num_positions = num_patches + 1;
+    const int hidden_size = hparams.hidden_size;
+    const int n_head = hparams.n_head;
+    const int d_head = hidden_size / n_head;
+    const int n_layer = hparams.n_layer;
+    const int n_intermediate = hparams.n_intermediate;
+    const int projection_dim = hparams.projection_dim;
+    const int batch_size = imgs.size();
+
+    auto &buf_compute = ctx->buf_compute;
+
+    struct ggml_init_params params = {
+        .mem_size = buf_compute.size,
+        .mem_buffer = buf_compute.data,
+        .no_alloc = false,
+    };
+
+    struct ggml_context *ctx0 = ggml_init(params);
+    struct ggml_cgraph gf = {};
+    gf.n_threads = n_threads;
+
+    static size_t scr0_size = get_scr_buf_req_by_size(ctx->text_model.tensors.size() + ctx->vision_model.tensors.size(), num_positions);
+    static void *scr0 = malloc(scr0_size);
+
+    struct ggml_tensor *inp = ggml_new_tensor_4d(ctx0, GGML_TYPE_F32, image_size, image_size, 3, batch_size);
+
+    {
+        float *data = (float *)ggml_get_data(inp);
+
+        const int nx = imgs[0].nx;
+        const int ny = imgs[0].ny;
+        const int n = nx * ny;
+
+        GGML_ASSERT(nx == image_size && ny == image_size);
+
+        for (int b = 0; b < batch_size; b++)
+        {
+            for (int k = 0; k < 3; k++)
+            {
+                for (int y = 0; y < ny; y++)
+                {
+                    for (int x = 0; x < nx; x++)
+                    {
+                        data[(b * k * n) + k * n + y * nx + x] = imgs[b].data[3 * (y * nx + x) + k];
+                    }
+                }
+            }
+        }
+    }
+
+    inp = ggml_conv_2d_sk_p0(ctx0, model.patch_embeddings, inp);
+    inp = ggml_reshape_3d(ctx0, inp, num_patches, hidden_size, batch_size);
+    inp = ggml_cont(ctx0, ggml_permute(ctx0, inp, 1, 0, 2, 3));
+
+    // concat class_embeddings and patch_embeddings
+    struct ggml_tensor *embeddings = ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, hidden_size, num_positions, batch_size);
+    /*
+    ggml_set_zero(embeddings);
+    for (int b = 0; b < batch_size; b++)
+    {
+        embeddings = ggml_acc(ctx0, embeddings, model.class_embedding, embeddings->nb[1] / batch_size, embeddings->nb[2] / batch_size, embeddings->nb[3] / batch_size, b * (ggml_nbytes(embeddings) / batch_size));
+        embeddings = ggml_acc(ctx0, embeddings, inp, embeddings->nb[1] / batch_size, embeddings->nb[2] / batch_size, embeddings->nb[3] / batch_size, ggml_element_size(model.class_embedding) * hidden_size);
+    }
+    */
+
+    embeddings = ggml_acc(ctx0, embeddings, model.class_embedding, embeddings->nb[1], embeddings->nb[2], embeddings->nb[3], 0);
+    embeddings = ggml_acc(ctx0, embeddings, inp, embeddings->nb[1], embeddings->nb[2], embeddings->nb[3], ggml_element_size(model.class_embedding) * hidden_size);
+
+    struct ggml_tensor *positions = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, num_positions);
+    for (int i = 0; i < num_positions; i++)
+    {
+        ggml_set_i32_1d(positions, i, i);
+    }
+
+    embeddings = ggml_add(ctx0, embeddings, ggml_repeat(ctx0, ggml_get_rows(ctx0, model.position_embeddings, positions), embeddings));
+
+    // pre-layernorm
+    {
+        embeddings = ggml_norm(ctx0, embeddings);
+
+        embeddings = ggml_add(ctx0,
+                              ggml_mul(ctx0,
+                                       ggml_repeat(ctx0, model.pre_ln_w, embeddings),
+                                       embeddings),
+                              ggml_repeat(ctx0, model.pre_ln_b, embeddings));
+    }
+
+    struct ggml_tensor *temp_w = ggml_new_tensor_4d(ctx0, model.layers[0].q_w->type, hidden_size, hidden_size, batch_size, 1);
+    struct ggml_tensor *temp_i = ggml_new_tensor_4d(ctx0, model.layers[0].ff_i_w->type, hidden_size, n_intermediate, batch_size, 1);
+    struct ggml_tensor *temp_o = ggml_new_tensor_4d(ctx0, model.layers[0].ff_o_w->type, n_intermediate, hidden_size, batch_size, 1);
+
+    // loop over layers
+    for (int il = 0; il < n_layer; il++)
+    {
+        struct ggml_tensor *cur = embeddings; // embeddings = residual, cur = hidden_states
+
+        const size_t nb_q_w = model.layers[il].q_w->nb[0];
+
+        ggml_set_scratch(ctx0, {0, scr0_size, scr0});
+
+        // layernorm1
+        {
+            cur = ggml_norm(ctx0, cur);
+
+            cur = ggml_add(ctx0,
+                           ggml_mul(ctx0,
+                                    ggml_repeat(ctx0, model.layers[il].ln_1_w, cur),
+                                    cur),
+                           ggml_repeat(ctx0, model.layers[il].ln_1_b, cur));
+        }
+
+        // self-attention
+        {
+
+            struct ggml_tensor *Q = ggml_add(ctx0, ggml_repeat(ctx0, model.layers[il].q_b, cur),
+                                             ggml_mul_mat(ctx0, ggml_repeat(ctx0, model.layers[il].q_w, temp_w),
+                                                          cur));
+
+            Q = ggml_scale_inplace(ctx0, Q, ggml_new_f32(ctx0, 1.0f / sqrt((float)d_head)));
+            Q = ggml_reshape_4d(ctx0, Q, d_head, n_head, num_positions, batch_size);
+            Q = ggml_cont(ctx0, ggml_permute(ctx0, Q, 0, 2, 1, 3));
+            Q = ggml_reshape_3d(ctx0, Q, d_head, num_positions, n_head * batch_size);
+
+            struct ggml_tensor *K = ggml_add(ctx0, ggml_repeat(ctx0, model.layers[il].k_b, cur),
+                                             ggml_mul_mat(ctx0, ggml_repeat(ctx0, model.layers[il].k_w, temp_w),
+                                                          cur));
+
+            K = ggml_reshape_4d(ctx0, K, d_head, n_head, num_positions, batch_size);
+            K = ggml_cont(ctx0, ggml_permute(ctx0, K, 0, 2, 1, 3));
+            K = ggml_reshape_3d(ctx0, K, d_head, num_positions, n_head * batch_size);
+
+            struct ggml_tensor *V = ggml_add(ctx0, ggml_repeat(ctx0, model.layers[il].v_b, cur),
+                                             ggml_mul_mat(ctx0, ggml_repeat(ctx0, model.layers[il].v_w, temp_w),
+                                                          cur));
+
+            V = ggml_reshape_4d(ctx0, V, d_head, n_head, num_positions, batch_size);
+            V = ggml_cont(ctx0, ggml_permute(ctx0, V, 1, 2, 0, 3));
+            V = ggml_reshape_3d(ctx0, V, num_positions, d_head, n_head * batch_size);
+
+            struct ggml_tensor *KQ = ggml_mul_mat(ctx0, K, Q);
+            KQ = ggml_soft_max_inplace(ctx0, KQ);
+            struct ggml_tensor *KQV = ggml_mul_mat(ctx0, V, KQ);
+            KQV = ggml_reshape_4d(ctx0, KQV, d_head, num_positions, n_head, batch_size);
+            KQV = ggml_cont(ctx0, ggml_permute(ctx0, KQV, 0, 2, 1, 3));
+
+            cur = ggml_cpy(ctx0,
+                           KQV,
+                           ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, hidden_size, num_positions, batch_size));
+        }
+
+        // attention output
+        cur = ggml_add(ctx0,
+                       ggml_repeat(ctx0, model.layers[il].o_b, cur),
+                       ggml_mul_mat(ctx0, ggml_repeat(ctx0, model.layers[il].o_w, temp_w),
+                                    cur));
+
+        // re-add the layer input, e.g., residual
+        cur = ggml_add(ctx0, cur, embeddings);
+
+        embeddings = cur; // embeddings = residual, cur = hidden_states
+
+        // layernorm2
+        {
+            cur = ggml_norm(ctx0, cur);
+
+            cur = ggml_add(ctx0,
+                           ggml_mul(ctx0,
+                                    ggml_repeat(ctx0, model.layers[il].ln_2_w, cur),
+                                    cur),
+                           ggml_repeat(ctx0, model.layers[il].ln_2_b, cur));
+        }
+
+        cur = ggml_mul_mat(ctx0, ggml_repeat(ctx0, model.layers[il].ff_i_w, temp_i), cur);
+        cur = ggml_add(ctx0,
+                       ggml_repeat(ctx0, model.layers[il].ff_i_b, cur),
+                       cur);
+
+        if (ctx->use_gelu)
+        {
+            cur = ggml_gelu_inplace(ctx0, cur);
+        }
+        else
+        {
+            cur = ggml_gelu_quick_inplace(ctx0, cur);
+        }
+
+        cur = ggml_mul_mat(ctx0, ggml_repeat(ctx0, model.layers[il].ff_o_w, temp_o), cur);
+        cur = ggml_add(ctx0,
+                       ggml_repeat(ctx0, model.layers[il].ff_o_b, cur),
+                       cur);
+
+        // residual 2
+        cur = ggml_add(ctx0, embeddings, cur);
+
+        embeddings = cur;
+    }
+
+    // get the output of cls token, e.g., 0th index
+    struct ggml_tensor *cls = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, batch_size);
+    for (int b = 0; b < batch_size; b++)
+    {
+        ggml_set_i32_1d(cls, b, b * num_positions);
+    }
+    embeddings = ggml_get_rows(ctx0, ggml_reshape_2d(ctx0, embeddings, hidden_size, num_positions * batch_size), cls);
+
+    // post-layernorm
+    {
+        embeddings = ggml_norm(ctx0, embeddings);
+
+        embeddings = ggml_add(ctx0,
+                              ggml_mul(ctx0,
+                                       ggml_repeat(ctx0, model.post_ln_w, embeddings),
+                                       embeddings),
+                              ggml_repeat(ctx0, model.post_ln_b, embeddings));
+    }
+
+    ggml_set_scratch(ctx0, {0, 0, nullptr});
+
+    // final visual projection
+    embeddings = ggml_mul_mat(ctx0, model.projection, embeddings);
+
+    // normalize output embeddings
+    ggml_tensor *length = ggml_sqrt(ctx0,
+                                    ggml_sum(ctx0, ggml_sqr(ctx0, embeddings)));
+    embeddings = ggml_scale_inplace(ctx0, embeddings, ggml_div(ctx0, ggml_new_f32(ctx0, 1.0f), length));
+
+    ggml_set_name(embeddings, "check");
+
+    // run the computation
+    ggml_build_forward_expand(&gf, embeddings);
+    ggml_graph_compute(ctx0, &gf);
+
+// print
+#ifdef CLIP_DEBUG
+    {
+        auto print_t_f32 = [&](struct ggml_tensor *t)
+        {
+            float *data = (float *)t->data;
+            printf("dtype: f32, dims: %jd %jd %jd %jd, nb: %jd %jd %jd %jd\n", t->ne[0], t->ne[1], t->ne[2], t->ne[3], t->nb[0], t->nb[1], t->nb[2], t->nb[3]);
+            printf("data: ");
+            for (int i = 0; i < std::min((int)t->ne[0], 20); i++)
+            {
+                printf("%f ", data[i]);
+            }
+
+            // printf("\n\n");
+            double sum = 0.0;
+            for (int i = 0; i < ggml_nelements(t); i++)
+            {
+                sum += data[i];
+            }
+            printf("sum:  %f\n", sum);
+        };
+
+        auto print_t_f16 = [&](struct ggml_tensor *t)
+        {
+            ggml_fp16_t *data = (ggml_fp16_t *)t->data;
+            printf("dtype: f16, dims: %jd %jd %jd %jd\n", t->ne[0], t->ne[1], t->ne[2], t->ne[3]);
+            printf("data: ");
+            for (int i = 0; i < std::min((int)t->ne[0], 10); i++)
+            {
+                printf("%f ", ggml_fp16_to_fp32(data[i]));
+            }
+            printf("\n\n");
+            double sum = 0.0;
+            for (int i = 0; i < ggml_nelements(t); i++)
+            {
+                sum += ggml_fp16_to_fp32(data[i]);
+            }
+            printf("sum:  %f\n", sum);
+        };
+
+        auto *t = ggml_get_tensor(ctx0, "check");
+        if (t->type == GGML_TYPE_F32)
+        {
+            print_t_f32(t);
+        }
+        else
+        {
+            print_t_f16(t);
+        }
+    }
+
+    printf("used_mem = %zu\n", ggml_used_mem(ctx0));
+#endif
+
+    memcpy(vec, ggml_get_data_f32(embeddings), sizeof(float) * projection_dim);
+
+    ggml_free(ctx0);
+
     return true;
 }

--- a/clip.cpp
+++ b/clip.cpp
@@ -11,7 +11,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
-#define CLIP_DEBUG
+// #define CLIP_DEBUG
 
 // utility function for a workaround until https://github.com/ggerganov/ggml/issues/260 is resolved
 // after that, remove this and use the mechanism implemented in GGML directly

--- a/clip.h
+++ b/clip.h
@@ -200,7 +200,7 @@ std::vector<clip_vocab::id> clip_tokenize(const clip_ctx *ctx, const std::string
 
 bool clip_image_load_from_file(const std::string &fname, clip_image_u8 &img);
 bool clip_image_preprocess(const clip_ctx *ctx, const clip_image_u8 *img, clip_image_f32 *res);
-void clip_image_batch_preprocess(const clip_ctx *ctx, const std::vector<clip_image_u8 *> &img_inputs, std::vector<clip_image_f32> &img_resized, const int n_threads);
+void clip_image_batch_preprocess(const clip_ctx *ctx, const int n_threads, const std::vector<clip_image_u8> &img_inputs, std::vector<clip_image_f32> &img_resized);
 
 bool clip_text_encode(
     const clip_ctx *ctx,

--- a/clip.h
+++ b/clip.h
@@ -200,6 +200,7 @@ std::vector<clip_vocab::id> clip_tokenize(const clip_ctx *ctx, const std::string
 
 bool clip_image_load_from_file(const std::string &fname, clip_image_u8 &img);
 bool clip_image_preprocess(const clip_ctx *ctx, const clip_image_u8 *img, clip_image_f32 *res);
+void clip_image_batch_preprocess(const clip_ctx *ctx, const std::vector<clip_image_u8 *> &img_inputs, std::vector<clip_image_f32> &img_resized, const int n_threads);
 
 bool clip_text_encode(
     const clip_ctx *ctx,

--- a/clip.h
+++ b/clip.h
@@ -219,8 +219,11 @@ bool clip_compare_text_and_image(clip_ctx *ctx, int n_threads, std::string &text
 float clip_similarity_score(float *vec1, float *vec2, int vec_dim);
 bool softmax_with_sorting(float *arr, int length, float *sorted_scores, int *indices);
 
-// utils for debugging
-void write_floats_to_file(float *array, int size, char *filename);
+bool clip_image_batch_encode(
+    const clip_ctx *ctx,
+    int n_threads,
+    const std::vector<clip_image_f32> &imgs,
+    float *vec);
 
 // #ifdef __cplusplus
 // }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 
     std::vector<clip_image_f32> imgs;
     imgs.push_back(img_res);
-    imgs.push_back(img_res);
+    // imgs.push_back(img_res);
 
     const int64_t t_image_encode_us = ggml_time_us();
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 
     std::vector<clip_image_f32> imgs;
     imgs.push_back(img_res);
-    // imgs.push_back(img_res);
+    imgs.push_back(img_res);
 
     const int64_t t_image_encode_us = ggml_time_us();
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 
     std::vector<clip_image_f32> imgs;
     imgs.push_back(img_res);
-    // imgs.push_back(img_res);
+    imgs.push_back(img_res);
 
     const int64_t t_image_encode_us = ggml_time_us();
 
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
 
     const int64_t t_similarity_score = ggml_time_us();
 
-    float score = clip_similarity_score(txt_vec, img_vec, vec_dim);
+    float score = clip_similarity_score(txt_vec, img_vec + vec_dim, vec_dim);
     printf("%s Similarity score = %2.3f\n", __func__, score);
 
     const int64_t t_main_end_us = ggml_time_us();

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -54,21 +54,17 @@ int main(int argc, char **argv)
 
     clip_image_preprocess(ctx, &img0, &img_res);
 
-    std::vector<clip_image_f32> imgs;
-    imgs.push_back(img_res);
-    imgs.push_back(img_res);
-
     const int64_t t_image_encode_us = ggml_time_us();
 
-    float img_vec[vec_dim * 2];
-    if (!clip_image_batch_encode(ctx, params.n_threads, imgs, img_vec))
+    float img_vec[vec_dim];
+    if (!clip_image_encode(ctx, params.n_threads, img_res, img_vec))
     {
         return 1;
     }
 
     const int64_t t_similarity_score = ggml_time_us();
 
-    float score = clip_similarity_score(txt_vec, img_vec + vec_dim, vec_dim);
+    float score = clip_similarity_score(txt_vec, img_vec, vec_dim);
     printf("%s Similarity score = %2.3f\n", __func__, score);
 
     const int64_t t_main_end_us = ggml_time_us();

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -54,10 +54,14 @@ int main(int argc, char **argv)
 
     clip_image_preprocess(ctx, &img0, &img_res);
 
+    std::vector<clip_image_f32> imgs;
+    imgs.push_back(img_res);
+    // imgs.push_back(img_res);
+
     const int64_t t_image_encode_us = ggml_time_us();
 
-    float img_vec[vec_dim];
-    if (!clip_image_encode(ctx, params.n_threads, img_res, img_vec))
+    float img_vec[vec_dim * 2];
+    if (!clip_image_batch_encode(ctx, params.n_threads, imgs, img_vec))
     {
         return 1;
     }

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -54,6 +54,7 @@ int main(int argc, char **argv)
     }
 
     const size_t batch_size = 4;
+    const size_t n_threads = 4;
 
     const int vec_dim = ctx->text_model.hparams.projection_dim;
 
@@ -70,7 +71,7 @@ int main(int argc, char **argv)
     for (const auto &entry : result)
     {
         auto tokens = clip_tokenize(ctx, entry.first);
-        if (!clip_text_encode(ctx, 4, tokens, txt_vecs + label_idx * vec_dim))
+        if (!clip_text_encode(ctx, n_threads, tokens, txt_vecs + label_idx * vec_dim))
         {
             printf("%s: Could not encode the label at index %d: %s\n", __func__, label_idx, entry.first.c_str());
             return 1;
@@ -120,9 +121,9 @@ int main(int argc, char **argv)
                 }
             }
 
-            clip_image_batch_preprocess(ctx, 4, img_inputs, imgs_resized);
+            clip_image_batch_preprocess(ctx, n_threads, img_inputs, imgs_resized);
 
-            clip_image_batch_encode(ctx, 4, imgs_resized, img_vecs);
+            clip_image_batch_encode(ctx, n_threads, imgs_resized, img_vecs);
 
             for (size_t b = 0; b < batch_size; b++)
             {

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    fprintf(fout, "%s: %d directories found in %s\n\n", __func__, n_labels, dir_path.c_str());
+    fprintf(fout, "%s: %zu directories found in %s\n\n", __func__, n_labels, dir_path.c_str());
 
     auto ctx = clip_model_load(model_path.c_str(), 2);
     if (!ctx)
@@ -53,14 +53,11 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    const size_t batch_size = 4;
+
     const int vec_dim = ctx->text_model.hparams.projection_dim;
 
-    // allocate memory for text vectors
-    float *txt_vecs = (float *)malloc(n_labels * vec_dim * sizeof(float));
-    if (!txt_vecs)
-    {
-        printf("%s: Could not allocate memory for %d vectors of %d dimensions\n", __func__, n_labels, vec_dim);
-    }
+    float txt_vecs[n_labels * vec_dim];
 
     ggml_time_init();
 
@@ -88,12 +85,13 @@ int main(int argc, char **argv)
     int n_total_items = 0;         // total number of images processed
     float total_acc1_score = 0.0f; // total accuracy at 1 for the intire dataset
     float total_acc5_score = 0.0f; // total accuracy at 5 in intitre dataset
-    float img_vec[vec_dim];
+    float img_vecs[vec_dim * batch_size];
+
     float similarities[n_labels];
     float sorted_scores[n_labels];
     int indices[n_labels];
-    clip_image_u8 img;
-    clip_image_f32 img_res;
+    std::vector<clip_image_u8> img_inputs(batch_size);
+    std::vector<clip_image_f32> imgs_resized(batch_size);
 
     // print table headers
     fprintf(fout, "| class name           | acc@1  | acc@5  |\n");
@@ -107,56 +105,59 @@ int main(int argc, char **argv)
         int n_acc1 = 0;
         int n_acc5 = 0;
 
-        int64_t t_start_encode_images = ggml_time_us();
+        size_t n_batched = (entry.second.size() / batch_size) * batch_size;
 
-        for (auto &file_path : entry.second)
+        for (size_t i = 0; i < n_batched; i += batch_size)
         {
-            if (!clip_image_load_from_file(file_path, img))
+            for (size_t ib = i; ib < i + batch_size; ib++)
             {
-                printf("%s: cannot load file from %s\n", __func__, file_path.c_str());
-                return 1;
-            }
+                std::string file_path = entry.second[ib];
 
-            if (!clip_image_preprocess(ctx, &img, &img_res))
-            {
-                printf("%s: cannot preprocess image loaded from %s\n", __func__, file_path.c_str());
-                return 1;
-            }
-
-            clip_image_encode(ctx, 4, img_res, img_vec);
-            for (size_t i = 0; i < n_labels; i++)
-            {
-                similarities[i] = clip_similarity_score(img_vec, txt_vecs + i * vec_dim, vec_dim);
-            }
-
-            softmax_with_sorting(similarities, n_labels, sorted_scores, indices);
-            for (int j = 0; j < 5; j++)
-            {
-                if (j == 0 && indices[j] == label_idx)
+                if (!clip_image_load_from_file(file_path, img_inputs[ib % batch_size]))
                 {
-                    n_acc1 += 1;
-                    n_acc5 += 1;
-                    break;
-                }
-                else if (indices[j] == label_idx)
-                {
-                    n_acc5 += 1;
-                    break;
+                    printf("%s: cannot load file from %s\n", __func__, file_path.c_str());
+                    return 1;
                 }
             }
 
-            n_items += 1;
-            n_total_items += 1;
+            clip_image_batch_preprocess(ctx, 4, img_inputs, imgs_resized);
+
+            clip_image_batch_encode(ctx, 4, imgs_resized, img_vecs);
+
+            for (size_t b = 0; b < batch_size; b++)
+            {
+                for (size_t j = 0; j < n_labels; j++)
+                {
+                    similarities[j] = clip_similarity_score(img_vecs + b * vec_dim, txt_vecs + j * vec_dim, vec_dim);
+                }
+                softmax_with_sorting(similarities, n_labels, sorted_scores, indices);
+
+                for (int k = 0; k < 5; k++)
+                {
+                    if (k == 0 && indices[k] == label_idx)
+                    {
+                        n_acc1 += 1;
+                        n_acc5 += 1;
+                        break;
+                    }
+                    else if (indices[k] == label_idx)
+                    {
+                        n_acc5 += 1;
+                        break;
+                    }
+                }
+
+                n_items += 1;
+                n_total_items += 1;
+            }
         }
 
         float acc1_score = (float)n_acc1 / n_items;
         float acc5_score = (float)n_acc5 / n_items;
         total_acc1_score += acc1_score;
         total_acc5_score += acc5_score;
-        // printf("%s: acc@1 = %2.4f - acc@5 = %2.4f\n", entry.first.c_str(), acc1_score, acc5_score);
         fprintf(fout, "| %-*s ", 20, entry.first.c_str());
         fprintf(fout, "| %2.4f | %2.4f |\n", acc1_score, acc5_score);
-
         label_idx += 1;
     }
 


### PR DESCRIPTION
Closes #3 

Currently batch inference is implemented only for image encoding. It'll be implemented for text encoding in a future PR.