### PR TITLE
Target C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ if (CLIP_ALL_WARNINGS)
 
 endif()
 
-add_compile_options(-Wno-format -O3)
+add_compile_options(-Wno-format)
 
 if (CLIP_LTO)
     include(CheckIPOSupported)
@@ -259,7 +259,7 @@ add_library(clip
             clip.h)
 
 target_include_directories(clip PUBLIC .)
-target_compile_features(clip PUBLIC cxx_std_20) # don't bump
+target_compile_features(clip PUBLIC cxx_std_11)
 target_link_libraries(clip PRIVATE ggml ${CLIP_EXTRA_LIBS})
 
 if (BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ if (CLIP_ALL_WARNINGS)
             -Wall
             -Wextra
             -Wpedantic
+            -Wno-format
             -Wcast-qual
             -Wdouble-promotion
             -Wshadow
@@ -127,6 +128,7 @@ if (CLIP_ALL_WARNINGS)
             -Wall
             -Wextra
             -Wpedantic
+            -Wno-format
             -Wcast-qual
             -Wno-unused-function
         )
@@ -140,8 +142,6 @@ if (CLIP_ALL_WARNINGS)
     )
 
 endif()
-
-add_compile_options(-Wno-format)
 
 if (CLIP_LTO)
     include(CheckIPOSupported)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The CLI args are the same as in `main`,
 but you must specify multiple `--text` arguments to specify the labels.
 
 3. `image-search` is an example for semantic image search with [USearch](https://github.com/unum-cloud/usearch/).
-You must enable `CLIP_BUILD_IMAGE_SEARCH` option to compile it, and the dependency will beautomatically fetched by cmake:
+You must enable `CLIP_BUILD_IMAGE_SEARCH` option to compile it, and the dependency will be automatically fetched by cmake:
 
 ```sh
 mkdir build
@@ -128,7 +128,7 @@ cmake -DCLIP_BUILD_IMAGE_SEARCH=ON ..
 make
 ```
 
-See [examples/image-search/README.md](examples/image-search/README.md) for more info.
+See [examples/image-search/README.md](examples/image-search/README.md) for more info and usage.
 
 ## Benchmarking
 You can use the benchmarking utility to compare the performances of different checkpoints and quantization types.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For example, you can run the following to convert the model to q4_0:
 Now you can use `ggml-model-q4_0.bin` just like the model in F16.
 
 ## Usage
-Currently we have two examples: `main` and `zsl`.
+Currently we have three examples: `main`, `zsl` and `image-search`.
 
 1. `main` is just for demonstrating the usage of API and optionally print out some verbose timings. It simply calculates the similarity between one image and one text passed as CLI args.
 
@@ -114,6 +114,21 @@ Options:  -h, --help: Show this message and exit
 2. `zsl` is a zero-shot image labeling example. It labels an image with one of the labels.
 The CLI args are the same as in `main`,
 but you must specify multiple `--text` arguments to specify the labels.
+
+3. `image-search` is an example for semantic image search with [USearch](https://github.com/unum-cloud/usearch/).
+You must enable `CLIP_BUILD_IMAGE_SEARCH` option to compile it, and the dependency will beautomatically fetched by cmake:
+
+```sh
+mkdir build
+
+cd build
+
+cmake -DCLIP_BUILD_IMAGE_SEARCH=ON ..
+
+make
+```
+
+See [examples/image-search/README.md](examples/image-search/README.md) for more info.
 
 ## Benchmarking
 You can use the benchmarking utility to compare the performances of different checkpoints and quantization types.

--- a/clip.cpp
+++ b/clip.cpp
@@ -123,7 +123,7 @@ std::vector<clip_vocab::id> clip_tokenize(const clip_ctx *ctx, const std::string
     {
         // feel lucky? let's try if it's a full word
         std::string full_word = "";
-        if (word.starts_with(" "))
+        if (word.find(" ") == 0) // starts_with for C++11
         {
             full_word += word.substr(1);
         }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,13 +1,16 @@
 add_library(common-clip STATIC common-clip.cpp)
-target_link_libraries(common-clip PRIVATE ggml)
 target_include_directories(common-clip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_features(common-clip PUBLIC cxx_std_11)
+target_link_libraries(common-clip PRIVATE ggml)
 
 if (CLIP_BUILD_IMAGE_SEARCH)
     add_subdirectory(./image-search)
 endif()
 
 add_executable(main main.cpp)
+target_compile_features(main PUBLIC cxx_std_11)
 target_link_libraries(main PRIVATE clip common-clip ggml)
 
 add_executable(zsl zsl.cpp)
+target_compile_features(zsl PUBLIC cxx_std_11)
 target_link_libraries(zsl PRIVATE clip common-clip ggml)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(common-clip STATIC common-clip.cpp)
+add_library(common-clip STATIC common-clip.h common-clip.cpp)
 target_include_directories(common-clip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(common-clip PUBLIC cxx_std_11)
 target_link_libraries(common-clip PRIVATE ggml)

--- a/examples/common-clip.cpp
+++ b/examples/common-clip.cpp
@@ -98,6 +98,10 @@ std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::s
         }
         else
         {
+            if (!is_image_file_extension(fullPath))
+            {
+                continue;
+            }
             size_t pos = path.find_last_of("/");
             std::string parentDir = (pos != std::string::npos) ? path.substr(pos + 1) : path;
             result[parentDir].push_back(fullPath);
@@ -112,6 +116,41 @@ std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::s
 #endif
 
     return result;
+}
+
+bool is_image_file_extension(std::string &path)
+{
+    size_t pos = path.find_last_of(".");
+    if (pos == std::string::npos)
+    {
+        return false;
+    }
+
+    std::string ext = path.substr(pos);
+
+    if (ext == ".jpg")
+        return true;
+    if (ext == ".JPG")
+        return true;
+
+    if (ext == ".jpeg")
+        return true;
+    if (ext == ".JPEG")
+        return true;
+
+    if (ext == ".gif")
+        return true;
+    if (ext == ".GIF")
+        return true;
+
+    if (ext == ".png")
+        return true;
+    if (ext == ".PNG")
+        return true;
+
+    // TODO(green-sky): determine if we should add more formats from stbi. tga/hdr/pnm seem kinda niche.
+
+    return false;
 }
 
 bool app_params_parse(int argc, char **argv, app_params &params)

--- a/examples/common-clip.cpp
+++ b/examples/common-clip.cpp
@@ -118,7 +118,7 @@ std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::s
     return result;
 }
 
-bool is_image_file_extension(std::string &path)
+bool is_image_file_extension(const std::string &path)
 {
     size_t pos = path.find_last_of(".");
     if (pos == std::string::npos)

--- a/examples/common-clip.h
+++ b/examples/common-clip.h
@@ -12,7 +12,7 @@
 
 std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::string &path, uint32_t max_files_per_dir);
 
-bool is_image_file_extension(std::string &ext);
+bool is_image_file_extension(const std::string &path);
 
 struct app_params
 {

--- a/examples/common-clip.h
+++ b/examples/common-clip.h
@@ -12,6 +12,8 @@
 
 std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::string &path, uint32_t max_files_per_dir);
 
+bool is_image_file_extension(std::string &ext);
+
 struct app_params
 {
     int32_t n_threads = std::min(4, (int32_t)std::thread::hardware_concurrency());

--- a/examples/image-search/CMakeLists.txt
+++ b/examples/image-search/CMakeLists.txt
@@ -13,13 +13,13 @@ add_executable(image-search-build
     build.cpp
 )
 
-target_link_libraries(image-search-build PRIVATE clip ggml usearch)
-target_compile_features(image-search-build PUBLIC cxx_std_17)
+target_link_libraries(image-search-build PRIVATE clip common-clip ggml usearch)
+target_compile_features(image-search-build PUBLIC cxx_std_11)
 
 add_executable(image-search
     search.cpp
 )
 
-target_link_libraries(image-search PRIVATE clip ggml usearch)
+target_link_libraries(image-search PRIVATE clip common-clip ggml usearch)
 target_compile_features(image-search PUBLIC cxx_std_11)
 

--- a/examples/image-search/README.md
+++ b/examples/image-search/README.md
@@ -31,7 +31,7 @@ creating db for `tests/`:
 help:
 ```sh
 ./image-search -h
-Usage: ./image-search [options] <search string>
+Usage: ./image-search [options] <search string or /path/to/query/image>
 
 Options:  -h, --help: Show this message and exit
   -m <path>, --model <path>: overwrite path to model. Read from images.paths by default.

--- a/examples/image-search/build.cpp
+++ b/examples/image-search/build.cpp
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
 
         for (auto &entry : results)
         {
-            printf("%s: processing %d files in %s\n", __func__, entry.second.size(), entry.first.c_str());
+            printf("\n%s: processing %d files in '%s'\n", __func__, entry.second.size(), entry.first.c_str());
 
             for (auto &img_path : entry.second)
             {

--- a/examples/image-search/build.cpp
+++ b/examples/image-search/build.cpp
@@ -4,14 +4,16 @@
 #include <fstream>
 #include <filesystem>
 
-struct my_app_params {
-    int32_t n_threads {4};
-    std::string model {"../models/ggml-model-f16.bin"};
-    int32_t verbose {1};
+struct my_app_params
+{
+    int32_t n_threads{4};
+    std::string model{"../models/ggml-model-f16.bin"};
+    int32_t verbose{1};
     std::vector<std::string> image_directories;
 };
 
-void my_print_help(int argc, char **argv, my_app_params &params) {
+void my_print_help(int argc, char **argv, my_app_params &params)
+{
     printf("Usage: %s [options] dir/with/pictures [more/dirs]\n", argv[0]);
     printf("\nOptions:");
     printf("  -h, --help: Show this message and exit\n");
@@ -21,39 +23,56 @@ void my_print_help(int argc, char **argv, my_app_params &params) {
 }
 
 // returns success
-bool my_app_params_parse(int argc, char **argv, my_app_params &params) {
+bool my_app_params_parse(int argc, char **argv, my_app_params &params)
+{
     bool invalid_param = false;
-    for (int i = 1; i < argc; i++) {
+    for (int i = 1; i < argc; i++)
+    {
 
         std::string arg = argv[i];
 
-        if (arg == "-m" || arg == "--model") {
-            if (++i >= argc) {
+        if (arg == "-m" || arg == "--model")
+        {
+            if (++i >= argc)
+            {
                 invalid_param = true;
                 break;
             }
             params.model = argv[i];
-        } else if (arg == "-t" || arg == "--threads") {
-            if (++i >= argc) {
+        }
+        else if (arg == "-t" || arg == "--threads")
+        {
+            if (++i >= argc)
+            {
                 invalid_param = true;
                 break;
             }
             params.n_threads = std::stoi(argv[i]);
-        } else if (arg == "-v" || arg == "--verbose") {
-            if (++i >= argc) {
+        }
+        else if (arg == "-v" || arg == "--verbose")
+        {
+            if (++i >= argc)
+            {
                 invalid_param = true;
                 break;
             }
             params.verbose = std::stoi(argv[i]);
-        } else if (arg == "-h" || arg == "--help") {
+        }
+        else if (arg == "-h" || arg == "--help")
+        {
             my_print_help(argc, argv, params);
             exit(0);
-        } else if (arg.starts_with('-')) {
-            if (i != 0) {
+        }
+        else if (arg.find('-') == 0)
+        {
+            if (i != 0)
+            {
                 printf("%s: unrecognized argument: %s\n", __func__, arg.c_str());
                 return false;
             }
-        } else {
+        }
+        else
+        {
             // assume image directory
             params.image_directories.push_back(argv[i]);
         }
@@ -62,33 +81,45 @@ bool my_app_params_parse(int argc, char **argv, my_app_params &params) {
     return !(invalid_param || params.image_directories.empty());
 }
 
-bool is_image_file_extension(std::string_view ext) {
-    if (ext == ".jpg") return true;
-    if (ext == ".JPG") return true;
+bool is_image_file_extension(std::string_view ext)
+{
+    if (ext == ".jpg")
+        return true;
+    if (ext == ".JPG")
+        return true;
 
-    if (ext == ".jpeg") return true;
-    if (ext == ".JPEG") return true;
+    if (ext == ".jpeg")
+        return true;
+    if (ext == ".JPEG")
+        return true;
 
-    if (ext == ".gif") return true;
-    if (ext == ".GIF") return true;
+    if (ext == ".gif")
+        return true;
+    if (ext == ".GIF")
+        return true;
 
-    if (ext == ".png") return true;
-    if (ext == ".PNG") return true;
+    if (ext == ".png")
+        return true;
+    if (ext == ".PNG")
+        return true;
 
     // TODO(green-sky): determine if we should add more formats from stbi. tga/hdr/pnm seem kinda niche.
 
     return false;
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv)
+{
     my_app_params params;
-    if (!my_app_params_parse(argc, argv, params)) {
+    if (!my_app_params_parse(argc, argv, params))
+    {
         my_print_help(argc, argv, params);
         return 1;
     }
 
     auto clip_ctx = clip_model_load(params.model.c_str(), params.verbose);
-    if (!clip_ctx) {
+    if (!clip_ctx)
+    {
         printf("%s: Unable  to load model from %s\n", __func__, params.model.c_str());
         return 1;
     }
@@ -103,30 +134,37 @@ int main(int argc, char** argv) {
     std::vector<float> vec(vec_dim);
 
     // search for images in path and write embedding to database
-    for (const auto& base_dir : params.image_directories) {
+    for (const auto &base_dir : params.image_directories)
+    {
         fprintf(stdout, "%s: starting base dir scan of '%s'\n", __func__, base_dir.c_str());
 
-        for (auto const& dir_entry : std::filesystem::recursive_directory_iterator(base_dir)) {
-            if (!dir_entry.is_regular_file()) {
+        for (auto const &dir_entry : std::filesystem::recursive_directory_iterator(base_dir))
+        {
+            if (!dir_entry.is_regular_file())
+            {
                 continue;
             }
 
             // check for image file
-            const auto& ext = dir_entry.path().extension();
-            if (ext.empty()) {
+            const auto &ext = dir_entry.path().extension();
+            if (ext.empty())
+            {
                 continue;
             }
-            if (!is_image_file_extension(ext.c_str())) {
+            if (!is_image_file_extension(ext.c_str()))
+            {
                 continue;
             }
 
-            std::string img_path {dir_entry.path()};
-            if (params.verbose >= 1) {
+            std::string img_path{dir_entry.path()};
+            if (params.verbose >= 1)
+            {
                 fprintf(stdout, "%s: found image file '%s'\n", __func__, img_path.c_str());
             }
 
             clip_image_u8 img0;
-            if (!clip_image_load_from_file(img_path, img0)) {
+            if (!clip_image_load_from_file(img_path, img0))
+            {
                 fprintf(stderr, "%s: failed to load image from '%s'\n", __func__, img_path.c_str());
                 continue;
             }
@@ -134,12 +172,14 @@ int main(int argc, char** argv) {
             clip_image_f32 img_res;
             clip_image_preprocess(clip_ctx, &img0, &img_res);
 
-            if (!clip_image_encode(clip_ctx, params.n_threads, img_res, vec.data())) {
+            if (!clip_image_encode(clip_ctx, params.n_threads, img_res, vec.data()))
+            {
                 fprintf(stderr, "%s: failed to encode image from '%s'\n", __func__, img_path.c_str());
                 continue;
             }
 
-            if (embd_index.capacity() == embd_index.size()) {
+            if (embd_index.capacity() == embd_index.size())
+            {
                 embd_index.reserve(embd_index.size() + 32);
             }
 
@@ -158,10 +198,10 @@ int main(int argc, char** argv) {
     std::ofstream image_file_index_file("images.paths", std::ios::binary | std::ios::trunc);
     // first line is model
     image_file_index_file << params.model << "\n";
-    for (const auto& i_path : image_file_index) {
+    for (const auto &i_path : image_file_index)
+    {
         image_file_index_file << i_path << "\n";
     }
 
     return 0;
 }
-

--- a/examples/image-search/search.cpp
+++ b/examples/image-search/search.cpp
@@ -3,19 +3,21 @@
 
 #include <fstream>
 
-struct my_app_params {
-    int32_t n_threads {4};
+struct my_app_params
+{
+    int32_t n_threads{4};
     std::string model;
-    int32_t verbose {1};
+    int32_t verbose{1};
     // TODO: index dir
 
     // TODO: search by image
     std::string search_text;
 
-    int32_t n_results {5};
+    int32_t n_results{5};
 };
 
-void my_print_help(int argc, char **argv, my_app_params &params) {
+void my_print_help(int argc, char **argv, my_app_params &params)
+{
     printf("Usage: %s [options] <search string>\n", argv[0]);
     printf("\nOptions:");
     printf("  -h, --help: Show this message and exit\n");
@@ -27,47 +29,68 @@ void my_print_help(int argc, char **argv, my_app_params &params) {
 }
 
 // returns success
-bool my_app_params_parse(int argc, char **argv, my_app_params &params) {
+bool my_app_params_parse(int argc, char **argv, my_app_params &params)
+{
     bool invalid_param = false;
-    for (int i = 1; i < argc; i++) {
+    for (int i = 1; i < argc; i++)
+    {
         std::string arg = argv[i];
 
-        if (arg == "-m" || arg == "--model") {
-            if (++i >= argc) {
+        if (arg == "-m" || arg == "--model")
+        {
+            if (++i >= argc)
+            {
                 invalid_param = true;
                 break;
             }
             params.model = argv[i];
-        } else if (arg == "-t" || arg == "--threads") {
-            if (++i >= argc) {
+        }
+        else if (arg == "-t" || arg == "--threads")
+        {
+            if (++i >= argc)
+            {
                 invalid_param = true;
                 break;
             }
             params.n_threads = std::stoi(argv[i]);
-        } else if (arg == "-n" || arg == "--results") {
-            if (++i >= argc) {
+        }
+        else if (arg == "-n" || arg == "--results")
+        {
+            if (++i >= argc)
+            {
                 invalid_param = true;
                 break;
             }
             params.n_results = std::stoi(argv[i]);
-        } else if (arg == "-v" || arg == "--verbose") {
-            if (++i >= argc) {
+        }
+        else if (arg == "-v" || arg == "--verbose")
+        {
+            if (++i >= argc)
+            {
                 invalid_param = true;
                 break;
             }
             params.verbose = std::stoi(argv[i]);
-        } else if (arg == "-h" || arg == "--help") {
+        }
+        else if (arg == "-h" || arg == "--help")
+        {
             my_print_help(argc, argv, params);
             exit(0);
-        } else if (arg.starts_with('-')) {
-            if (i != 0) {
+        }
+        else if (arg.find('-') == 0)
+        {
+            if (i != 0)
+            {
                 printf("%s: unrecognized argument: %s\n", __func__, arg.c_str());
                 return false;
             }
-        } else {
+        }
+        else
+        {
             // assume search string from here on out
             params.search_text = arg;
-            for (++i; i < argc; i++) {
+            for (++i; i < argc; i++)
+            {
                 params.search_text += " ";
                 params.search_text += argv[i];
             }
@@ -77,9 +100,11 @@ bool my_app_params_parse(int argc, char **argv, my_app_params &params) {
     return !(invalid_param || params.search_text.empty());
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv)
+{
     my_app_params params;
-    if (!my_app_params_parse(argc, argv, params)) {
+    if (!my_app_params_parse(argc, argv, params))
+    {
         my_print_help(argc, argv, params);
         return 1;
     }
@@ -88,15 +113,19 @@ int main(int argc, char** argv) {
     std::ifstream image_file_index_file("images.paths", std::ios::binary);
     std::string line;
     std::getline(image_file_index_file, line);
-    if (params.model.empty()) {
+    if (params.model.empty())
+    {
         params.model = line;
-    } else {
+    }
+    else
+    {
         printf("%s: using alternative model from %s. Make sure you use the same model you used for indexing, or the embeddings wont work.\n", __func__, params.model.c_str());
     }
 
     // load model
     auto clip_ctx = clip_model_load(params.model.c_str(), params.verbose);
-    if (!clip_ctx) {
+    if (!clip_ctx)
+    {
         printf("%s: Unable to load model from %s\n", __func__, params.model.c_str());
         return 1;
     }
@@ -108,15 +137,18 @@ int main(int argc, char** argv) {
     embd_index.view("images.usearch");
 
     // load image paths
-    do {
+    do
+    {
         std::getline(image_file_index_file, line);
-        if (line.empty()) {
+        if (line.empty())
+        {
             break;
         }
         image_file_index.push_back(line);
-    } while(image_file_index_file.good());
+    } while (image_file_index_file.good());
 
-    if (image_file_index.size() != embd_index.size()) {
+    if (image_file_index.size() != embd_index.size())
+    {
         printf("%s: index files size missmatch\n", __func__);
     }
 
@@ -132,7 +164,8 @@ int main(int argc, char** argv) {
 
     printf("search results:\n");
     printf("distance path\n");
-    for (std::size_t i = 0; i != results.size(); ++i) {
+    for (std::size_t i = 0; i != results.size(); ++i)
+    {
         printf("  %f %s\n", results[i].distance, image_file_index.at(results[i].member.label).c_str());
     }
 
@@ -140,4 +173,3 @@ int main(int argc, char** argv) {
 
     return 0;
 }
-


### PR DESCRIPTION
Safely ignore changes in `image-search`, they are due to formatting other than a single line, which is simply the very same change in `clip.cpp`.

I'll also try using our own recursive directory walk function from `common-clip` instead of `std::filesystem`.