### PR TITLE
Add clang-format config and formatting script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,222 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     128
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  Decimal:         0
+  Hex:             0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Middle
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/clip.h
+++ b/clip.h
@@ -1,11 +1,11 @@
 #ifndef CLIP_H
 #define CLIP_H
 
-#include <vector>
+#include "ggml/ggml.h"
 #include <cstring>
 #include <map>
 #include <thread>
-#include "ggml/ggml.h"
+#include <vector>
 
 // TODO: make the API in C
 // #ifdef __cplusplus
@@ -13,8 +13,7 @@
 // #endif
 
 // default hparams for text_model (ViT-B/32)
-struct clip_text_hparams
-{
+struct clip_text_hparams {
     int32_t n_vocab = 49408;
     int32_t num_positions = 77;
     int32_t hidden_size = 512;
@@ -25,8 +24,7 @@ struct clip_text_hparams
 };
 
 // default hparams for vision_model (ViT-B/32)
-struct clip_vision_hparams
-{
+struct clip_vision_hparams {
     int32_t image_size = 224;
     int32_t patch_size = 32;
     int32_t hidden_size = 768;
@@ -40,15 +38,11 @@ struct clip_vision_hparams
 // Vocab utils
 //
 
-std::string trim(const std::string &s);
+std::string trim(const std::string & s);
 
-std::string replace(
-    const std::string &s,
-    const std::string &from,
-    const std::string &to);
+std::string replace(const std::string & s, const std::string & from, const std::string & to);
 
-struct clip_vocab
-{
+struct clip_vocab {
     using id = int32_t;
     using token = std::string;
 
@@ -56,12 +50,12 @@ struct clip_vocab
     std::map<id, token> id_to_token;
     std::vector<std::string> special_tokens;
 
-    void add_special_token(const std::string &token);
+    void add_special_token(const std::string & token);
 };
 
-std::string convert_to_utf8(const std::wstring &input);
+std::string convert_to_utf8(const std::wstring & input);
 
-std::wstring convert_to_wstring(const std::string &input);
+std::wstring convert_to_wstring(const std::string & input);
 
 // split text into tokens
 //
@@ -74,112 +68,102 @@ std::wstring convert_to_wstring(const std::string &input);
 // R"('s|'t|'re|'ve|'m|'ll|'d| ?[[:alpha:]]+| ?[[:digit:]]+| ?[^\s[:alpha:][:digit:]]+|\s+(?!\S)|\s+)"
 //
 
-struct clip_layer
-{
+struct clip_layer {
     // attention
-    struct ggml_tensor *k_w;
-    struct ggml_tensor *k_b;
-    struct ggml_tensor *q_w;
-    struct ggml_tensor *q_b;
-    struct ggml_tensor *v_w;
-    struct ggml_tensor *v_b;
+    struct ggml_tensor * k_w;
+    struct ggml_tensor * k_b;
+    struct ggml_tensor * q_w;
+    struct ggml_tensor * q_b;
+    struct ggml_tensor * v_w;
+    struct ggml_tensor * v_b;
 
-    struct ggml_tensor *o_w;
-    struct ggml_tensor *o_b;
+    struct ggml_tensor * o_w;
+    struct ggml_tensor * o_b;
 
     // layernorm 1
-    struct ggml_tensor *ln_1_w;
-    struct ggml_tensor *ln_1_b;
+    struct ggml_tensor * ln_1_w;
+    struct ggml_tensor * ln_1_b;
 
     // ff
-    struct ggml_tensor *ff_i_w;
-    struct ggml_tensor *ff_i_b;
+    struct ggml_tensor * ff_i_w;
+    struct ggml_tensor * ff_i_b;
 
-    struct ggml_tensor *ff_o_w;
-    struct ggml_tensor *ff_o_b;
+    struct ggml_tensor * ff_o_w;
+    struct ggml_tensor * ff_o_b;
 
     // layernorm 2
-    struct ggml_tensor *ln_2_w;
-    struct ggml_tensor *ln_2_b;
+    struct ggml_tensor * ln_2_w;
+    struct ggml_tensor * ln_2_b;
 };
 
-struct clip_text_model
-{
+struct clip_text_model {
     clip_text_hparams hparams;
 
     // embeddings
-    struct ggml_tensor *token_embeddings;
-    struct ggml_tensor *position_embeddings;
+    struct ggml_tensor * token_embeddings;
+    struct ggml_tensor * position_embeddings;
 
     std::vector<clip_layer> layers;
 
-    struct ggml_tensor *post_ln_w;
-    struct ggml_tensor *post_ln_b;
+    struct ggml_tensor * post_ln_w;
+    struct ggml_tensor * post_ln_b;
 
-    struct ggml_tensor *projection;
+    struct ggml_tensor * projection;
 
     std::map<std::string, struct ggml_tensor *> tensors;
 };
 
-struct clip_vision_model
-{
+struct clip_vision_model {
     clip_vision_hparams hparams;
 
     // embeddings
-    struct ggml_tensor *class_embedding;
-    struct ggml_tensor *patch_embeddings;
-    struct ggml_tensor *position_embeddings;
+    struct ggml_tensor * class_embedding;
+    struct ggml_tensor * patch_embeddings;
+    struct ggml_tensor * position_embeddings;
 
-    struct ggml_tensor *pre_ln_w;
-    struct ggml_tensor *pre_ln_b;
+    struct ggml_tensor * pre_ln_w;
+    struct ggml_tensor * pre_ln_b;
 
     std::vector<clip_layer> layers;
 
-    struct ggml_tensor *post_ln_w;
-    struct ggml_tensor *post_ln_b;
+    struct ggml_tensor * post_ln_w;
+    struct ggml_tensor * post_ln_b;
 
-    struct ggml_tensor *projection;
+    struct ggml_tensor * projection;
 
     std::map<std::string, struct ggml_tensor *> tensors;
 };
 
-struct clip_ctx *clip_model_load(const char *fname, const int verbosity);
+struct clip_ctx * clip_model_load(const char * fname, const int verbosity);
 
 // Replacement for std::vector<uint8_t> that doesn't require zero-initialization.
-struct clip_buffer
-{
-    uint8_t *data = NULL;
+struct clip_buffer {
+    uint8_t * data = NULL;
     size_t size = 0;
 
-    void resize(size_t size)
-    {
+    void resize(size_t size) {
         delete[] data;
         data = new uint8_t[size];
         this->size = size;
     }
 
-    ~clip_buffer()
-    {
-        delete[] data;
-    }
+    ~clip_buffer() { delete[] data; }
 };
 
-struct clip_ctx
-{
+struct clip_ctx {
     clip_text_model text_model;
     clip_vision_model vision_model;
     clip_vocab vocab;
     int32_t use_gelu = 0;
     int32_t ftype = 1;
-    ggml_context *ctx;
+    ggml_context * ctx;
     clip_buffer buf_compute;
 };
 
-void clip_free(clip_ctx *ctx);
+void clip_free(clip_ctx * ctx);
 
 // RGB uint8 image
-struct clip_image_u8
-{
+struct clip_image_u8 {
     int nx;
     int ny;
 
@@ -188,43 +172,31 @@ struct clip_image_u8
 
 // RGB float32 image
 // Memory layout: RGBRGBRGB...
-struct clip_image_f32
-{
+struct clip_image_f32 {
     int nx;
     int ny;
 
     std::vector<float> data;
 };
 
-std::vector<clip_vocab::id> clip_tokenize(const clip_ctx *ctx, const std::string &text);
+std::vector<clip_vocab::id> clip_tokenize(const clip_ctx * ctx, const std::string & text);
 
-bool clip_image_load_from_file(const std::string &fname, clip_image_u8 &img);
-bool clip_image_preprocess(const clip_ctx *ctx, const clip_image_u8 *img, clip_image_f32 *res);
-void clip_image_batch_preprocess(const clip_ctx *ctx, const int n_threads, const std::vector<clip_image_u8> &img_inputs, std::vector<clip_image_f32> &img_resized);
+bool clip_image_load_from_file(const std::string & fname, clip_image_u8 & img);
+bool clip_image_preprocess(const clip_ctx * ctx, const clip_image_u8 * img, clip_image_f32 * res);
+void clip_image_batch_preprocess(const clip_ctx * ctx, const int n_threads, const std::vector<clip_image_u8> & img_inputs,
+                                 std::vector<clip_image_f32> & img_resized);
 
-bool clip_text_encode(
-    const clip_ctx *ctx,
-    int n_threads,
-    const std::vector<clip_vocab::id> &tokens,
-    float *vec);
+bool clip_text_encode(const clip_ctx * ctx, int n_threads, const std::vector<clip_vocab::id> & tokens, float * vec);
 
-bool clip_image_encode(
-    const clip_ctx *ctx,
-    int n_threads,
-    const clip_image_f32 &img,
-    float *vec);
+bool clip_image_encode(const clip_ctx * ctx, int n_threads, const clip_image_f32 & img, float * vec);
 
 // bool image_normalize(clip_image_u8 *img, clip_image_f32 *res);
 
-bool clip_compare_text_and_image(clip_ctx *ctx, int n_threads, std::string &text, clip_image_u8 &image, float *score);
-float clip_similarity_score(float *vec1, float *vec2, int vec_dim);
-bool softmax_with_sorting(float *arr, int length, float *sorted_scores, int *indices);
+bool clip_compare_text_and_image(clip_ctx * ctx, int n_threads, std::string & text, clip_image_u8 & image, float * score);
+float clip_similarity_score(float * vec1, float * vec2, int vec_dim);
+bool softmax_with_sorting(float * arr, int length, float * sorted_scores, int * indices);
 
-bool clip_image_batch_encode(
-    const clip_ctx *ctx,
-    int n_threads,
-    const std::vector<clip_image_f32> &imgs,
-    float *vec);
+bool clip_image_batch_encode(const clip_ctx * ctx, int n_threads, const std::vector<clip_image_f32> & imgs, float * vec);
 
 // #ifdef __cplusplus
 // }

--- a/examples/common-clip.cpp
+++ b/examples/common-clip.cpp
@@ -1,17 +1,17 @@
 #include "common-clip.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
-#include <cmath>
-#include <iostream>
 #include <fstream>
-#include <vector>
+#include <iostream>
 #include <map>
+#include <vector>
 
 #ifdef _WIN32
-#include <windows.h>
 #include <tchar.h>
+#include <windows.h>
 #else
 #include <dirent.h>
 #include <sys/stat.h>
@@ -19,8 +19,7 @@
 
 // common utility functions mainly intended for examples and debugging
 
-std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::string &path, uint32_t max_files_per_dir = 0)
-{
+std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::string & path, uint32_t max_files_per_dir = 0) {
     std::map<std::string, std::vector<std::string>> result;
 
 #ifdef _WIN32
@@ -28,30 +27,25 @@ std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::s
     WIN32_FIND_DATAA fileData;
     HANDLE hFind = FindFirstFileA(wildcard.c_str(), &fileData);
 
-    if (hFind == INVALID_HANDLE_VALUE)
-    {
+    if (hFind == INVALID_HANDLE_VALUE) {
         std::cerr << "Failed to open directory: " << path << std::endl;
         return result;
     }
 
     uint32_t fileCount = 0;
 
-    do
-    {
+    do {
         std::string name = fileData.cFileName;
         std::string fullPath = path + "\\" + name;
 
-        if (fileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-        {
+        if (fileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
             // Skip . and ..
             if (name == "." || name == "..")
                 continue;
 
             std::map<std::string, std::vector<std::string>> subResult = get_dir_keyed_files(fullPath, max_files_per_dir);
             result.insert(subResult.begin(), subResult.end());
-        }
-        else
-        {
+        } else {
             size_t pos = path.find_last_of("\\/");
             std::string parentDir = (pos != std::string::npos) ? path.substr(pos + 1) : path;
             result[parentDir].push_back(fullPath);
@@ -64,42 +58,35 @@ std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::s
 
     FindClose(hFind);
 #else
-    DIR *dir;
-    struct dirent *entry;
+    DIR * dir;
+    struct dirent * entry;
     struct stat fileStat;
 
-    if ((dir = opendir(path.c_str())) == NULL)
-    {
+    if ((dir = opendir(path.c_str())) == NULL) {
         std::cerr << "Failed to open directory: " << path << std::endl;
         return result;
     }
 
     uint32_t fileCount = 0;
 
-    while ((entry = readdir(dir)) != NULL)
-    {
+    while ((entry = readdir(dir)) != NULL) {
         std::string name = entry->d_name;
         std::string fullPath = path + "/" + name;
 
-        if (stat(fullPath.c_str(), &fileStat) < 0)
-        {
+        if (stat(fullPath.c_str(), &fileStat) < 0) {
             std::cerr << "Failed to get file stat: " << fullPath << std::endl;
             continue;
         }
 
-        if (S_ISDIR(fileStat.st_mode))
-        {
+        if (S_ISDIR(fileStat.st_mode)) {
             // Skip . and ..
             if (name == "." || name == "..")
                 continue;
 
             std::map<std::string, std::vector<std::string>> subResult = get_dir_keyed_files(fullPath, max_files_per_dir);
             result.insert(subResult.begin(), subResult.end());
-        }
-        else
-        {
-            if (!is_image_file_extension(fullPath))
-            {
+        } else {
+            if (!is_image_file_extension(fullPath)) {
                 continue;
             }
             size_t pos = path.find_last_of("/");
@@ -118,11 +105,9 @@ std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::s
     return result;
 }
 
-bool is_image_file_extension(const std::string &path)
-{
+bool is_image_file_extension(const std::string & path) {
     size_t pos = path.find_last_of(".");
-    if (pos == std::string::npos)
-    {
+    if (pos == std::string::npos) {
         return false;
     }
 
@@ -153,40 +138,24 @@ bool is_image_file_extension(const std::string &path)
     return false;
 }
 
-bool app_params_parse(int argc, char **argv, app_params &params)
-{
-    for (int i = 0; i < argc; i++)
-    {
+bool app_params_parse(int argc, char ** argv, app_params & params) {
+    for (int i = 0; i < argc; i++) {
         std::string arg = std::string(argv[i]);
-        if (arg == "-m" || arg == "--model")
-        {
+        if (arg == "-m" || arg == "--model") {
             params.model = argv[++i];
-        }
-        else if (arg == "-t" || arg == "--threads")
-        {
+        } else if (arg == "-t" || arg == "--threads") {
             params.n_threads = std::stoi(argv[++i]);
-        }
-        else if (arg == "--text")
-        {
+        } else if (arg == "--text") {
             params.texts.push_back(argv[++i]);
-        }
-        else if (arg == "--image")
-        {
+        } else if (arg == "--image") {
             params.image_paths.push_back(argv[++i]);
-        }
-        else if (arg == "-v" || arg == "--verbose")
-        {
+        } else if (arg == "-v" || arg == "--verbose") {
             params.verbose = std::stoi(argv[++i]);
-        }
-        else if (arg == "-h" || arg == "--help")
-        {
+        } else if (arg == "-h" || arg == "--help") {
             print_help(argc, argv, params);
             exit(0);
-        }
-        else
-        {
-            if (i != 0)
-            {
+        } else {
+            if (i != 0) {
                 printf("%s: unrecognized argument: %s\n", __func__, arg.c_str());
                 return false;
             }
@@ -195,8 +164,7 @@ bool app_params_parse(int argc, char **argv, app_params &params)
     return params.image_paths.size() >= 1 && params.texts.size() >= 1;
 }
 
-void print_help(int argc, char **argv, app_params &params)
-{
+void print_help(int argc, char ** argv, app_params & params) {
     printf("Usage: %s [options]\n", argv[0]);
     printf("\nOptions:");
     printf("  -h, --help: Show this message and exit\n");
@@ -204,22 +172,20 @@ void print_help(int argc, char **argv, app_params &params)
     printf("  -t N, --threads N: Number of threads to use for inference. Default: %d\n", params.n_threads);
     printf("  --text <text>: Text to encode. At least one text should be specified\n");
     printf("  --image <path>: Path to an image file. At least one image path should be specified\n");
-    printf("  -v <level>, --verbose <level>: Control the level of verbosity. 0 = minimum, 2 = maximum. Default: %d\n", params.verbose);
+    printf("  -v <level>, --verbose <level>: Control the level of verbosity. 0 = minimum, 2 = maximum. Default: %d\n",
+           params.verbose);
 }
 
-void write_floats_to_file(float *array, int size, char *filename)
-{
+void write_floats_to_file(float * array, int size, char * filename) {
     // Open the file for writing.
-    FILE *file = fopen(filename, "w");
-    if (file == NULL)
-    {
+    FILE * file = fopen(filename, "w");
+    if (file == NULL) {
         printf("Error opening file: %s\n", filename);
         return;
     }
 
     // Write the float values to the file.
-    for (int i = 0; i < size; i++)
-    {
+    for (int i = 0; i < size; i++) {
         fprintf(file, "%f\n", array[i]);
     }
 

--- a/examples/common-clip.h
+++ b/examples/common-clip.h
@@ -1,21 +1,20 @@
 #ifndef COMMON_CLIP_H
 #define COMMON_CLIP_H
 
-#include <vector>
-#include <map>
 #include <cstring>
+#include <map>
 #include <thread>
+#include <vector>
 
 // #ifdef __cplusplus
 // extern "C" {
 // #endif
 
-std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::string &path, uint32_t max_files_per_dir);
+std::map<std::string, std::vector<std::string>> get_dir_keyed_files(const std::string & path, uint32_t max_files_per_dir);
 
-bool is_image_file_extension(const std::string &path);
+bool is_image_file_extension(const std::string & path);
 
-struct app_params
-{
+struct app_params {
     int32_t n_threads = std::min(4, (int32_t)std::thread::hardware_concurrency());
 
     std::string model = "models/ggml-model-f16.bin";
@@ -24,11 +23,11 @@ struct app_params
     int verbose = 1;
 };
 
-bool app_params_parse(int argc, char **argv, app_params &params);
-void print_help(int argc, char **argv, app_params &params);
+bool app_params_parse(int argc, char ** argv, app_params & params);
+void print_help(int argc, char ** argv, app_params & params);
 
 // utils for debugging
-void write_floats_to_file(float *array, int size, char *filename);
+void write_floats_to_file(float * array, int size, char * filename);
 
 // #ifdef __cplusplus
 // }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -3,8 +3,7 @@
 #include "clip.h"
 #include "common-clip.h"
 
-int main(int argc, char **argv)
-{
+int main(int argc, char ** argv) {
     // TODO: replace this example with only clip_compare_text_and_image
     // and demonstrate usage of individual functions in zero-shot labelling and image search examples.
 
@@ -12,8 +11,7 @@ int main(int argc, char **argv)
     const int64_t t_main_start_us = ggml_time_us();
 
     app_params params;
-    if (!app_params_parse(argc, argv, params))
-    {
+    if (!app_params_parse(argc, argv, params)) {
         print_help(argc, argv, params);
         return 1;
     }
@@ -21,8 +19,7 @@ int main(int argc, char **argv)
     const int64_t t_load_us = ggml_time_us();
 
     auto ctx = clip_model_load(params.model.c_str(), params.verbose);
-    if (!ctx)
-    {
+    if (!ctx) {
         printf("%s: Unable  to load model from %s", __func__, params.model.c_str());
         return 1;
     }
@@ -46,8 +43,7 @@ int main(int argc, char **argv)
     std::string img_path = params.image_paths[0];
     clip_image_u8 img0;
     clip_image_f32 img_res;
-    if (!clip_image_load_from_file(img_path, img0))
-    {
+    if (!clip_image_load_from_file(img_path, img0)) {
         fprintf(stderr, "%s: failed to load image from '%s'\n", __func__, img_path.c_str());
         return 1;
     }
@@ -57,8 +53,7 @@ int main(int argc, char **argv)
     const int64_t t_image_encode_us = ggml_time_us();
 
     float img_vec[vec_dim];
-    if (!clip_image_encode(ctx, params.n_threads, img_res, img_vec))
-    {
+    if (!clip_image_encode(ctx, params.n_threads, img_res, img_vec)) {
         return 1;
     }
 
@@ -69,8 +64,7 @@ int main(int argc, char **argv)
 
     const int64_t t_main_end_us = ggml_time_us();
 
-    if (params.verbose >= 1)
-    {
+    if (params.verbose >= 1) {
         printf("\n\nTimings\n");
         printf("%s: Model loaded in %8.2f ms\n", __func__, (t_tokenize_us - t_load_us) / 1000.0);
         printf("%s: Text tokenized in %8.2f ms\n", __func__, (t_text_encode_us - t_tokenize_us) / 1000.0);

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,2 @@
+#/bin/bash
+find . -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.c' -o -name '*.h' \) ! -path "./ggml/*" ! -path "./build/*" -exec clang-format -i {} +

--- a/stb_image.h
+++ b/stb_image.h
@@ -371,8 +371,7 @@ RECENT REVISION HISTORY:
 
 #define STBI_VERSION 1
 
-enum
-{
+enum {
     STBI_default = 0, // only used for desired_channels
 
     STBI_grey = 1,
@@ -386,8 +385,7 @@ typedef unsigned char stbi_uc;
 typedef unsigned short stbi_us;
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 #ifndef STBIDEF
@@ -398,55 +396,60 @@ extern "C"
 #endif
 #endif
 
-    //////////////////////////////////////////////////////////////////////////////
-    //
-    // PRIMARY API - works on images of any type
-    //
+//////////////////////////////////////////////////////////////////////////////
+//
+// PRIMARY API - works on images of any type
+//
 
-    //
-    // load image by filename, open file, or memory buffer
-    //
+//
+// load image by filename, open file, or memory buffer
+//
 
-    typedef struct
-    {
-        int (*read)(void *user, char *data, int size); // fill 'data' with 'size' bytes.  return number of bytes actually read
-        void (*skip)(void *user, int n);               // skip the next 'n' bytes, or 'unget' the last -n bytes if negative
-        int (*eof)(void *user);                        // returns nonzero if we are at end of file/data
-    } stbi_io_callbacks;
+typedef struct {
+    int (*read)(void * user, char * data,
+                int size);            // fill 'data' with 'size' bytes.  return number of bytes actually read
+    void (*skip)(void * user, int n); // skip the next 'n' bytes, or 'unget' the last -n bytes if negative
+    int (*eof)(void * user);          // returns nonzero if we are at end of file/data
+} stbi_io_callbacks;
 
-    ////////////////////////////////////
-    //
-    // 8-bits-per-channel interface
-    //
+////////////////////////////////////
+//
+// 8-bits-per-channel interface
+//
 
-    STBIDEF stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
-    STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc * stbi_load_from_memory(stbi_uc const * buffer, int len, int * x, int * y, int * channels_in_file,
+                                        int desired_channels);
+STBIDEF stbi_uc * stbi_load_from_callbacks(stbi_io_callbacks const * clbk, void * user, int * x, int * y,
+                                           int * channels_in_file, int desired_channels);
 
 #ifndef STBI_NO_STDIO
-    STBIDEF stbi_uc *stbi_load(char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
-    STBIDEF stbi_uc *stbi_load_from_file(FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc * stbi_load(char const * filename, int * x, int * y, int * channels_in_file, int desired_channels);
+STBIDEF stbi_uc * stbi_load_from_file(FILE * f, int * x, int * y, int * channels_in_file, int desired_channels);
 // for stbi_load_from_file, file pointer is left pointing immediately after image
 #endif
 
 #ifndef STBI_NO_GIF
-    STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
+STBIDEF stbi_uc * stbi_load_gif_from_memory(stbi_uc const * buffer, int len, int ** delays, int * x, int * y, int * z,
+                                            int * comp, int req_comp);
 #endif
 
 #ifdef STBI_WINDOWS_UTF8
-    STBIDEF int stbi_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t *input);
+STBIDEF int stbi_convert_wchar_to_utf8(char * buffer, size_t bufferlen, const wchar_t * input);
 #endif
 
-    ////////////////////////////////////
-    //
-    // 16-bits-per-channel interface
-    //
+////////////////////////////////////
+//
+// 16-bits-per-channel interface
+//
 
-    STBIDEF stbi_us *stbi_load_16_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
-    STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us * stbi_load_16_from_memory(stbi_uc const * buffer, int len, int * x, int * y, int * channels_in_file,
+                                           int desired_channels);
+STBIDEF stbi_us * stbi_load_16_from_callbacks(stbi_io_callbacks const * clbk, void * user, int * x, int * y,
+                                              int * channels_in_file, int desired_channels);
 
 #ifndef STBI_NO_STDIO
-    STBIDEF stbi_us *stbi_load_16(char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
-    STBIDEF stbi_us *stbi_load_from_file_16(FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us * stbi_load_16(char const * filename, int * x, int * y, int * channels_in_file, int desired_channels);
+STBIDEF stbi_us * stbi_load_from_file_16(FILE * f, int * x, int * y, int * channels_in_file, int desired_channels);
 #endif
 
 ////////////////////////////////////
@@ -454,81 +457,84 @@ extern "C"
 // float-per-channel interface
 //
 #ifndef STBI_NO_LINEAR
-    STBIDEF float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
-    STBIDEF float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF float * stbi_loadf_from_memory(stbi_uc const * buffer, int len, int * x, int * y, int * channels_in_file,
+                                       int desired_channels);
+STBIDEF float * stbi_loadf_from_callbacks(stbi_io_callbacks const * clbk, void * user, int * x, int * y, int * channels_in_file,
+                                          int desired_channels);
 
 #ifndef STBI_NO_STDIO
-    STBIDEF float *stbi_loadf(char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
-    STBIDEF float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF float * stbi_loadf(char const * filename, int * x, int * y, int * channels_in_file, int desired_channels);
+STBIDEF float * stbi_loadf_from_file(FILE * f, int * x, int * y, int * channels_in_file, int desired_channels);
 #endif
 #endif
 
 #ifndef STBI_NO_HDR
-    STBIDEF void stbi_hdr_to_ldr_gamma(float gamma);
-    STBIDEF void stbi_hdr_to_ldr_scale(float scale);
+STBIDEF void stbi_hdr_to_ldr_gamma(float gamma);
+STBIDEF void stbi_hdr_to_ldr_scale(float scale);
 #endif // STBI_NO_HDR
 
 #ifndef STBI_NO_LINEAR
-    STBIDEF void stbi_ldr_to_hdr_gamma(float gamma);
-    STBIDEF void stbi_ldr_to_hdr_scale(float scale);
+STBIDEF void stbi_ldr_to_hdr_gamma(float gamma);
+STBIDEF void stbi_ldr_to_hdr_scale(float scale);
 #endif // STBI_NO_LINEAR
 
-    // stbi_is_hdr is always defined, but always returns false if STBI_NO_HDR
-    STBIDEF int stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user);
-    STBIDEF int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len);
+// stbi_is_hdr is always defined, but always returns false if STBI_NO_HDR
+STBIDEF int stbi_is_hdr_from_callbacks(stbi_io_callbacks const * clbk, void * user);
+STBIDEF int stbi_is_hdr_from_memory(stbi_uc const * buffer, int len);
 #ifndef STBI_NO_STDIO
-    STBIDEF int stbi_is_hdr(char const *filename);
-    STBIDEF int stbi_is_hdr_from_file(FILE *f);
+STBIDEF int stbi_is_hdr(char const * filename);
+STBIDEF int stbi_is_hdr_from_file(FILE * f);
 #endif // STBI_NO_STDIO
 
-    // get a VERY brief reason for failure
-    // on most compilers (and ALL modern mainstream compilers) this is threadsafe
-    STBIDEF const char *stbi_failure_reason(void);
+// get a VERY brief reason for failure
+// on most compilers (and ALL modern mainstream compilers) this is threadsafe
+STBIDEF const char * stbi_failure_reason(void);
 
-    // free the loaded image -- this is just free()
-    STBIDEF void stbi_image_free(void *retval_from_stbi_load);
+// free the loaded image -- this is just free()
+STBIDEF void stbi_image_free(void * retval_from_stbi_load);
 
-    // get image dimensions & components without fully decoding
-    STBIDEF int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
-    STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp);
-    STBIDEF int stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len);
-    STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *clbk, void *user);
+// get image dimensions & components without fully decoding
+STBIDEF int stbi_info_from_memory(stbi_uc const * buffer, int len, int * x, int * y, int * comp);
+STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const * clbk, void * user, int * x, int * y, int * comp);
+STBIDEF int stbi_is_16_bit_from_memory(stbi_uc const * buffer, int len);
+STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const * clbk, void * user);
 
 #ifndef STBI_NO_STDIO
-    STBIDEF int stbi_info(char const *filename, int *x, int *y, int *comp);
-    STBIDEF int stbi_info_from_file(FILE *f, int *x, int *y, int *comp);
-    STBIDEF int stbi_is_16_bit(char const *filename);
-    STBIDEF int stbi_is_16_bit_from_file(FILE *f);
+STBIDEF int stbi_info(char const * filename, int * x, int * y, int * comp);
+STBIDEF int stbi_info_from_file(FILE * f, int * x, int * y, int * comp);
+STBIDEF int stbi_is_16_bit(char const * filename);
+STBIDEF int stbi_is_16_bit_from_file(FILE * f);
 #endif
 
-    // for image formats that explicitly notate that they have premultiplied alpha,
-    // we just return the colors as stored in the file. set this flag to force
-    // unpremultiplication. results are undefined if the unpremultiply overflow.
-    STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply);
+// for image formats that explicitly notate that they have premultiplied alpha,
+// we just return the colors as stored in the file. set this flag to force
+// unpremultiplication. results are undefined if the unpremultiply overflow.
+STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply);
 
-    // indicate whether we should process iphone images back to canonical format,
-    // or just pass them through "as-is"
-    STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert);
+// indicate whether we should process iphone images back to canonical format,
+// or just pass them through "as-is"
+STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert);
 
-    // flip the image vertically, so the first pixel in the output array is the bottom left
-    STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip);
+// flip the image vertically, so the first pixel in the output array is the bottom left
+STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip);
 
-    // as above, but only applies to images loaded on the thread that calls the function
-    // this function is only available if your compiler supports thread-local variables;
-    // calling it will fail to link if your compiler doesn't
-    STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply);
-    STBIDEF void stbi_convert_iphone_png_to_rgb_thread(int flag_true_if_should_convert);
-    STBIDEF void stbi_set_flip_vertically_on_load_thread(int flag_true_if_should_flip);
+// as above, but only applies to images loaded on the thread that calls the function
+// this function is only available if your compiler supports thread-local variables;
+// calling it will fail to link if your compiler doesn't
+STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply);
+STBIDEF void stbi_convert_iphone_png_to_rgb_thread(int flag_true_if_should_convert);
+STBIDEF void stbi_set_flip_vertically_on_load_thread(int flag_true_if_should_flip);
 
-    // ZLIB client - used by PNG, available for other purposes
+// ZLIB client - used by PNG, available for other purposes
 
-    STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen);
-    STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header);
-    STBIDEF char *stbi_zlib_decode_malloc(const char *buffer, int len, int *outlen);
-    STBIDEF int stbi_zlib_decode_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
+STBIDEF char * stbi_zlib_decode_malloc_guesssize(const char * buffer, int len, int initial_size, int * outlen);
+STBIDEF char * stbi_zlib_decode_malloc_guesssize_headerflag(const char * buffer, int len, int initial_size, int * outlen,
+                                                            int parse_header);
+STBIDEF char * stbi_zlib_decode_malloc(const char * buffer, int len, int * outlen);
+STBIDEF int stbi_zlib_decode_buffer(char * obuffer, int olen, const char * ibuffer, int ilen);
 
-    STBIDEF char *stbi_zlib_decode_noheader_malloc(const char *buffer, int len, int *outlen);
-    STBIDEF int stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
+STBIDEF char * stbi_zlib_decode_noheader_malloc(const char * buffer, int len, int * outlen);
+STBIDEF int stbi_zlib_decode_noheader_buffer(char * obuffer, int olen, const char * ibuffer, int ilen);
 
 #ifdef __cplusplus
 }
@@ -541,7 +547,9 @@ extern "C"
 
 #ifdef STB_IMAGE_IMPLEMENTATION
 
-#if defined(STBI_ONLY_JPEG) || defined(STBI_ONLY_PNG) || defined(STBI_ONLY_BMP) || defined(STBI_ONLY_TGA) || defined(STBI_ONLY_GIF) || defined(STBI_ONLY_PSD) || defined(STBI_ONLY_HDR) || defined(STBI_ONLY_PIC) || defined(STBI_ONLY_PNM) || defined(STBI_ONLY_ZLIB)
+#if defined(STBI_ONLY_JPEG) || defined(STBI_ONLY_PNG) || defined(STBI_ONLY_BMP) || defined(STBI_ONLY_TGA) ||                   \
+    defined(STBI_ONLY_GIF) || defined(STBI_ONLY_PSD) || defined(STBI_ONLY_HDR) || defined(STBI_ONLY_PIC) ||                    \
+    defined(STBI_ONLY_PNM) || defined(STBI_ONLY_ZLIB)
 #ifndef STBI_ONLY_JPEG
 #define STBI_NO_JPEG
 #endif
@@ -575,11 +583,11 @@ extern "C"
 #define STBI_NO_ZLIB
 #endif
 
+#include <limits.h>
 #include <stdarg.h>
 #include <stddef.h> // ptrdiff_t on osx
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
 
 #if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
 #include <math.h> // ldexp, pow
@@ -719,15 +727,13 @@ typedef unsigned char validate_uint32[sizeof(stbi__uint32) == 4 ? 1 : -1];
 
 #if _MSC_VER >= 1400 // not VC6
 #include <intrin.h>  // __cpuid
-static int stbi__cpuid3(void)
-{
+static int stbi__cpuid3(void) {
     int info[4];
     __cpuid(info, 1);
     return info[3];
 }
 #else
-static int stbi__cpuid3(void)
-{
+static int stbi__cpuid3(void) {
     int res;
     __asm {
       mov  eax,1
@@ -741,8 +747,7 @@ static int stbi__cpuid3(void)
 #define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
 
 #if !defined(STBI_NO_JPEG) && defined(STBI_SSE2)
-static int stbi__sse2_available(void)
-{
+static int stbi__sse2_available(void) {
     int info3 = stbi__cpuid3();
     return ((info3 >> 26) & 1) != 0;
 }
@@ -752,8 +757,7 @@ static int stbi__sse2_available(void)
 #define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
 
 #if !defined(STBI_NO_JPEG) && defined(STBI_SSE2)
-static int stbi__sse2_available(void)
-{
+static int stbi__sse2_available(void) {
     // If we're even attempting to compile this on GCC/Clang, that means
     // -msse2 is on, which means the compiler is allowed to use SSE2
     // instructions at will, and so are we.
@@ -792,13 +796,12 @@ static int stbi__sse2_available(void)
 
 // stbi__context structure is our basic context used by all images, so it
 // contains all the IO context, plus some basic image information
-typedef struct
-{
+typedef struct {
     stbi__uint32 img_x, img_y;
     int img_n, img_out_n;
 
     stbi_io_callbacks io;
-    void *io_user_data;
+    void * io_user_data;
 
     int read_from_callbacks;
     int buflen;
@@ -809,11 +812,10 @@ typedef struct
     stbi_uc *img_buffer_original, *img_buffer_original_end;
 } stbi__context;
 
-static void stbi__refill_buffer(stbi__context *s);
+static void stbi__refill_buffer(stbi__context * s);
 
 // initialize a memory-decode context
-static void stbi__start_mem(stbi__context *s, stbi_uc const *buffer, int len)
-{
+static void stbi__start_mem(stbi__context * s, stbi_uc const * buffer, int len) {
     s->io.read = NULL;
     s->read_from_callbacks = 0;
     s->callback_already_read = 0;
@@ -822,8 +824,7 @@ static void stbi__start_mem(stbi__context *s, stbi_uc const *buffer, int len)
 }
 
 // initialize a callback-based context
-static void stbi__start_callbacks(stbi__context *s, stbi_io_callbacks *c, void *user)
-{
+static void stbi__start_callbacks(stbi__context * s, stbi_io_callbacks * c, void * user) {
     s->io = *c;
     s->io_user_data = user;
     s->buflen = sizeof(s->buffer_start);
@@ -836,45 +837,32 @@ static void stbi__start_callbacks(stbi__context *s, stbi_io_callbacks *c, void *
 
 #ifndef STBI_NO_STDIO
 
-static int stbi__stdio_read(void *user, char *data, int size)
-{
-    return (int)fread(data, 1, size, (FILE *)user);
-}
+static int stbi__stdio_read(void * user, char * data, int size) { return (int)fread(data, 1, size, (FILE *)user); }
 
-static void stbi__stdio_skip(void *user, int n)
-{
+static void stbi__stdio_skip(void * user, int n) {
     int ch;
     fseek((FILE *)user, n, SEEK_CUR);
     ch = fgetc((FILE *)user); /* have to read a byte to reset feof()'s flag */
-    if (ch != EOF)
-    {
+    if (ch != EOF) {
         ungetc(ch, (FILE *)user); /* push byte back onto stream if valid. */
     }
 }
 
-static int stbi__stdio_eof(void *user)
-{
-    return feof((FILE *)user) || ferror((FILE *)user);
-}
+static int stbi__stdio_eof(void * user) { return feof((FILE *)user) || ferror((FILE *)user); }
 
-static stbi_io_callbacks stbi__stdio_callbacks =
-    {
-        stbi__stdio_read,
-        stbi__stdio_skip,
-        stbi__stdio_eof,
+static stbi_io_callbacks stbi__stdio_callbacks = {
+    stbi__stdio_read,
+    stbi__stdio_skip,
+    stbi__stdio_eof,
 };
 
-static void stbi__start_file(stbi__context *s, FILE *f)
-{
-    stbi__start_callbacks(s, &stbi__stdio_callbacks, (void *)f);
-}
+static void stbi__start_file(stbi__context * s, FILE * f) { stbi__start_callbacks(s, &stbi__stdio_callbacks, (void *)f); }
 
 // static void stop_file(stbi__context *s) { }
 
 #endif // !STBI_NO_STDIO
 
-static void stbi__rewind(stbi__context *s)
-{
+static void stbi__rewind(stbi__context * s) {
     // conceptually rewind SHOULD rewind to the beginning of the stream,
     // but we just rewind to the beginning of the initial buffer, because
     // we only use it after doing 'test', which only ever looks at at most 92 bytes
@@ -882,100 +870,88 @@ static void stbi__rewind(stbi__context *s)
     s->img_buffer_end = s->img_buffer_original_end;
 }
 
-enum
-{
-    STBI_ORDER_RGB,
-    STBI_ORDER_BGR
-};
+enum { STBI_ORDER_RGB, STBI_ORDER_BGR };
 
-typedef struct
-{
+typedef struct {
     int bits_per_channel;
     int num_channels;
     int channel_order;
 } stbi__result_info;
 
 #ifndef STBI_NO_JPEG
-static int stbi__jpeg_test(stbi__context *s);
-static void *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
-static int stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp);
+static int stbi__jpeg_test(stbi__context * s);
+static void * stbi__jpeg_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri);
+static int stbi__jpeg_info(stbi__context * s, int * x, int * y, int * comp);
 #endif
 
 #ifndef STBI_NO_PNG
-static int stbi__png_test(stbi__context *s);
-static void *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
-static int stbi__png_info(stbi__context *s, int *x, int *y, int *comp);
-static int stbi__png_is16(stbi__context *s);
+static int stbi__png_test(stbi__context * s);
+static void * stbi__png_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri);
+static int stbi__png_info(stbi__context * s, int * x, int * y, int * comp);
+static int stbi__png_is16(stbi__context * s);
 #endif
 
 #ifndef STBI_NO_BMP
-static int stbi__bmp_test(stbi__context *s);
-static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
-static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp);
+static int stbi__bmp_test(stbi__context * s);
+static void * stbi__bmp_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri);
+static int stbi__bmp_info(stbi__context * s, int * x, int * y, int * comp);
 #endif
 
 #ifndef STBI_NO_TGA
-static int stbi__tga_test(stbi__context *s);
-static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
-static int stbi__tga_info(stbi__context *s, int *x, int *y, int *comp);
+static int stbi__tga_test(stbi__context * s);
+static void * stbi__tga_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri);
+static int stbi__tga_info(stbi__context * s, int * x, int * y, int * comp);
 #endif
 
 #ifndef STBI_NO_PSD
-static int stbi__psd_test(stbi__context *s);
-static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc);
-static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp);
-static int stbi__psd_is16(stbi__context *s);
+static int stbi__psd_test(stbi__context * s);
+static void * stbi__psd_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri, int bpc);
+static int stbi__psd_info(stbi__context * s, int * x, int * y, int * comp);
+static int stbi__psd_is16(stbi__context * s);
 #endif
 
 #ifndef STBI_NO_HDR
-static int stbi__hdr_test(stbi__context *s);
-static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
-static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp);
+static int stbi__hdr_test(stbi__context * s);
+static float * stbi__hdr_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri);
+static int stbi__hdr_info(stbi__context * s, int * x, int * y, int * comp);
 #endif
 
 #ifndef STBI_NO_PIC
-static int stbi__pic_test(stbi__context *s);
-static void *stbi__pic_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
-static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp);
+static int stbi__pic_test(stbi__context * s);
+static void * stbi__pic_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri);
+static int stbi__pic_info(stbi__context * s, int * x, int * y, int * comp);
 #endif
 
 #ifndef STBI_NO_GIF
-static int stbi__gif_test(stbi__context *s);
-static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
-static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
-static int stbi__gif_info(stbi__context *s, int *x, int *y, int *comp);
+static int stbi__gif_test(stbi__context * s);
+static void * stbi__gif_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri);
+static void * stbi__load_gif_main(stbi__context * s, int ** delays, int * x, int * y, int * z, int * comp, int req_comp);
+static int stbi__gif_info(stbi__context * s, int * x, int * y, int * comp);
 #endif
 
 #ifndef STBI_NO_PNM
-static int stbi__pnm_test(stbi__context *s);
-static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
-static int stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp);
-static int stbi__pnm_is16(stbi__context *s);
+static int stbi__pnm_test(stbi__context * s);
+static void * stbi__pnm_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri);
+static int stbi__pnm_info(stbi__context * s, int * x, int * y, int * comp);
+static int stbi__pnm_is16(stbi__context * s);
 #endif
 
 static
 #ifdef STBI_THREAD_LOCAL
     STBI_THREAD_LOCAL
 #endif
-    const char *stbi__g_failure_reason;
+    const char * stbi__g_failure_reason;
 
-STBIDEF const char *stbi_failure_reason(void)
-{
-    return stbi__g_failure_reason;
-}
+STBIDEF const char * stbi_failure_reason(void) { return stbi__g_failure_reason; }
 
 #ifndef STBI_NO_FAILURE_STRINGS
-static int stbi__err(const char *str)
-{
+static int stbi__err(const char * str) {
     stbi__g_failure_reason = str;
     return 0;
 }
 #endif
 
-static void *stbi__malloc(size_t size)
-{
-    return STBI_MALLOC(size);
-}
+static void * stbi__malloc(size_t size) { return STBI_MALLOC(size); }
 
 // stb_image uses ints pervasively, including for offset calculations.
 // therefore the largest decoded image size we can support with the
@@ -989,8 +965,7 @@ static void *stbi__malloc(size_t size)
 
 // return 1 if the sum is valid, 0 on overflow.
 // negative terms are considered invalid.
-static int stbi__addsizes_valid(int a, int b)
-{
+static int stbi__addsizes_valid(int a, int b) {
     if (b < 0)
         return 0;
     // now 0 <= b <= INT_MAX, hence also
@@ -1002,8 +977,7 @@ static int stbi__addsizes_valid(int a, int b)
 
 // returns 1 if the product is valid, 0 on overflow.
 // negative factors are considered invalid.
-static int stbi__mul2sizes_valid(int a, int b)
-{
+static int stbi__mul2sizes_valid(int a, int b) {
     if (a < 0 || b < 0)
         return 0;
     if (b == 0)
@@ -1014,48 +988,41 @@ static int stbi__mul2sizes_valid(int a, int b)
 
 #if !defined(STBI_NO_JPEG) || !defined(STBI_NO_PNG) || !defined(STBI_NO_TGA) || !defined(STBI_NO_HDR)
 // returns 1 if "a*b + add" has no negative terms/factors and doesn't overflow
-static int stbi__mad2sizes_valid(int a, int b, int add)
-{
+static int stbi__mad2sizes_valid(int a, int b, int add) {
     return stbi__mul2sizes_valid(a, b) && stbi__addsizes_valid(a * b, add);
 }
 #endif
 
 // returns 1 if "a*b*c + add" has no negative terms/factors and doesn't overflow
-static int stbi__mad3sizes_valid(int a, int b, int c, int add)
-{
-    return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a * b, c) &&
-           stbi__addsizes_valid(a * b * c, add);
+static int stbi__mad3sizes_valid(int a, int b, int c, int add) {
+    return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a * b, c) && stbi__addsizes_valid(a * b * c, add);
 }
 
 // returns 1 if "a*b*c*d + add" has no negative terms/factors and doesn't overflow
 #if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM)
-static int stbi__mad4sizes_valid(int a, int b, int c, int d, int add)
-{
-    return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a * b, c) &&
-           stbi__mul2sizes_valid(a * b * c, d) && stbi__addsizes_valid(a * b * c * d, add);
+static int stbi__mad4sizes_valid(int a, int b, int c, int d, int add) {
+    return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a * b, c) && stbi__mul2sizes_valid(a * b * c, d) &&
+           stbi__addsizes_valid(a * b * c * d, add);
 }
 #endif
 
 #if !defined(STBI_NO_JPEG) || !defined(STBI_NO_PNG) || !defined(STBI_NO_TGA) || !defined(STBI_NO_HDR)
 // mallocs with size overflow checking
-static void *stbi__malloc_mad2(int a, int b, int add)
-{
+static void * stbi__malloc_mad2(int a, int b, int add) {
     if (!stbi__mad2sizes_valid(a, b, add))
         return NULL;
     return stbi__malloc(a * b + add);
 }
 #endif
 
-static void *stbi__malloc_mad3(int a, int b, int c, int add)
-{
+static void * stbi__malloc_mad3(int a, int b, int c, int add) {
     if (!stbi__mad3sizes_valid(a, b, c, add))
         return NULL;
     return stbi__malloc(a * b * c + add);
 }
 
 #if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM)
-static void *stbi__malloc_mad4(int a, int b, int c, int d, int add)
-{
+static void * stbi__malloc_mad4(int a, int b, int c, int d, int add) {
     if (!stbi__mad4sizes_valid(a, b, c, d, add))
         return NULL;
     return stbi__malloc(a * b * c * d + add);
@@ -1063,8 +1030,7 @@ static void *stbi__malloc_mad4(int a, int b, int c, int d, int add)
 #endif
 
 // returns 1 if the sum of two signed ints is valid (between -2^31 and 2^31-1 inclusive), 0 on overflow.
-static int stbi__addints_valid(int a, int b)
-{
+static int stbi__addints_valid(int a, int b) {
     if ((a >= 0) != (b >= 0))
         return 1; // a and b have different signs, so no overflow
     if (a < 0 && b < 0)
@@ -1073,8 +1039,7 @@ static int stbi__addints_valid(int a, int b)
 }
 
 // returns 1 if the product of two signed shorts is valid, 0 on overflow.
-static int stbi__mul2shorts_valid(short a, short b)
-{
+static int stbi__mul2shorts_valid(short a, short b) {
     if (b == 0 || b == -1)
         return 1; // multiplication by 0 is always 0; check for -1 so SHRT_MIN/b doesn't overflow
     if ((a >= 0) == (b >= 0))
@@ -1099,23 +1064,19 @@ static int stbi__mul2shorts_valid(short a, short b)
 #define stbi__errpf(x, y) ((float *)(size_t)(stbi__err(x, y) ? NULL : NULL))
 #define stbi__errpuc(x, y) ((unsigned char *)(size_t)(stbi__err(x, y) ? NULL : NULL))
 
-STBIDEF void stbi_image_free(void *retval_from_stbi_load)
-{
-    STBI_FREE(retval_from_stbi_load);
-}
+STBIDEF void stbi_image_free(void * retval_from_stbi_load) { STBI_FREE(retval_from_stbi_load); }
 
 #ifndef STBI_NO_LINEAR
-static float *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp);
+static float * stbi__ldr_to_hdr(stbi_uc * data, int x, int y, int comp);
 #endif
 
 #ifndef STBI_NO_HDR
-static stbi_uc *stbi__hdr_to_ldr(float *data, int x, int y, int comp);
+static stbi_uc * stbi__hdr_to_ldr(float * data, int x, int y, int comp);
 #endif
 
 static int stbi__vertically_flip_on_load_global = 0;
 
-STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip)
-{
+STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip) {
     stbi__vertically_flip_on_load_global = flag_true_if_should_flip;
 }
 
@@ -1124,19 +1085,16 @@ STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip)
 #else
 static STBI_THREAD_LOCAL int stbi__vertically_flip_on_load_local, stbi__vertically_flip_on_load_set;
 
-STBIDEF void stbi_set_flip_vertically_on_load_thread(int flag_true_if_should_flip)
-{
+STBIDEF void stbi_set_flip_vertically_on_load_thread(int flag_true_if_should_flip) {
     stbi__vertically_flip_on_load_local = flag_true_if_should_flip;
     stbi__vertically_flip_on_load_set = 1;
 }
 
-#define stbi__vertically_flip_on_load (stbi__vertically_flip_on_load_set         \
-                                           ? stbi__vertically_flip_on_load_local \
-                                           : stbi__vertically_flip_on_load_global)
+#define stbi__vertically_flip_on_load                                                                                          \
+    (stbi__vertically_flip_on_load_set ? stbi__vertically_flip_on_load_local : stbi__vertically_flip_on_load_global)
 #endif // STBI_THREAD_LOCAL
 
-static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
-{
+static void * stbi__load_main(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri, int bpc) {
     memset(ri, 0, sizeof(*ri));         // make sure it's initialized if we add new fields
     ri->bits_per_channel = 8;           // default is 8 so most paths don't have to be changed
     ri->channel_order = STBI_ORDER_RGB; // all current input & output are this, but this is here so we can add BGR order
@@ -1180,9 +1138,8 @@ static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int re
 #endif
 
 #ifndef STBI_NO_HDR
-    if (stbi__hdr_test(s))
-    {
-        float *hdr = stbi__hdr_load(s, x, y, comp, req_comp, ri);
+    if (stbi__hdr_test(s)) {
+        float * hdr = stbi__hdr_load(s, x, y, comp, req_comp, ri);
         return stbi__hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
     }
 #endif
@@ -1196,11 +1153,10 @@ static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int re
     return stbi__errpuc("unknown image type", "Image not of any known type, or corrupt");
 }
 
-static stbi_uc *stbi__convert_16_to_8(stbi__uint16 *orig, int w, int h, int channels)
-{
+static stbi_uc * stbi__convert_16_to_8(stbi__uint16 * orig, int w, int h, int channels) {
     int i;
     int img_len = w * h * channels;
-    stbi_uc *reduced;
+    stbi_uc * reduced;
 
     reduced = (stbi_uc *)stbi__malloc(img_len);
     if (reduced == NULL)
@@ -1213,11 +1169,10 @@ static stbi_uc *stbi__convert_16_to_8(stbi__uint16 *orig, int w, int h, int chan
     return reduced;
 }
 
-static stbi__uint16 *stbi__convert_8_to_16(stbi_uc *orig, int w, int h, int channels)
-{
+static stbi__uint16 * stbi__convert_8_to_16(stbi_uc * orig, int w, int h, int channels) {
     int i;
     int img_len = w * h * channels;
-    stbi__uint16 *enlarged;
+    stbi__uint16 * enlarged;
 
     enlarged = (stbi__uint16 *)stbi__malloc(img_len * 2);
     if (enlarged == NULL)
@@ -1230,21 +1185,18 @@ static stbi__uint16 *stbi__convert_8_to_16(stbi_uc *orig, int w, int h, int chan
     return enlarged;
 }
 
-static void stbi__vertical_flip(void *image, int w, int h, int bytes_per_pixel)
-{
+static void stbi__vertical_flip(void * image, int w, int h, int bytes_per_pixel) {
     int row;
     size_t bytes_per_row = (size_t)w * bytes_per_pixel;
     stbi_uc temp[2048];
-    stbi_uc *bytes = (stbi_uc *)image;
+    stbi_uc * bytes = (stbi_uc *)image;
 
-    for (row = 0; row < (h >> 1); row++)
-    {
-        stbi_uc *row0 = bytes + row * bytes_per_row;
-        stbi_uc *row1 = bytes + (h - row - 1) * bytes_per_row;
+    for (row = 0; row < (h >> 1); row++) {
+        stbi_uc * row0 = bytes + row * bytes_per_row;
+        stbi_uc * row1 = bytes + (h - row - 1) * bytes_per_row;
         // swap row0 with row1
         size_t bytes_left = bytes_per_row;
-        while (bytes_left)
-        {
+        while (bytes_left) {
             size_t bytes_copy = (bytes_left < sizeof(temp)) ? bytes_left : sizeof(temp);
             memcpy(temp, row0, bytes_copy);
             memcpy(row0, row1, bytes_copy);
@@ -1257,24 +1209,21 @@ static void stbi__vertical_flip(void *image, int w, int h, int bytes_per_pixel)
 }
 
 #ifndef STBI_NO_GIF
-static void stbi__vertical_flip_slices(void *image, int w, int h, int z, int bytes_per_pixel)
-{
+static void stbi__vertical_flip_slices(void * image, int w, int h, int z, int bytes_per_pixel) {
     int slice;
     int slice_size = w * h * bytes_per_pixel;
 
-    stbi_uc *bytes = (stbi_uc *)image;
-    for (slice = 0; slice < z; ++slice)
-    {
+    stbi_uc * bytes = (stbi_uc *)image;
+    for (slice = 0; slice < z; ++slice) {
         stbi__vertical_flip(bytes, w, h, bytes_per_pixel);
         bytes += slice_size;
     }
 }
 #endif
 
-static unsigned char *stbi__load_and_postprocess_8bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
-{
+static unsigned char * stbi__load_and_postprocess_8bit(stbi__context * s, int * x, int * y, int * comp, int req_comp) {
     stbi__result_info ri;
-    void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 8);
+    void * result = stbi__load_main(s, x, y, comp, req_comp, &ri, 8);
 
     if (result == NULL)
         return NULL;
@@ -1282,16 +1231,14 @@ static unsigned char *stbi__load_and_postprocess_8bit(stbi__context *s, int *x, 
     // it is the responsibility of the loaders to make sure we get either 8 or 16 bit.
     STBI_ASSERT(ri.bits_per_channel == 8 || ri.bits_per_channel == 16);
 
-    if (ri.bits_per_channel != 8)
-    {
+    if (ri.bits_per_channel != 8) {
         result = stbi__convert_16_to_8((stbi__uint16 *)result, *x, *y, req_comp == 0 ? *comp : req_comp);
         ri.bits_per_channel = 8;
     }
 
     // @TODO: move stbi__convert_format to here
 
-    if (stbi__vertically_flip_on_load)
-    {
+    if (stbi__vertically_flip_on_load) {
         int channels = req_comp ? req_comp : *comp;
         stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi_uc));
     }
@@ -1299,10 +1246,9 @@ static unsigned char *stbi__load_and_postprocess_8bit(stbi__context *s, int *x, 
     return (unsigned char *)result;
 }
 
-static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
-{
+static stbi__uint16 * stbi__load_and_postprocess_16bit(stbi__context * s, int * x, int * y, int * comp, int req_comp) {
     stbi__result_info ri;
-    void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 16);
+    void * result = stbi__load_main(s, x, y, comp, req_comp, &ri, 16);
 
     if (result == NULL)
         return NULL;
@@ -1310,8 +1256,7 @@ static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, 
     // it is the responsibility of the loaders to make sure we get either 8 or 16 bit.
     STBI_ASSERT(ri.bits_per_channel == 8 || ri.bits_per_channel == 16);
 
-    if (ri.bits_per_channel != 16)
-    {
+    if (ri.bits_per_channel != 16) {
         result = stbi__convert_8_to_16((stbi_uc *)result, *x, *y, req_comp == 0 ? *comp : req_comp);
         ri.bits_per_channel = 16;
     }
@@ -1319,8 +1264,7 @@ static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, 
     // @TODO: move stbi__convert_format16 to here
     // @TODO: special case RGB-to-Y (and RGBA-to-YA) for 8-bit-to-16-bit case to keep more precision
 
-    if (stbi__vertically_flip_on_load)
-    {
+    if (stbi__vertically_flip_on_load) {
         int channels = req_comp ? req_comp : *comp;
         stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi__uint16));
     }
@@ -1329,10 +1273,8 @@ static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, 
 }
 
 #if !defined(STBI_NO_HDR) && !defined(STBI_NO_LINEAR)
-static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, int req_comp)
-{
-    if (stbi__vertically_flip_on_load && result != NULL)
-    {
+static void stbi__float_postprocess(float * result, int * x, int * y, int * comp, int req_comp) {
+    if (stbi__vertically_flip_on_load && result != NULL) {
         int channels = req_comp ? req_comp : *comp;
         stbi__vertical_flip(result, *x, *y, channels * sizeof(float));
     }
@@ -1342,20 +1284,21 @@ static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, in
 #ifndef STBI_NO_STDIO
 
 #if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
-STBI_EXTERN __declspec(dllimport) int __stdcall MultiByteToWideChar(unsigned int cp, unsigned long flags, const char *str, int cbmb, wchar_t *widestr, int cchwide);
-STBI_EXTERN __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigned long flags, const wchar_t *widestr, int cchwide, char *str, int cbmb, const char *defchar, int *used_default);
+STBI_EXTERN __declspec(dllimport) int __stdcall MultiByteToWideChar(unsigned int cp, unsigned long flags, const char * str,
+                                                                    int cbmb, wchar_t * widestr, int cchwide);
+STBI_EXTERN __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigned long flags,
+                                                                    const wchar_t * widestr, int cchwide, char * str, int cbmb,
+                                                                    const char * defchar, int * used_default);
 #endif
 
 #if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
-STBIDEF int stbi_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t *input)
-{
+STBIDEF int stbi_convert_wchar_to_utf8(char * buffer, size_t bufferlen, const wchar_t * input) {
     return WideCharToMultiByte(65001 /* UTF8 */, 0, input, -1, buffer, (int)bufferlen, NULL, NULL);
 }
 #endif
 
-static FILE *stbi__fopen(char const *filename, char const *mode)
-{
-    FILE *f;
+static FILE * stbi__fopen(char const * filename, char const * mode) {
+    FILE * f;
 #if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
     wchar_t wMode[64];
     wchar_t wFilename[1024];
@@ -1381,10 +1324,9 @@ static FILE *stbi__fopen(char const *filename, char const *mode)
     return f;
 }
 
-STBIDEF stbi_uc *stbi_load(char const *filename, int *x, int *y, int *comp, int req_comp)
-{
-    FILE *f = stbi__fopen(filename, "rb");
-    unsigned char *result;
+STBIDEF stbi_uc * stbi_load(char const * filename, int * x, int * y, int * comp, int req_comp) {
+    FILE * f = stbi__fopen(filename, "rb");
+    unsigned char * result;
     if (!f)
         return stbi__errpuc("can't fopen", "Unable to open file");
     result = stbi_load_from_file(f, x, y, comp, req_comp);
@@ -1392,38 +1334,33 @@ STBIDEF stbi_uc *stbi_load(char const *filename, int *x, int *y, int *comp, int 
     return result;
 }
 
-STBIDEF stbi_uc *stbi_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
-{
-    unsigned char *result;
+STBIDEF stbi_uc * stbi_load_from_file(FILE * f, int * x, int * y, int * comp, int req_comp) {
+    unsigned char * result;
     stbi__context s;
     stbi__start_file(&s, f);
     result = stbi__load_and_postprocess_8bit(&s, x, y, comp, req_comp);
-    if (result)
-    {
+    if (result) {
         // need to 'unget' all the characters in the IO buffer
         fseek(f, -(int)(s.img_buffer_end - s.img_buffer), SEEK_CUR);
     }
     return result;
 }
 
-STBIDEF stbi__uint16 *stbi_load_from_file_16(FILE *f, int *x, int *y, int *comp, int req_comp)
-{
-    stbi__uint16 *result;
+STBIDEF stbi__uint16 * stbi_load_from_file_16(FILE * f, int * x, int * y, int * comp, int req_comp) {
+    stbi__uint16 * result;
     stbi__context s;
     stbi__start_file(&s, f);
     result = stbi__load_and_postprocess_16bit(&s, x, y, comp, req_comp);
-    if (result)
-    {
+    if (result) {
         // need to 'unget' all the characters in the IO buffer
         fseek(f, -(int)(s.img_buffer_end - s.img_buffer), SEEK_CUR);
     }
     return result;
 }
 
-STBIDEF stbi_us *stbi_load_16(char const *filename, int *x, int *y, int *comp, int req_comp)
-{
-    FILE *f = stbi__fopen(filename, "rb");
-    stbi__uint16 *result;
+STBIDEF stbi_us * stbi_load_16(char const * filename, int * x, int * y, int * comp, int req_comp) {
+    FILE * f = stbi__fopen(filename, "rb");
+    stbi__uint16 * result;
     if (!f)
         return (stbi_us *)stbi__errpuc("can't fopen", "Unable to open file");
     result = stbi_load_from_file_16(f, x, y, comp, req_comp);
@@ -1433,44 +1370,42 @@ STBIDEF stbi_us *stbi_load_16(char const *filename, int *x, int *y, int *comp, i
 
 #endif //! STBI_NO_STDIO
 
-STBIDEF stbi_us *stbi_load_16_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels)
-{
+STBIDEF stbi_us * stbi_load_16_from_memory(stbi_uc const * buffer, int len, int * x, int * y, int * channels_in_file,
+                                           int desired_channels) {
     stbi__context s;
     stbi__start_mem(&s, buffer, len);
     return stbi__load_and_postprocess_16bit(&s, x, y, channels_in_file, desired_channels);
 }
 
-STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels)
-{
+STBIDEF stbi_us * stbi_load_16_from_callbacks(stbi_io_callbacks const * clbk, void * user, int * x, int * y,
+                                              int * channels_in_file, int desired_channels) {
     stbi__context s;
     stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
     return stbi__load_and_postprocess_16bit(&s, x, y, channels_in_file, desired_channels);
 }
 
-STBIDEF stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
+STBIDEF stbi_uc * stbi_load_from_memory(stbi_uc const * buffer, int len, int * x, int * y, int * comp, int req_comp) {
     stbi__context s;
     stbi__start_mem(&s, buffer, len);
     return stbi__load_and_postprocess_8bit(&s, x, y, comp, req_comp);
 }
 
-STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
-{
+STBIDEF stbi_uc * stbi_load_from_callbacks(stbi_io_callbacks const * clbk, void * user, int * x, int * y, int * comp,
+                                           int req_comp) {
     stbi__context s;
     stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
     return stbi__load_and_postprocess_8bit(&s, x, y, comp, req_comp);
 }
 
 #ifndef STBI_NO_GIF
-STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
-{
-    unsigned char *result;
+STBIDEF stbi_uc * stbi_load_gif_from_memory(stbi_uc const * buffer, int len, int ** delays, int * x, int * y, int * z,
+                                            int * comp, int req_comp) {
+    unsigned char * result;
     stbi__context s;
     stbi__start_mem(&s, buffer, len);
 
     result = (unsigned char *)stbi__load_gif_main(&s, delays, x, y, z, comp, req_comp);
-    if (stbi__vertically_flip_on_load)
-    {
+    if (stbi__vertically_flip_on_load) {
         stbi__vertical_flip_slices(result, *x, *y, *z, *comp);
     }
 
@@ -1479,14 +1414,12 @@ STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int *
 #endif
 
 #ifndef STBI_NO_LINEAR
-static float *stbi__loadf_main(stbi__context *s, int *x, int *y, int *comp, int req_comp)
-{
-    unsigned char *data;
+static float * stbi__loadf_main(stbi__context * s, int * x, int * y, int * comp, int req_comp) {
+    unsigned char * data;
 #ifndef STBI_NO_HDR
-    if (stbi__hdr_test(s))
-    {
+    if (stbi__hdr_test(s)) {
         stbi__result_info ri;
-        float *hdr_data = stbi__hdr_load(s, x, y, comp, req_comp, &ri);
+        float * hdr_data = stbi__hdr_load(s, x, y, comp, req_comp, &ri);
         if (hdr_data)
             stbi__float_postprocess(hdr_data, x, y, comp, req_comp);
         return hdr_data;
@@ -1498,25 +1431,23 @@ static float *stbi__loadf_main(stbi__context *s, int *x, int *y, int *comp, int 
     return stbi__errpf("unknown image type", "Image not of any known type, or corrupt");
 }
 
-STBIDEF float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
-{
+STBIDEF float * stbi_loadf_from_memory(stbi_uc const * buffer, int len, int * x, int * y, int * comp, int req_comp) {
     stbi__context s;
     stbi__start_mem(&s, buffer, len);
     return stbi__loadf_main(&s, x, y, comp, req_comp);
 }
 
-STBIDEF float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
-{
+STBIDEF float * stbi_loadf_from_callbacks(stbi_io_callbacks const * clbk, void * user, int * x, int * y, int * comp,
+                                          int req_comp) {
     stbi__context s;
     stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
     return stbi__loadf_main(&s, x, y, comp, req_comp);
 }
 
 #ifndef STBI_NO_STDIO
-STBIDEF float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
-{
-    float *result;
-    FILE *f = stbi__fopen(filename, "rb");
+STBIDEF float * stbi_loadf(char const * filename, int * x, int * y, int * comp, int req_comp) {
+    float * result;
+    FILE * f = stbi__fopen(filename, "rb");
     if (!f)
         return stbi__errpf("can't fopen", "Unable to open file");
     result = stbi_loadf_from_file(f, x, y, comp, req_comp);
@@ -1524,8 +1455,7 @@ STBIDEF float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int r
     return result;
 }
 
-STBIDEF float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
-{
+STBIDEF float * stbi_loadf_from_file(FILE * f, int * x, int * y, int * comp, int req_comp) {
     stbi__context s;
     stbi__start_file(&s, f);
     return stbi__loadf_main(&s, x, y, comp, req_comp);
@@ -1538,8 +1468,7 @@ STBIDEF float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *comp, int req_
 // defined, for API simplicity; if STBI_NO_LINEAR is defined, it always
 // reports false!
 
-STBIDEF int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
-{
+STBIDEF int stbi_is_hdr_from_memory(stbi_uc const * buffer, int len) {
 #ifndef STBI_NO_HDR
     stbi__context s;
     stbi__start_mem(&s, buffer, len);
@@ -1552,20 +1481,17 @@ STBIDEF int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
 }
 
 #ifndef STBI_NO_STDIO
-STBIDEF int stbi_is_hdr(char const *filename)
-{
-    FILE *f = stbi__fopen(filename, "rb");
+STBIDEF int stbi_is_hdr(char const * filename) {
+    FILE * f = stbi__fopen(filename, "rb");
     int result = 0;
-    if (f)
-    {
+    if (f) {
         result = stbi_is_hdr_from_file(f);
         fclose(f);
     }
     return result;
 }
 
-STBIDEF int stbi_is_hdr_from_file(FILE *f)
-{
+STBIDEF int stbi_is_hdr_from_file(FILE * f) {
 #ifndef STBI_NO_HDR
     long pos = ftell(f);
     int res;
@@ -1581,8 +1507,7 @@ STBIDEF int stbi_is_hdr_from_file(FILE *f)
 }
 #endif // !STBI_NO_STDIO
 
-STBIDEF int stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user)
-{
+STBIDEF int stbi_is_hdr_from_callbacks(stbi_io_callbacks const * clbk, void * user) {
 #ifndef STBI_NO_HDR
     stbi__context s;
     stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
@@ -1611,39 +1536,28 @@ STBIDEF void stbi_hdr_to_ldr_scale(float scale) { stbi__h2l_scale_i = 1 / scale;
 // Common code used by all image loaders
 //
 
-enum
-{
-    STBI__SCAN_load = 0,
-    STBI__SCAN_type,
-    STBI__SCAN_header
-};
+enum { STBI__SCAN_load = 0, STBI__SCAN_type, STBI__SCAN_header };
 
-static void stbi__refill_buffer(stbi__context *s)
-{
+static void stbi__refill_buffer(stbi__context * s) {
     int n = (s->io.read)(s->io_user_data, (char *)s->buffer_start, s->buflen);
     s->callback_already_read += (int)(s->img_buffer - s->img_buffer_original);
-    if (n == 0)
-    {
+    if (n == 0) {
         // at end of file, treat same as if from memory, but need to handle case
         // where s->img_buffer isn't pointing to safe memory, e.g. 0-byte file
         s->read_from_callbacks = 0;
         s->img_buffer = s->buffer_start;
         s->img_buffer_end = s->buffer_start + 1;
         *s->img_buffer = 0;
-    }
-    else
-    {
+    } else {
         s->img_buffer = s->buffer_start;
         s->img_buffer_end = s->buffer_start + n;
     }
 }
 
-stbi_inline static stbi_uc stbi__get8(stbi__context *s)
-{
+stbi_inline static stbi_uc stbi__get8(stbi__context * s) {
     if (s->img_buffer < s->img_buffer_end)
         return *s->img_buffer++;
-    if (s->read_from_callbacks)
-    {
+    if (s->read_from_callbacks) {
         stbi__refill_buffer(s);
         return *s->img_buffer++;
     }
@@ -1653,10 +1567,8 @@ stbi_inline static stbi_uc stbi__get8(stbi__context *s)
 #if defined(STBI_NO_JPEG) && defined(STBI_NO_HDR) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
 // nothing
 #else
-stbi_inline static int stbi__at_eof(stbi__context *s)
-{
-    if (s->io.read)
-    {
+stbi_inline static int stbi__at_eof(stbi__context * s) {
+    if (s->io.read) {
         if (!(s->io.eof)(s->io_user_data))
             return 0;
         // if feof() is true, check if buffer = end
@@ -1669,23 +1581,20 @@ stbi_inline static int stbi__at_eof(stbi__context *s)
 }
 #endif
 
-#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC)
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) &&   \
+    defined(STBI_NO_GIF) && defined(STBI_NO_PIC)
 // nothing
 #else
-static void stbi__skip(stbi__context *s, int n)
-{
+static void stbi__skip(stbi__context * s, int n) {
     if (n == 0)
         return; // already there!
-    if (n < 0)
-    {
+    if (n < 0) {
         s->img_buffer = s->img_buffer_end;
         return;
     }
-    if (s->io.read)
-    {
+    if (s->io.read) {
         int blen = (int)(s->img_buffer_end - s->img_buffer);
-        if (blen < n)
-        {
+        if (blen < n) {
             s->img_buffer = s->img_buffer_end;
             (s->io.skip)(s->io_user_data, n - blen);
             return;
@@ -1698,13 +1607,10 @@ static void stbi__skip(stbi__context *s, int n)
 #if defined(STBI_NO_PNG) && defined(STBI_NO_TGA) && defined(STBI_NO_HDR) && defined(STBI_NO_PNM)
 // nothing
 #else
-static int stbi__getn(stbi__context *s, stbi_uc *buffer, int n)
-{
-    if (s->io.read)
-    {
+static int stbi__getn(stbi__context * s, stbi_uc * buffer, int n) {
+    if (s->io.read) {
         int blen = (int)(s->img_buffer_end - s->img_buffer);
-        if (blen < n)
-        {
+        if (blen < n) {
             int res, count;
 
             memcpy(buffer, s->img_buffer, blen);
@@ -1716,13 +1622,11 @@ static int stbi__getn(stbi__context *s, stbi_uc *buffer, int n)
         }
     }
 
-    if (s->img_buffer + n <= s->img_buffer_end)
-    {
+    if (s->img_buffer + n <= s->img_buffer_end) {
         memcpy(buffer, s->img_buffer, n);
         s->img_buffer += n;
         return 1;
-    }
-    else
+    } else
         return 0;
 }
 #endif
@@ -1730,8 +1634,7 @@ static int stbi__getn(stbi__context *s, stbi_uc *buffer, int n)
 #if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_PSD) && defined(STBI_NO_PIC)
 // nothing
 #else
-static int stbi__get16be(stbi__context *s)
-{
+static int stbi__get16be(stbi__context * s) {
     int z = stbi__get8(s);
     return (z << 8) + stbi__get8(s);
 }
@@ -1740,8 +1643,7 @@ static int stbi__get16be(stbi__context *s)
 #if defined(STBI_NO_PNG) && defined(STBI_NO_PSD) && defined(STBI_NO_PIC)
 // nothing
 #else
-static stbi__uint32 stbi__get32be(stbi__context *s)
-{
+static stbi__uint32 stbi__get32be(stbi__context * s) {
     stbi__uint32 z = stbi__get16be(s);
     return (z << 16) + stbi__get16be(s);
 }
@@ -1750,16 +1652,14 @@ static stbi__uint32 stbi__get32be(stbi__context *s)
 #if defined(STBI_NO_BMP) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF)
 // nothing
 #else
-static int stbi__get16le(stbi__context *s)
-{
+static int stbi__get16le(stbi__context * s) {
     int z = stbi__get8(s);
     return z + (stbi__get8(s) << 8);
 }
 #endif
 
 #ifndef STBI_NO_BMP
-static stbi__uint32 stbi__get32le(stbi__context *s)
-{
+static stbi__uint32 stbi__get32le(stbi__context * s) {
     stbi__uint32 z = stbi__get16le(s);
     z += (stbi__uint32)stbi__get16le(s) << 16;
     return z;
@@ -1768,7 +1668,8 @@ static stbi__uint32 stbi__get32le(stbi__context *s)
 
 #define STBI__BYTECAST(x) ((stbi_uc)((x)&255)) // truncate int to byte without warnings
 
-#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) &&   \
+    defined(STBI_NO_GIF) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
 // nothing
 #else
 //////////////////////////////////////////////////////////////////////////////
@@ -1782,54 +1683,46 @@ static stbi__uint32 stbi__get32le(stbi__context *s)
 //  assume data buffer is malloced, so malloc a new one and free that one
 //  only failure mode is malloc failing
 
-static stbi_uc stbi__compute_y(int r, int g, int b)
-{
-    return (stbi_uc)(((r * 77) + (g * 150) + (29 * b)) >> 8);
-}
+static stbi_uc stbi__compute_y(int r, int g, int b) { return (stbi_uc)(((r * 77) + (g * 150) + (29 * b)) >> 8); }
 #endif
 
-#if defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
+#if defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) &&    \
+    defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
 // nothing
 #else
-static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int req_comp, unsigned int x, unsigned int y)
-{
+static unsigned char * stbi__convert_format(unsigned char * data, int img_n, int req_comp, unsigned int x, unsigned int y) {
     int i, j;
-    unsigned char *good;
+    unsigned char * good;
 
     if (req_comp == img_n)
         return data;
     STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
 
     good = (unsigned char *)stbi__malloc_mad3(req_comp, x, y, 0);
-    if (good == NULL)
-    {
+    if (good == NULL) {
         STBI_FREE(data);
         return stbi__errpuc("outofmem", "Out of memory");
     }
 
-    for (j = 0; j < (int)y; ++j)
-    {
-        unsigned char *src = data + j * x * img_n;
-        unsigned char *dest = good + j * x * req_comp;
+    for (j = 0; j < (int)y; ++j) {
+        unsigned char * src = data + j * x * img_n;
+        unsigned char * dest = good + j * x * req_comp;
 
 #define STBI__COMBO(a, b) ((a)*8 + (b))
-#define STBI__CASE(a, b)    \
-    case STBI__COMBO(a, b): \
+#define STBI__CASE(a, b)                                                                                                       \
+    case STBI__COMBO(a, b):                                                                                                    \
         for (i = x - 1; i >= 0; --i, src += a, dest += b)
         // convert source image with img_n components to one with req_comp components;
         // avoid switch per pixel, so use switch per scanline and massive macros
-        switch (STBI__COMBO(img_n, req_comp))
-        {
-            STBI__CASE(1, 2)
-            {
+        switch (STBI__COMBO(img_n, req_comp)) {
+            STBI__CASE(1, 2) {
                 dest[0] = src[0];
                 dest[1] = 255;
             }
             break;
             STBI__CASE(1, 3) { dest[0] = dest[1] = dest[2] = src[0]; }
             break;
-            STBI__CASE(1, 4)
-            {
+            STBI__CASE(1, 4) {
                 dest[0] = dest[1] = dest[2] = src[0];
                 dest[3] = 255;
             }
@@ -1838,14 +1731,12 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
             break;
             STBI__CASE(2, 3) { dest[0] = dest[1] = dest[2] = src[0]; }
             break;
-            STBI__CASE(2, 4)
-            {
+            STBI__CASE(2, 4) {
                 dest[0] = dest[1] = dest[2] = src[0];
                 dest[3] = src[1];
             }
             break;
-            STBI__CASE(3, 4)
-            {
+            STBI__CASE(3, 4) {
                 dest[0] = src[0];
                 dest[1] = src[1];
                 dest[2] = src[2];
@@ -1854,22 +1745,19 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
             break;
             STBI__CASE(3, 1) { dest[0] = stbi__compute_y(src[0], src[1], src[2]); }
             break;
-            STBI__CASE(3, 2)
-            {
+            STBI__CASE(3, 2) {
                 dest[0] = stbi__compute_y(src[0], src[1], src[2]);
                 dest[1] = 255;
             }
             break;
             STBI__CASE(4, 1) { dest[0] = stbi__compute_y(src[0], src[1], src[2]); }
             break;
-            STBI__CASE(4, 2)
-            {
+            STBI__CASE(4, 2) {
                 dest[0] = stbi__compute_y(src[0], src[1], src[2]);
                 dest[1] = src[3];
             }
             break;
-            STBI__CASE(4, 3)
-            {
+            STBI__CASE(4, 3) {
                 dest[0] = src[0];
                 dest[1] = src[1];
                 dest[2] = src[2];
@@ -1892,54 +1780,45 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
 #if defined(STBI_NO_PNG) && defined(STBI_NO_PSD)
 // nothing
 #else
-static stbi__uint16 stbi__compute_y_16(int r, int g, int b)
-{
-    return (stbi__uint16)(((r * 77) + (g * 150) + (29 * b)) >> 8);
-}
+static stbi__uint16 stbi__compute_y_16(int r, int g, int b) { return (stbi__uint16)(((r * 77) + (g * 150) + (29 * b)) >> 8); }
 #endif
 
 #if defined(STBI_NO_PNG) && defined(STBI_NO_PSD)
 // nothing
 #else
-static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int req_comp, unsigned int x, unsigned int y)
-{
+static stbi__uint16 * stbi__convert_format16(stbi__uint16 * data, int img_n, int req_comp, unsigned int x, unsigned int y) {
     int i, j;
-    stbi__uint16 *good;
+    stbi__uint16 * good;
 
     if (req_comp == img_n)
         return data;
     STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
 
     good = (stbi__uint16 *)stbi__malloc(req_comp * x * y * 2);
-    if (good == NULL)
-    {
+    if (good == NULL) {
         STBI_FREE(data);
         return (stbi__uint16 *)stbi__errpuc("outofmem", "Out of memory");
     }
 
-    for (j = 0; j < (int)y; ++j)
-    {
-        stbi__uint16 *src = data + j * x * img_n;
-        stbi__uint16 *dest = good + j * x * req_comp;
+    for (j = 0; j < (int)y; ++j) {
+        stbi__uint16 * src = data + j * x * img_n;
+        stbi__uint16 * dest = good + j * x * req_comp;
 
 #define STBI__COMBO(a, b) ((a)*8 + (b))
-#define STBI__CASE(a, b)    \
-    case STBI__COMBO(a, b): \
+#define STBI__CASE(a, b)                                                                                                       \
+    case STBI__COMBO(a, b):                                                                                                    \
         for (i = x - 1; i >= 0; --i, src += a, dest += b)
         // convert source image with img_n components to one with req_comp components;
         // avoid switch per pixel, so use switch per scanline and massive macros
-        switch (STBI__COMBO(img_n, req_comp))
-        {
-            STBI__CASE(1, 2)
-            {
+        switch (STBI__COMBO(img_n, req_comp)) {
+            STBI__CASE(1, 2) {
                 dest[0] = src[0];
                 dest[1] = 0xffff;
             }
             break;
             STBI__CASE(1, 3) { dest[0] = dest[1] = dest[2] = src[0]; }
             break;
-            STBI__CASE(1, 4)
-            {
+            STBI__CASE(1, 4) {
                 dest[0] = dest[1] = dest[2] = src[0];
                 dest[3] = 0xffff;
             }
@@ -1948,14 +1827,12 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int r
             break;
             STBI__CASE(2, 3) { dest[0] = dest[1] = dest[2] = src[0]; }
             break;
-            STBI__CASE(2, 4)
-            {
+            STBI__CASE(2, 4) {
                 dest[0] = dest[1] = dest[2] = src[0];
                 dest[3] = src[1];
             }
             break;
-            STBI__CASE(3, 4)
-            {
+            STBI__CASE(3, 4) {
                 dest[0] = src[0];
                 dest[1] = src[1];
                 dest[2] = src[2];
@@ -1964,22 +1841,19 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int r
             break;
             STBI__CASE(3, 1) { dest[0] = stbi__compute_y_16(src[0], src[1], src[2]); }
             break;
-            STBI__CASE(3, 2)
-            {
+            STBI__CASE(3, 2) {
                 dest[0] = stbi__compute_y_16(src[0], src[1], src[2]);
                 dest[1] = 0xffff;
             }
             break;
             STBI__CASE(4, 1) { dest[0] = stbi__compute_y_16(src[0], src[1], src[2]); }
             break;
-            STBI__CASE(4, 2)
-            {
+            STBI__CASE(4, 2) {
                 dest[0] = stbi__compute_y_16(src[0], src[1], src[2]);
                 dest[1] = src[3];
             }
             break;
-            STBI__CASE(4, 3)
-            {
+            STBI__CASE(4, 3) {
                 dest[0] = src[0];
                 dest[1] = src[1];
                 dest[2] = src[2];
@@ -2000,15 +1874,13 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int r
 #endif
 
 #ifndef STBI_NO_LINEAR
-static float *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
-{
+static float * stbi__ldr_to_hdr(stbi_uc * data, int x, int y, int comp) {
     int i, k, n;
-    float *output;
+    float * output;
     if (!data)
         return NULL;
     output = (float *)stbi__malloc_mad4(x, y, comp, sizeof(float), 0);
-    if (output == NULL)
-    {
+    if (output == NULL) {
         STBI_FREE(data);
         return stbi__errpf("outofmem", "Out of memory");
     }
@@ -2017,17 +1889,13 @@ static float *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
         n = comp;
     else
         n = comp - 1;
-    for (i = 0; i < x * y; ++i)
-    {
-        for (k = 0; k < n; ++k)
-        {
+    for (i = 0; i < x * y; ++i) {
+        for (k = 0; k < n; ++k) {
             output[i * comp + k] = (float)(pow(data[i * comp + k] / 255.0f, stbi__l2h_gamma) * stbi__l2h_scale);
         }
     }
-    if (n < comp)
-    {
-        for (i = 0; i < x * y; ++i)
-        {
+    if (n < comp) {
+        for (i = 0; i < x * y; ++i) {
             output[i * comp + n] = data[i * comp + n] / 255.0f;
         }
     }
@@ -2038,15 +1906,13 @@ static float *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
 
 #ifndef STBI_NO_HDR
 #define stbi__float2int(x) ((int)(x))
-static stbi_uc *stbi__hdr_to_ldr(float *data, int x, int y, int comp)
-{
+static stbi_uc * stbi__hdr_to_ldr(float * data, int x, int y, int comp) {
     int i, k, n;
-    stbi_uc *output;
+    stbi_uc * output;
     if (!data)
         return NULL;
     output = (stbi_uc *)stbi__malloc_mad3(x, y, comp, 0);
-    if (output == NULL)
-    {
+    if (output == NULL) {
         STBI_FREE(data);
         return stbi__errpuc("outofmem", "Out of memory");
     }
@@ -2055,10 +1921,8 @@ static stbi_uc *stbi__hdr_to_ldr(float *data, int x, int y, int comp)
         n = comp;
     else
         n = comp - 1;
-    for (i = 0; i < x * y; ++i)
-    {
-        for (k = 0; k < n; ++k)
-        {
+    for (i = 0; i < x * y; ++i) {
+        for (k = 0; k < n; ++k) {
             float z = (float)pow(data[i * comp + k] * stbi__h2l_scale_i, stbi__h2l_gamma_i) * 255 + 0.5f;
             if (z < 0)
                 z = 0;
@@ -2066,8 +1930,7 @@ static stbi_uc *stbi__hdr_to_ldr(float *data, int x, int y, int comp)
                 z = 255;
             output[i * comp + k] = (stbi_uc)stbi__float2int(z);
         }
-        if (k < comp)
-        {
+        if (k < comp) {
             float z = data[i * comp + k] * 255 + 0.5f;
             if (z < 0)
                 z = 0;
@@ -2107,8 +1970,7 @@ static stbi_uc *stbi__hdr_to_ldr(float *data, int x, int y, int comp)
 // huffman decoding acceleration
 #define FAST_BITS 9 // larger handles more cases; smaller stomps less cache
 
-typedef struct
-{
+typedef struct {
     stbi_uc fast[1 << FAST_BITS];
     // weirdly, repacking this into AoS is a 10% speed loss, instead of a win
     stbi__uint16 code[256];
@@ -2118,9 +1980,8 @@ typedef struct
     int delta[17]; // old 'firstsymbol' - old 'firstcode'
 } stbi__huffman;
 
-typedef struct
-{
-    stbi__context *s;
+typedef struct {
+    stbi__context * s;
     stbi__huffman huff_dc[4];
     stbi__huffman huff_ac[4];
     stbi__uint16 dequant[4][64];
@@ -2132,8 +1993,7 @@ typedef struct
     int img_mcu_w, img_mcu_h;
 
     // definition of jpeg image component
-    struct
-    {
+    struct {
         int id;
         int h, v;
         int tq;
@@ -2141,10 +2001,10 @@ typedef struct
         int dc_pred;
 
         int x, y, w2, h2;
-        stbi_uc *data;
+        stbi_uc * data;
         void *raw_data, *raw_coeff;
-        stbi_uc *linebuf;
-        short *coeff;         // progressive only
+        stbi_uc * linebuf;
+        short * coeff;        // progressive only
         int coeff_w, coeff_h; // number of 8x8 coefficient blocks
     } img_comp[4];
 
@@ -2167,20 +2027,18 @@ typedef struct
     int restart_interval, todo;
 
     // kernels
-    void (*idct_block_kernel)(stbi_uc *out, int out_stride, short data[64]);
-    void (*YCbCr_to_RGB_kernel)(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step);
-    stbi_uc *(*resample_row_hv_2_kernel)(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs);
+    void (*idct_block_kernel)(stbi_uc * out, int out_stride, short data[64]);
+    void (*YCbCr_to_RGB_kernel)(stbi_uc * out, const stbi_uc * y, const stbi_uc * pcb, const stbi_uc * pcr, int count,
+                                int step);
+    stbi_uc * (*resample_row_hv_2_kernel)(stbi_uc * out, stbi_uc * in_near, stbi_uc * in_far, int w, int hs);
 } stbi__jpeg;
 
-static int stbi__build_huffman(stbi__huffman *h, int *count)
-{
+static int stbi__build_huffman(stbi__huffman * h, int * count) {
     int i, j, k = 0;
     unsigned int code;
     // build size list for each symbol (from JPEG spec)
-    for (i = 0; i < 16; ++i)
-    {
-        for (j = 0; j < count[i]; ++j)
-        {
+    for (i = 0; i < 16; ++i) {
+        for (j = 0; j < count[i]; ++j) {
             h->size[k++] = (stbi_uc)(i + 1);
             if (k >= 257)
                 return stbi__err("bad size list", "Corrupt JPEG");
@@ -2191,12 +2049,10 @@ static int stbi__build_huffman(stbi__huffman *h, int *count)
     // compute actual symbols (from jpeg spec)
     code = 0;
     k = 0;
-    for (j = 1; j <= 16; ++j)
-    {
+    for (j = 1; j <= 16; ++j) {
         // compute delta to add to code to compute symbol id
         h->delta[j] = k - code;
-        if (h->size[k] == j)
-        {
+        if (h->size[k] == j) {
             while (h->size[k] == j)
                 h->code[k++] = (stbi__uint16)(code++);
             if (code - 1 >= (1u << j))
@@ -2210,15 +2066,12 @@ static int stbi__build_huffman(stbi__huffman *h, int *count)
 
     // build non-spec acceleration table; 255 is flag for not-accelerated
     memset(h->fast, 255, 1 << FAST_BITS);
-    for (i = 0; i < k; ++i)
-    {
+    for (i = 0; i < k; ++i) {
         int s = h->size[i];
-        if (s <= FAST_BITS)
-        {
+        if (s <= FAST_BITS) {
             int c = h->code[i] << (FAST_BITS - s);
             int m = 1 << (FAST_BITS - s);
-            for (j = 0; j < m; ++j)
-            {
+            for (j = 0; j < m; ++j) {
                 h->fast[c + j] = (stbi_uc)i;
             }
         }
@@ -2228,22 +2081,18 @@ static int stbi__build_huffman(stbi__huffman *h, int *count)
 
 // build a table that decodes both magnitude and value of small ACs in
 // one go.
-static void stbi__build_fast_ac(stbi__int16 *fast_ac, stbi__huffman *h)
-{
+static void stbi__build_fast_ac(stbi__int16 * fast_ac, stbi__huffman * h) {
     int i;
-    for (i = 0; i < (1 << FAST_BITS); ++i)
-    {
+    for (i = 0; i < (1 << FAST_BITS); ++i) {
         stbi_uc fast = h->fast[i];
         fast_ac[i] = 0;
-        if (fast < 255)
-        {
+        if (fast < 255) {
             int rs = h->values[fast];
             int run = (rs >> 4) & 15;
             int magbits = rs & 15;
             int len = h->size[fast];
 
-            if (magbits && len + magbits <= FAST_BITS)
-            {
+            if (magbits && len + magbits <= FAST_BITS) {
                 // magnitude code followed by receive_extend code
                 int k = ((i << len) & ((1 << FAST_BITS) - 1)) >> (FAST_BITS - magbits);
                 int m = 1 << (magbits - 1);
@@ -2257,18 +2106,14 @@ static void stbi__build_fast_ac(stbi__int16 *fast_ac, stbi__huffman *h)
     }
 }
 
-static void stbi__grow_buffer_unsafe(stbi__jpeg *j)
-{
-    do
-    {
+static void stbi__grow_buffer_unsafe(stbi__jpeg * j) {
+    do {
         unsigned int b = j->nomore ? 0 : stbi__get8(j->s);
-        if (b == 0xff)
-        {
+        if (b == 0xff) {
             int c = stbi__get8(j->s);
             while (c == 0xff)
                 c = stbi__get8(j->s); // consume fill bytes
-            if (c != 0)
-            {
+            if (c != 0) {
                 j->marker = (unsigned char)c;
                 j->nomore = 1;
                 return;
@@ -2280,11 +2125,11 @@ static void stbi__grow_buffer_unsafe(stbi__jpeg *j)
 }
 
 // (1 << n) - 1
-static const stbi__uint32 stbi__bmask[17] = {0, 1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095, 8191, 16383, 32767, 65535};
+static const stbi__uint32 stbi__bmask[17] = {0,   1,    3,    7,    15,   31,    63,    127,  255,
+                                             511, 1023, 2047, 4095, 8191, 16383, 32767, 65535};
 
 // decode a jpeg huffman value from the bitstream
-stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
-{
+stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg * j, stbi__huffman * h) {
     unsigned int temp;
     int c, k;
 
@@ -2295,8 +2140,7 @@ stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
     // if the code is <= FAST_BITS
     c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS) - 1);
     k = h->fast[c];
-    if (k < 255)
-    {
+    if (k < 255) {
         int s = h->size[k];
         if (s > j->code_bits)
             return -1;
@@ -2315,8 +2159,7 @@ stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
     for (k = FAST_BITS + 1;; ++k)
         if (temp < h->maxcode[k])
             break;
-    if (k == 17)
-    {
+    if (k == 17) {
         // error! code not found
         j->code_bits -= 16;
         return -1;
@@ -2342,8 +2185,7 @@ static const int stbi__jbias[16] = {0, -1, -3, -7, -15, -31, -63, -127, -255, -5
 
 // combined JPEG 'receive' and JPEG 'extend', since baseline
 // always extends everything it receives.
-stbi_inline static int stbi__extend_receive(stbi__jpeg *j, int n)
-{
+stbi_inline static int stbi__extend_receive(stbi__jpeg * j, int n) {
     unsigned int k;
     int sgn;
     if (j->code_bits < n)
@@ -2360,8 +2202,7 @@ stbi_inline static int stbi__extend_receive(stbi__jpeg *j, int n)
 }
 
 // get some unsigned bits
-stbi_inline static int stbi__jpeg_get_bits(stbi__jpeg *j, int n)
-{
+stbi_inline static int stbi__jpeg_get_bits(stbi__jpeg * j, int n) {
     unsigned int k;
     if (j->code_bits < n)
         stbi__grow_buffer_unsafe(j);
@@ -2374,8 +2215,7 @@ stbi_inline static int stbi__jpeg_get_bits(stbi__jpeg *j, int n)
     return k;
 }
 
-stbi_inline static int stbi__jpeg_get_bit(stbi__jpeg *j)
-{
+stbi_inline static int stbi__jpeg_get_bit(stbi__jpeg * j) {
     unsigned int k;
     if (j->code_bits < 1)
         stbi__grow_buffer_unsafe(j);
@@ -2389,23 +2229,15 @@ stbi_inline static int stbi__jpeg_get_bit(stbi__jpeg *j)
 
 // given a value that's at position X in the zigzag stream,
 // where does it appear in the 8x8 matrix coded as row-major?
-static const stbi_uc stbi__jpeg_dezigzag[64 + 15] =
-    {
-        0, 1, 8, 16, 9, 2, 3, 10,
-        17, 24, 32, 25, 18, 11, 4, 5,
-        12, 19, 26, 33, 40, 48, 41, 34,
-        27, 20, 13, 6, 7, 14, 21, 28,
-        35, 42, 49, 56, 57, 50, 43, 36,
-        29, 22, 15, 23, 30, 37, 44, 51,
-        58, 59, 52, 45, 38, 31, 39, 46,
-        53, 60, 61, 54, 47, 55, 62, 63,
-        // let corrupt input sample past end
-        63, 63, 63, 63, 63, 63, 63, 63,
-        63, 63, 63, 63, 63, 63, 63};
+static const stbi_uc stbi__jpeg_dezigzag[64 + 15] = {
+    0, 1, 8, 16, 9, 2, 3, 10, 17, 24, 32, 25, 18, 11, 4, 5, 12, 19, 26, 33, 40, 48, 41, 34, 27, 20, 13, 6, 7, 14, 21, 28, 35,
+    42, 49, 56, 57, 50, 43, 36, 29, 22, 15, 23, 30, 37, 44, 51, 58, 59, 52, 45, 38, 31, 39, 46, 53, 60, 61, 54, 47, 55, 62, 63,
+    // let corrupt input sample past end
+    63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63};
 
 // decode one 64-entry block--
-static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman *hdc, stbi__huffman *hac, stbi__int16 *fac, int b, stbi__uint16 *dequant)
-{
+static int stbi__jpeg_decode_block(stbi__jpeg * j, short data[64], stbi__huffman * hdc, stbi__huffman * hac, stbi__int16 * fac,
+                                   int b, stbi__uint16 * dequant) {
     int diff, dc, k;
     int t;
 
@@ -2429,16 +2261,14 @@ static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman 
 
     // decode AC components, see JPEG spec
     k = 1;
-    do
-    {
+    do {
         unsigned int zig;
         int c, r, s;
         if (j->code_bits < 16)
             stbi__grow_buffer_unsafe(j);
         c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS) - 1);
         r = fac[c];
-        if (r)
-        {                       // fast-AC path
+        if (r) {                // fast-AC path
             k += (r >> 4) & 15; // run
             s = r & 15;         // combined length
             if (s > j->code_bits)
@@ -2448,22 +2278,17 @@ static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman 
             // decode into unzigzag'd location
             zig = stbi__jpeg_dezigzag[k++];
             data[zig] = (short)((r >> 8) * dequant[zig]);
-        }
-        else
-        {
+        } else {
             int rs = stbi__jpeg_huff_decode(j, hac);
             if (rs < 0)
                 return stbi__err("bad huffman code", "Corrupt JPEG");
             s = rs & 15;
             r = rs >> 4;
-            if (s == 0)
-            {
+            if (s == 0) {
                 if (rs != 0xf0)
                     break; // end block
                 k += 16;
-            }
-            else
-            {
+            } else {
                 k += r;
                 // decode into unzigzag'd location
                 zig = stbi__jpeg_dezigzag[k++];
@@ -2474,8 +2299,7 @@ static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman 
     return 1;
 }
 
-static int stbi__jpeg_decode_block_prog_dc(stbi__jpeg *j, short data[64], stbi__huffman *hdc, int b)
-{
+static int stbi__jpeg_decode_block_prog_dc(stbi__jpeg * j, short data[64], stbi__huffman * hdc, int b) {
     int diff, dc;
     int t;
     if (j->spec_end != 0)
@@ -2484,8 +2308,7 @@ static int stbi__jpeg_decode_block_prog_dc(stbi__jpeg *j, short data[64], stbi__
     if (j->code_bits < 16)
         stbi__grow_buffer_unsafe(j);
 
-    if (j->succ_high == 0)
-    {
+    if (j->succ_high == 0) {
         // first scan for DC coefficient, must be first
         memset(data, 0, 64 * sizeof(data[0])); // 0 all the ac values now
         t = stbi__jpeg_huff_decode(j, hdc);
@@ -2500,9 +2323,7 @@ static int stbi__jpeg_decode_block_prog_dc(stbi__jpeg *j, short data[64], stbi__
         if (!stbi__mul2shorts_valid(dc, 1 << j->succ_low))
             return stbi__err("can't merge dc and ac", "Corrupt JPEG");
         data[0] = (short)(dc * (1 << j->succ_low));
-    }
-    else
-    {
+    } else {
         // refinement scan for DC coefficient
         if (stbi__jpeg_get_bit(j))
             data[0] += (short)(1 << j->succ_low);
@@ -2512,33 +2333,28 @@ static int stbi__jpeg_decode_block_prog_dc(stbi__jpeg *j, short data[64], stbi__
 
 // @OPTIMIZE: store non-zigzagged during the decode passes,
 // and only de-zigzag when dequantizing
-static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__huffman *hac, stbi__int16 *fac)
-{
+static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg * j, short data[64], stbi__huffman * hac, stbi__int16 * fac) {
     int k;
     if (j->spec_start == 0)
         return stbi__err("can't merge dc and ac", "Corrupt JPEG");
 
-    if (j->succ_high == 0)
-    {
+    if (j->succ_high == 0) {
         int shift = j->succ_low;
 
-        if (j->eob_run)
-        {
+        if (j->eob_run) {
             --j->eob_run;
             return 1;
         }
 
         k = j->spec_start;
-        do
-        {
+        do {
             unsigned int zig;
             int c, r, s;
             if (j->code_bits < 16)
                 stbi__grow_buffer_unsafe(j);
             c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS) - 1);
             r = fac[c];
-            if (r)
-            {                       // fast-AC path
+            if (r) {                // fast-AC path
                 k += (r >> 4) & 15; // run
                 s = r & 15;         // combined length
                 if (s > j->code_bits)
@@ -2547,18 +2363,14 @@ static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__
                 j->code_bits -= s;
                 zig = stbi__jpeg_dezigzag[k++];
                 data[zig] = (short)((r >> 8) * (1 << shift));
-            }
-            else
-            {
+            } else {
                 int rs = stbi__jpeg_huff_decode(j, hac);
                 if (rs < 0)
                     return stbi__err("bad huffman code", "Corrupt JPEG");
                 s = rs & 15;
                 r = rs >> 4;
-                if (s == 0)
-                {
-                    if (r < 15)
-                    {
+                if (s == 0) {
+                    if (r < 15) {
                         j->eob_run = (1 << r);
                         if (r)
                             j->eob_run += stbi__jpeg_get_bits(j, r);
@@ -2566,68 +2378,53 @@ static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__
                         break;
                     }
                     k += 16;
-                }
-                else
-                {
+                } else {
                     k += r;
                     zig = stbi__jpeg_dezigzag[k++];
                     data[zig] = (short)(stbi__extend_receive(j, s) * (1 << shift));
                 }
             }
         } while (k <= j->spec_end);
-    }
-    else
-    {
+    } else {
         // refinement scan for these AC coefficients
 
         short bit = (short)(1 << j->succ_low);
 
-        if (j->eob_run)
-        {
+        if (j->eob_run) {
             --j->eob_run;
-            for (k = j->spec_start; k <= j->spec_end; ++k)
-            {
-                short *p = &data[stbi__jpeg_dezigzag[k]];
+            for (k = j->spec_start; k <= j->spec_end; ++k) {
+                short * p = &data[stbi__jpeg_dezigzag[k]];
                 if (*p != 0)
                     if (stbi__jpeg_get_bit(j))
-                        if ((*p & bit) == 0)
-                        {
+                        if ((*p & bit) == 0) {
                             if (*p > 0)
                                 *p += bit;
                             else
                                 *p -= bit;
                         }
             }
-        }
-        else
-        {
+        } else {
             k = j->spec_start;
-            do
-            {
+            do {
                 int r, s;
-                int rs = stbi__jpeg_huff_decode(j, hac); // @OPTIMIZE see if we can use the fast path here, advance-by-r is so slow, eh
+                int rs = stbi__jpeg_huff_decode(
+                    j, hac); // @OPTIMIZE see if we can use the fast path here, advance-by-r is so slow, eh
                 if (rs < 0)
                     return stbi__err("bad huffman code", "Corrupt JPEG");
                 s = rs & 15;
                 r = rs >> 4;
-                if (s == 0)
-                {
-                    if (r < 15)
-                    {
+                if (s == 0) {
+                    if (r < 15) {
                         j->eob_run = (1 << r) - 1;
                         if (r)
                             j->eob_run += stbi__jpeg_get_bits(j, r);
                         r = 64; // force end of block
-                    }
-                    else
-                    {
+                    } else {
                         // r=15 s=0 should write 16 0s, so we just do
                         // a run of 15 0s and then write s (which is 0),
                         // so we don't have to do anything special here
                     }
-                }
-                else
-                {
+                } else {
                     if (s != 1)
                         return stbi__err("bad huffman code", "Corrupt JPEG");
                     // sign bit
@@ -2638,24 +2435,18 @@ static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__
                 }
 
                 // advance by r
-                while (k <= j->spec_end)
-                {
-                    short *p = &data[stbi__jpeg_dezigzag[k++]];
-                    if (*p != 0)
-                    {
+                while (k <= j->spec_end) {
+                    short * p = &data[stbi__jpeg_dezigzag[k++]];
+                    if (*p != 0) {
                         if (stbi__jpeg_get_bit(j))
-                            if ((*p & bit) == 0)
-                            {
+                            if ((*p & bit) == 0) {
                                 if (*p > 0)
                                     *p += bit;
                                 else
                                     *p -= bit;
                             }
-                    }
-                    else
-                    {
-                        if (r == 0)
-                        {
+                    } else {
+                        if (r == 0) {
                             *p = (short)s;
                             break;
                         }
@@ -2669,11 +2460,9 @@ static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__
 }
 
 // take a -128..127 value and stbi__clamp it and convert to 0..255
-stbi_inline static stbi_uc stbi__clamp(int x)
-{
+stbi_inline static stbi_uc stbi__clamp(int x) {
     // trick to use a single test to catch both cases
-    if ((unsigned int)x > 255)
-    {
+    if ((unsigned int)x > 255) {
         if (x < 0)
             return 0;
         if (x > 255)
@@ -2686,64 +2475,59 @@ stbi_inline static stbi_uc stbi__clamp(int x)
 #define stbi__fsh(x) ((x)*4096)
 
 // derived from jidctint -- DCT_ISLOW
-#define STBI__IDCT_1D(s0, s1, s2, s3, s4, s5, s6, s7)       \
-    int t0, t1, t2, t3, p1, p2, p3, p4, p5, x0, x1, x2, x3; \
-    p2 = s2;                                                \
-    p3 = s6;                                                \
-    p1 = (p2 + p3) * stbi__f2f(0.5411961f);                 \
-    t2 = p1 + p3 * stbi__f2f(-1.847759065f);                \
-    t3 = p1 + p2 * stbi__f2f(0.765366865f);                 \
-    p2 = s0;                                                \
-    p3 = s4;                                                \
-    t0 = stbi__fsh(p2 + p3);                                \
-    t1 = stbi__fsh(p2 - p3);                                \
-    x0 = t0 + t3;                                           \
-    x3 = t0 - t3;                                           \
-    x1 = t1 + t2;                                           \
-    x2 = t1 - t2;                                           \
-    t0 = s7;                                                \
-    t1 = s5;                                                \
-    t2 = s3;                                                \
-    t3 = s1;                                                \
-    p3 = t0 + t2;                                           \
-    p4 = t1 + t3;                                           \
-    p1 = t0 + t3;                                           \
-    p2 = t1 + t2;                                           \
-    p5 = (p3 + p4) * stbi__f2f(1.175875602f);               \
-    t0 = t0 * stbi__f2f(0.298631336f);                      \
-    t1 = t1 * stbi__f2f(2.053119869f);                      \
-    t2 = t2 * stbi__f2f(3.072711026f);                      \
-    t3 = t3 * stbi__f2f(1.501321110f);                      \
-    p1 = p5 + p1 * stbi__f2f(-0.899976223f);                \
-    p2 = p5 + p2 * stbi__f2f(-2.562915447f);                \
-    p3 = p3 * stbi__f2f(-1.961570560f);                     \
-    p4 = p4 * stbi__f2f(-0.390180644f);                     \
-    t3 += p1 + p4;                                          \
-    t2 += p2 + p3;                                          \
-    t1 += p2 + p4;                                          \
+#define STBI__IDCT_1D(s0, s1, s2, s3, s4, s5, s6, s7)                                                                          \
+    int t0, t1, t2, t3, p1, p2, p3, p4, p5, x0, x1, x2, x3;                                                                    \
+    p2 = s2;                                                                                                                   \
+    p3 = s6;                                                                                                                   \
+    p1 = (p2 + p3) * stbi__f2f(0.5411961f);                                                                                    \
+    t2 = p1 + p3 * stbi__f2f(-1.847759065f);                                                                                   \
+    t3 = p1 + p2 * stbi__f2f(0.765366865f);                                                                                    \
+    p2 = s0;                                                                                                                   \
+    p3 = s4;                                                                                                                   \
+    t0 = stbi__fsh(p2 + p3);                                                                                                   \
+    t1 = stbi__fsh(p2 - p3);                                                                                                   \
+    x0 = t0 + t3;                                                                                                              \
+    x3 = t0 - t3;                                                                                                              \
+    x1 = t1 + t2;                                                                                                              \
+    x2 = t1 - t2;                                                                                                              \
+    t0 = s7;                                                                                                                   \
+    t1 = s5;                                                                                                                   \
+    t2 = s3;                                                                                                                   \
+    t3 = s1;                                                                                                                   \
+    p3 = t0 + t2;                                                                                                              \
+    p4 = t1 + t3;                                                                                                              \
+    p1 = t0 + t3;                                                                                                              \
+    p2 = t1 + t2;                                                                                                              \
+    p5 = (p3 + p4) * stbi__f2f(1.175875602f);                                                                                  \
+    t0 = t0 * stbi__f2f(0.298631336f);                                                                                         \
+    t1 = t1 * stbi__f2f(2.053119869f);                                                                                         \
+    t2 = t2 * stbi__f2f(3.072711026f);                                                                                         \
+    t3 = t3 * stbi__f2f(1.501321110f);                                                                                         \
+    p1 = p5 + p1 * stbi__f2f(-0.899976223f);                                                                                   \
+    p2 = p5 + p2 * stbi__f2f(-2.562915447f);                                                                                   \
+    p3 = p3 * stbi__f2f(-1.961570560f);                                                                                        \
+    p4 = p4 * stbi__f2f(-0.390180644f);                                                                                        \
+    t3 += p1 + p4;                                                                                                             \
+    t2 += p2 + p3;                                                                                                             \
+    t1 += p2 + p4;                                                                                                             \
     t0 += p1 + p3;
 
-static void stbi__idct_block(stbi_uc *out, int out_stride, short data[64])
-{
+static void stbi__idct_block(stbi_uc * out, int out_stride, short data[64]) {
     int i, val[64], *v = val;
-    stbi_uc *o;
-    short *d = data;
+    stbi_uc * o;
+    short * d = data;
 
     // columns
-    for (i = 0; i < 8; ++i, ++d, ++v)
-    {
+    for (i = 0; i < 8; ++i, ++d, ++v) {
         // if all zeroes, shortcut -- this avoids dequantizing 0s and IDCTing
-        if (d[8] == 0 && d[16] == 0 && d[24] == 0 && d[32] == 0 && d[40] == 0 && d[48] == 0 && d[56] == 0)
-        {
+        if (d[8] == 0 && d[16] == 0 && d[24] == 0 && d[32] == 0 && d[40] == 0 && d[48] == 0 && d[56] == 0) {
             //    no shortcut                 0     seconds
             //    (1|2|3|4|5|6|7)==0          0     seconds
             //    all separate               -0.047 seconds
             //    1 && 2|3 && 4|5 && 6|7:    -0.047 seconds
             int dcterm = d[0] * 4;
             v[0] = v[8] = v[16] = v[24] = v[32] = v[40] = v[48] = v[56] = dcterm;
-        }
-        else
-        {
+        } else {
             STBI__IDCT_1D(d[0], d[8], d[16], d[24], d[32], d[40], d[48], d[56])
             // constants scaled things up by 1<<12; let's bring them back
             // down, but keep 2 extra bits of precision
@@ -2762,8 +2546,7 @@ static void stbi__idct_block(stbi_uc *out, int out_stride, short data[64])
         }
     }
 
-    for (i = 0, v = val, o = out; i < 8; ++i, v += 8, o += out_stride)
-    {
+    for (i = 0, v = val, o = out; i < 8; ++i, v += 8, o += out_stride) {
         // no fast case since the first 1D IDCT spread components out
         STBI__IDCT_1D(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7])
         // constants scaled things up by 1<<12, plus we had 1<<2 from first
@@ -2793,8 +2576,7 @@ static void stbi__idct_block(stbi_uc *out, int out_stride, short data[64])
 // sse2 integer IDCT. not the fastest possible implementation but it
 // produces bit-identical results to the generic C version so it's
 // fully "transparent".
-static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
-{
+static void stbi__idct_simd(stbi_uc * out, int out_stride, short data[64]) {
     // This is constructed to match our regular (generic) integer IDCT exactly.
     __m128i row0, row1, row2, row3, row4, row5, row6, row7;
     __m128i tmp;
@@ -2804,78 +2586,78 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
 
 // out(0) = c0[even]*x + c0[odd]*y   (c0, x, y 16-bit, out 32-bit)
 // out(1) = c1[even]*x + c1[odd]*y
-#define dct_rot(out0, out1, x, y, c0, c1)          \
-    __m128i c0##lo = _mm_unpacklo_epi16((x), (y)); \
-    __m128i c0##hi = _mm_unpackhi_epi16((x), (y)); \
-    __m128i out0##_l = _mm_madd_epi16(c0##lo, c0); \
-    __m128i out0##_h = _mm_madd_epi16(c0##hi, c0); \
-    __m128i out1##_l = _mm_madd_epi16(c0##lo, c1); \
+#define dct_rot(out0, out1, x, y, c0, c1)                                                                                      \
+    __m128i c0##lo = _mm_unpacklo_epi16((x), (y));                                                                             \
+    __m128i c0##hi = _mm_unpackhi_epi16((x), (y));                                                                             \
+    __m128i out0##_l = _mm_madd_epi16(c0##lo, c0);                                                                             \
+    __m128i out0##_h = _mm_madd_epi16(c0##hi, c0);                                                                             \
+    __m128i out1##_l = _mm_madd_epi16(c0##lo, c1);                                                                             \
     __m128i out1##_h = _mm_madd_epi16(c0##hi, c1)
 
 // out = in << 12  (in 16-bit, out 32-bit)
-#define dct_widen(out, in)                                                              \
-    __m128i out##_l = _mm_srai_epi32(_mm_unpacklo_epi16(_mm_setzero_si128(), (in)), 4); \
+#define dct_widen(out, in)                                                                                                     \
+    __m128i out##_l = _mm_srai_epi32(_mm_unpacklo_epi16(_mm_setzero_si128(), (in)), 4);                                        \
     __m128i out##_h = _mm_srai_epi32(_mm_unpackhi_epi16(_mm_setzero_si128(), (in)), 4)
 
 // wide add
-#define dct_wadd(out, a, b)                        \
-    __m128i out##_l = _mm_add_epi32(a##_l, b##_l); \
+#define dct_wadd(out, a, b)                                                                                                    \
+    __m128i out##_l = _mm_add_epi32(a##_l, b##_l);                                                                             \
     __m128i out##_h = _mm_add_epi32(a##_h, b##_h)
 
 // wide sub
-#define dct_wsub(out, a, b)                        \
-    __m128i out##_l = _mm_sub_epi32(a##_l, b##_l); \
+#define dct_wsub(out, a, b)                                                                                                    \
+    __m128i out##_l = _mm_sub_epi32(a##_l, b##_l);                                                                             \
     __m128i out##_h = _mm_sub_epi32(a##_h, b##_h)
 
 // butterfly a/b, add bias, then shift by "s" and pack
-#define dct_bfly32o(out0, out1, a, b, bias, s)                                      \
-    {                                                                               \
-        __m128i abiased_l = _mm_add_epi32(a##_l, bias);                             \
-        __m128i abiased_h = _mm_add_epi32(a##_h, bias);                             \
-        dct_wadd(sum, abiased, b);                                                  \
-        dct_wsub(dif, abiased, b);                                                  \
-        out0 = _mm_packs_epi32(_mm_srai_epi32(sum_l, s), _mm_srai_epi32(sum_h, s)); \
-        out1 = _mm_packs_epi32(_mm_srai_epi32(dif_l, s), _mm_srai_epi32(dif_h, s)); \
+#define dct_bfly32o(out0, out1, a, b, bias, s)                                                                                 \
+    {                                                                                                                          \
+        __m128i abiased_l = _mm_add_epi32(a##_l, bias);                                                                        \
+        __m128i abiased_h = _mm_add_epi32(a##_h, bias);                                                                        \
+        dct_wadd(sum, abiased, b);                                                                                             \
+        dct_wsub(dif, abiased, b);                                                                                             \
+        out0 = _mm_packs_epi32(_mm_srai_epi32(sum_l, s), _mm_srai_epi32(sum_h, s));                                            \
+        out1 = _mm_packs_epi32(_mm_srai_epi32(dif_l, s), _mm_srai_epi32(dif_h, s));                                            \
     }
 
 // 8-bit interleave step (for transposes)
-#define dct_interleave8(a, b)    \
-    tmp = a;                     \
-    a = _mm_unpacklo_epi8(a, b); \
+#define dct_interleave8(a, b)                                                                                                  \
+    tmp = a;                                                                                                                   \
+    a = _mm_unpacklo_epi8(a, b);                                                                                               \
     b = _mm_unpackhi_epi8(tmp, b)
 
 // 16-bit interleave step (for transposes)
-#define dct_interleave16(a, b)    \
-    tmp = a;                      \
-    a = _mm_unpacklo_epi16(a, b); \
+#define dct_interleave16(a, b)                                                                                                 \
+    tmp = a;                                                                                                                   \
+    a = _mm_unpacklo_epi16(a, b);                                                                                              \
     b = _mm_unpackhi_epi16(tmp, b)
 
-#define dct_pass(bias, shift)                            \
-    {                                                    \
-        /* even part */                                  \
-        dct_rot(t2e, t3e, row2, row6, rot0_0, rot0_1);   \
-        __m128i sum04 = _mm_add_epi16(row0, row4);       \
-        __m128i dif04 = _mm_sub_epi16(row0, row4);       \
-        dct_widen(t0e, sum04);                           \
-        dct_widen(t1e, dif04);                           \
-        dct_wadd(x0, t0e, t3e);                          \
-        dct_wsub(x3, t0e, t3e);                          \
-        dct_wadd(x1, t1e, t2e);                          \
-        dct_wsub(x2, t1e, t2e);                          \
-        /* odd part */                                   \
-        dct_rot(y0o, y2o, row7, row3, rot2_0, rot2_1);   \
-        dct_rot(y1o, y3o, row5, row1, rot3_0, rot3_1);   \
-        __m128i sum17 = _mm_add_epi16(row1, row7);       \
-        __m128i sum35 = _mm_add_epi16(row3, row5);       \
-        dct_rot(y4o, y5o, sum17, sum35, rot1_0, rot1_1); \
-        dct_wadd(x4, y0o, y4o);                          \
-        dct_wadd(x5, y1o, y5o);                          \
-        dct_wadd(x6, y2o, y5o);                          \
-        dct_wadd(x7, y3o, y4o);                          \
-        dct_bfly32o(row0, row7, x0, x7, bias, shift);    \
-        dct_bfly32o(row1, row6, x1, x6, bias, shift);    \
-        dct_bfly32o(row2, row5, x2, x5, bias, shift);    \
-        dct_bfly32o(row3, row4, x3, x4, bias, shift);    \
+#define dct_pass(bias, shift)                                                                                                  \
+    {                                                                                                                          \
+        /* even part */                                                                                                        \
+        dct_rot(t2e, t3e, row2, row6, rot0_0, rot0_1);                                                                         \
+        __m128i sum04 = _mm_add_epi16(row0, row4);                                                                             \
+        __m128i dif04 = _mm_sub_epi16(row0, row4);                                                                             \
+        dct_widen(t0e, sum04);                                                                                                 \
+        dct_widen(t1e, dif04);                                                                                                 \
+        dct_wadd(x0, t0e, t3e);                                                                                                \
+        dct_wsub(x3, t0e, t3e);                                                                                                \
+        dct_wadd(x1, t1e, t2e);                                                                                                \
+        dct_wsub(x2, t1e, t2e);                                                                                                \
+        /* odd part */                                                                                                         \
+        dct_rot(y0o, y2o, row7, row3, rot2_0, rot2_1);                                                                         \
+        dct_rot(y1o, y3o, row5, row1, rot3_0, rot3_1);                                                                         \
+        __m128i sum17 = _mm_add_epi16(row1, row7);                                                                             \
+        __m128i sum35 = _mm_add_epi16(row3, row5);                                                                             \
+        dct_rot(y4o, y5o, sum17, sum35, rot1_0, rot1_1);                                                                       \
+        dct_wadd(x4, y0o, y4o);                                                                                                \
+        dct_wadd(x5, y1o, y5o);                                                                                                \
+        dct_wadd(x6, y2o, y5o);                                                                                                \
+        dct_wadd(x7, y3o, y4o);                                                                                                \
+        dct_bfly32o(row0, row7, x0, x7, bias, shift);                                                                          \
+        dct_bfly32o(row1, row6, x1, x6, bias, shift);                                                                          \
+        dct_bfly32o(row2, row5, x2, x5, bias, shift);                                                                          \
+        dct_bfly32o(row3, row4, x3, x4, bias, shift);                                                                          \
     }
 
     __m128i rot0_0 = dct_const(stbi__f2f(0.5411961f), stbi__f2f(0.5411961f) + stbi__f2f(-1.847759065f));
@@ -2981,8 +2763,7 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
 
 // NEON integer IDCT. should produce bit-identical
 // results to the generic C version.
-static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
-{
+static void stbi__idct_simd(stbi_uc * out, int out_stride, short data[64]) {
     int16x8_t row0, row1, row2, row3, row4, row5, row6, row7;
 
     int16x4_t rot0_0 = vdup_n_s16(stbi__f2f(0.5411961f));
@@ -2998,75 +2779,75 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
     int16x4_t rot3_2 = vdup_n_s16(stbi__f2f(3.072711026f));
     int16x4_t rot3_3 = vdup_n_s16(stbi__f2f(1.501321110f));
 
-#define dct_long_mul(out, inq, coeff)                        \
-    int32x4_t out##_l = vmull_s16(vget_low_s16(inq), coeff); \
+#define dct_long_mul(out, inq, coeff)                                                                                          \
+    int32x4_t out##_l = vmull_s16(vget_low_s16(inq), coeff);                                                                   \
     int32x4_t out##_h = vmull_s16(vget_high_s16(inq), coeff)
 
-#define dct_long_mac(out, acc, inq, coeff)                            \
-    int32x4_t out##_l = vmlal_s16(acc##_l, vget_low_s16(inq), coeff); \
+#define dct_long_mac(out, acc, inq, coeff)                                                                                     \
+    int32x4_t out##_l = vmlal_s16(acc##_l, vget_low_s16(inq), coeff);                                                          \
     int32x4_t out##_h = vmlal_s16(acc##_h, vget_high_s16(inq), coeff)
 
-#define dct_widen(out, inq)                                 \
-    int32x4_t out##_l = vshll_n_s16(vget_low_s16(inq), 12); \
+#define dct_widen(out, inq)                                                                                                    \
+    int32x4_t out##_l = vshll_n_s16(vget_low_s16(inq), 12);                                                                    \
     int32x4_t out##_h = vshll_n_s16(vget_high_s16(inq), 12)
 
 // wide add
-#define dct_wadd(out, a, b)                      \
-    int32x4_t out##_l = vaddq_s32(a##_l, b##_l); \
+#define dct_wadd(out, a, b)                                                                                                    \
+    int32x4_t out##_l = vaddq_s32(a##_l, b##_l);                                                                               \
     int32x4_t out##_h = vaddq_s32(a##_h, b##_h)
 
 // wide sub
-#define dct_wsub(out, a, b)                      \
-    int32x4_t out##_l = vsubq_s32(a##_l, b##_l); \
+#define dct_wsub(out, a, b)                                                                                                    \
+    int32x4_t out##_l = vsubq_s32(a##_l, b##_l);                                                                               \
     int32x4_t out##_h = vsubq_s32(a##_h, b##_h)
 
 // butterfly a/b, then shift using "shiftop" by "s" and pack
-#define dct_bfly32o(out0, out1, a, b, shiftop, s)                  \
-    {                                                              \
-        dct_wadd(sum, a, b);                                       \
-        dct_wsub(dif, a, b);                                       \
-        out0 = vcombine_s16(shiftop(sum_l, s), shiftop(sum_h, s)); \
-        out1 = vcombine_s16(shiftop(dif_l, s), shiftop(dif_h, s)); \
+#define dct_bfly32o(out0, out1, a, b, shiftop, s)                                                                              \
+    {                                                                                                                          \
+        dct_wadd(sum, a, b);                                                                                                   \
+        dct_wsub(dif, a, b);                                                                                                   \
+        out0 = vcombine_s16(shiftop(sum_l, s), shiftop(sum_h, s));                                                             \
+        out1 = vcombine_s16(shiftop(dif_l, s), shiftop(dif_h, s));                                                             \
     }
 
-#define dct_pass(shiftop, shift)                         \
-    {                                                    \
-        /* even part */                                  \
-        int16x8_t sum26 = vaddq_s16(row2, row6);         \
-        dct_long_mul(p1e, sum26, rot0_0);                \
-        dct_long_mac(t2e, p1e, row6, rot0_1);            \
-        dct_long_mac(t3e, p1e, row2, rot0_2);            \
-        int16x8_t sum04 = vaddq_s16(row0, row4);         \
-        int16x8_t dif04 = vsubq_s16(row0, row4);         \
-        dct_widen(t0e, sum04);                           \
-        dct_widen(t1e, dif04);                           \
-        dct_wadd(x0, t0e, t3e);                          \
-        dct_wsub(x3, t0e, t3e);                          \
-        dct_wadd(x1, t1e, t2e);                          \
-        dct_wsub(x2, t1e, t2e);                          \
-        /* odd part */                                   \
-        int16x8_t sum15 = vaddq_s16(row1, row5);         \
-        int16x8_t sum17 = vaddq_s16(row1, row7);         \
-        int16x8_t sum35 = vaddq_s16(row3, row5);         \
-        int16x8_t sum37 = vaddq_s16(row3, row7);         \
-        int16x8_t sumodd = vaddq_s16(sum17, sum35);      \
-        dct_long_mul(p5o, sumodd, rot1_0);               \
-        dct_long_mac(p1o, p5o, sum17, rot1_1);           \
-        dct_long_mac(p2o, p5o, sum35, rot1_2);           \
-        dct_long_mul(p3o, sum37, rot2_0);                \
-        dct_long_mul(p4o, sum15, rot2_1);                \
-        dct_wadd(sump13o, p1o, p3o);                     \
-        dct_wadd(sump24o, p2o, p4o);                     \
-        dct_wadd(sump23o, p2o, p3o);                     \
-        dct_wadd(sump14o, p1o, p4o);                     \
-        dct_long_mac(x4, sump13o, row7, rot3_0);         \
-        dct_long_mac(x5, sump24o, row5, rot3_1);         \
-        dct_long_mac(x6, sump23o, row3, rot3_2);         \
-        dct_long_mac(x7, sump14o, row1, rot3_3);         \
-        dct_bfly32o(row0, row7, x0, x7, shiftop, shift); \
-        dct_bfly32o(row1, row6, x1, x6, shiftop, shift); \
-        dct_bfly32o(row2, row5, x2, x5, shiftop, shift); \
-        dct_bfly32o(row3, row4, x3, x4, shiftop, shift); \
+#define dct_pass(shiftop, shift)                                                                                               \
+    {                                                                                                                          \
+        /* even part */                                                                                                        \
+        int16x8_t sum26 = vaddq_s16(row2, row6);                                                                               \
+        dct_long_mul(p1e, sum26, rot0_0);                                                                                      \
+        dct_long_mac(t2e, p1e, row6, rot0_1);                                                                                  \
+        dct_long_mac(t3e, p1e, row2, rot0_2);                                                                                  \
+        int16x8_t sum04 = vaddq_s16(row0, row4);                                                                               \
+        int16x8_t dif04 = vsubq_s16(row0, row4);                                                                               \
+        dct_widen(t0e, sum04);                                                                                                 \
+        dct_widen(t1e, dif04);                                                                                                 \
+        dct_wadd(x0, t0e, t3e);                                                                                                \
+        dct_wsub(x3, t0e, t3e);                                                                                                \
+        dct_wadd(x1, t1e, t2e);                                                                                                \
+        dct_wsub(x2, t1e, t2e);                                                                                                \
+        /* odd part */                                                                                                         \
+        int16x8_t sum15 = vaddq_s16(row1, row5);                                                                               \
+        int16x8_t sum17 = vaddq_s16(row1, row7);                                                                               \
+        int16x8_t sum35 = vaddq_s16(row3, row5);                                                                               \
+        int16x8_t sum37 = vaddq_s16(row3, row7);                                                                               \
+        int16x8_t sumodd = vaddq_s16(sum17, sum35);                                                                            \
+        dct_long_mul(p5o, sumodd, rot1_0);                                                                                     \
+        dct_long_mac(p1o, p5o, sum17, rot1_1);                                                                                 \
+        dct_long_mac(p2o, p5o, sum35, rot1_2);                                                                                 \
+        dct_long_mul(p3o, sum37, rot2_0);                                                                                      \
+        dct_long_mul(p4o, sum15, rot2_1);                                                                                      \
+        dct_wadd(sump13o, p1o, p3o);                                                                                           \
+        dct_wadd(sump24o, p2o, p4o);                                                                                           \
+        dct_wadd(sump23o, p2o, p3o);                                                                                           \
+        dct_wadd(sump14o, p1o, p4o);                                                                                           \
+        dct_long_mac(x4, sump13o, row7, rot3_0);                                                                               \
+        dct_long_mac(x5, sump24o, row5, rot3_1);                                                                               \
+        dct_long_mac(x6, sump23o, row3, rot3_2);                                                                               \
+        dct_long_mac(x7, sump14o, row1, rot3_3);                                                                               \
+        dct_bfly32o(row0, row7, x0, x7, shiftop, shift);                                                                       \
+        dct_bfly32o(row1, row6, x1, x6, shiftop, shift);                                                                       \
+        dct_bfly32o(row2, row5, x2, x5, shiftop, shift);                                                                       \
+        dct_bfly32o(row3, row4, x3, x4, shiftop, shift);                                                                       \
     }
 
     // load
@@ -3089,24 +2870,24 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
     {
 // these three map to a single VTRN.16, VTRN.32, and VSWP, respectively.
 // whether compilers actually get this is another story, sadly.
-#define dct_trn16(x, y)                  \
-    {                                    \
-        int16x8x2_t t = vtrnq_s16(x, y); \
-        x = t.val[0];                    \
-        y = t.val[1];                    \
+#define dct_trn16(x, y)                                                                                                        \
+    {                                                                                                                          \
+        int16x8x2_t t = vtrnq_s16(x, y);                                                                                       \
+        x = t.val[0];                                                                                                          \
+        y = t.val[1];                                                                                                          \
     }
-#define dct_trn32(x, y)                                                                \
-    {                                                                                  \
-        int32x4x2_t t = vtrnq_s32(vreinterpretq_s32_s16(x), vreinterpretq_s32_s16(y)); \
-        x = vreinterpretq_s16_s32(t.val[0]);                                           \
-        y = vreinterpretq_s16_s32(t.val[1]);                                           \
+#define dct_trn32(x, y)                                                                                                        \
+    {                                                                                                                          \
+        int32x4x2_t t = vtrnq_s32(vreinterpretq_s32_s16(x), vreinterpretq_s32_s16(y));                                         \
+        x = vreinterpretq_s16_s32(t.val[0]);                                                                                   \
+        y = vreinterpretq_s16_s32(t.val[1]);                                                                                   \
     }
-#define dct_trn64(x, y)                                         \
-    {                                                           \
-        int16x8_t x0 = x;                                       \
-        int16x8_t y0 = y;                                       \
-        x = vcombine_s16(vget_low_s16(x0), vget_low_s16(y0));   \
-        y = vcombine_s16(vget_high_s16(x0), vget_high_s16(y0)); \
+#define dct_trn64(x, y)                                                                                                        \
+    {                                                                                                                          \
+        int16x8_t x0 = x;                                                                                                      \
+        int16x8_t y0 = y;                                                                                                      \
+        x = vcombine_s16(vget_low_s16(x0), vget_low_s16(y0));                                                                  \
+        y = vcombine_s16(vget_high_s16(x0), vget_high_s16(y0));                                                                \
     }
 
         // pass 1
@@ -3150,23 +2931,23 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
         uint8x8_t p7 = vqrshrun_n_s16(row7, 1);
 
         // again, these can translate into one instruction, but often don't.
-#define dct_trn8_8(x, y)               \
-    {                                  \
-        uint8x8x2_t t = vtrn_u8(x, y); \
-        x = t.val[0];                  \
-        y = t.val[1];                  \
+#define dct_trn8_8(x, y)                                                                                                       \
+    {                                                                                                                          \
+        uint8x8x2_t t = vtrn_u8(x, y);                                                                                         \
+        x = t.val[0];                                                                                                          \
+        y = t.val[1];                                                                                                          \
     }
-#define dct_trn8_16(x, y)                                                          \
-    {                                                                              \
-        uint16x4x2_t t = vtrn_u16(vreinterpret_u16_u8(x), vreinterpret_u16_u8(y)); \
-        x = vreinterpret_u8_u16(t.val[0]);                                         \
-        y = vreinterpret_u8_u16(t.val[1]);                                         \
+#define dct_trn8_16(x, y)                                                                                                      \
+    {                                                                                                                          \
+        uint16x4x2_t t = vtrn_u16(vreinterpret_u16_u8(x), vreinterpret_u16_u8(y));                                             \
+        x = vreinterpret_u8_u16(t.val[0]);                                                                                     \
+        y = vreinterpret_u8_u16(t.val[1]);                                                                                     \
     }
-#define dct_trn8_32(x, y)                                                          \
-    {                                                                              \
-        uint32x2x2_t t = vtrn_u32(vreinterpret_u32_u8(x), vreinterpret_u32_u8(y)); \
-        x = vreinterpret_u8_u32(t.val[0]);                                         \
-        y = vreinterpret_u8_u32(t.val[1]);                                         \
+#define dct_trn8_32(x, y)                                                                                                      \
+    {                                                                                                                          \
+        uint32x2x2_t t = vtrn_u32(vreinterpret_u32_u8(x), vreinterpret_u32_u8(y));                                             \
+        x = vreinterpret_u8_u32(t.val[0]);                                                                                     \
+        y = vreinterpret_u8_u32(t.val[1]);                                                                                     \
     }
 
         // sadly can't use interleaved stores here since we only write
@@ -3227,11 +3008,9 @@ static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
 // if there's a pending marker from the entropy stream, return that
 // otherwise, fetch from the stream and get a marker. if there's no
 // marker, return 0xff, which is never a valid marker value
-static stbi_uc stbi__get_marker(stbi__jpeg *j)
-{
+static stbi_uc stbi__get_marker(stbi__jpeg * j) {
     stbi_uc x;
-    if (j->marker != STBI__MARKER_none)
-    {
+    if (j->marker != STBI__MARKER_none) {
         x = j->marker;
         j->marker = STBI__MARKER_none;
         return x;
@@ -3250,8 +3029,7 @@ static stbi_uc stbi__get_marker(stbi__jpeg *j)
 
 // after a restart interval, stbi__jpeg_reset the entropy decoder and
 // the dc prediction
-static void stbi__jpeg_reset(stbi__jpeg *j)
-{
+static void stbi__jpeg_reset(stbi__jpeg * j) {
     j->code_bits = 0;
     j->code_buffer = 0;
     j->nomore = 0;
@@ -3263,13 +3041,10 @@ static void stbi__jpeg_reset(stbi__jpeg *j)
     // since we don't even allow 1<<30 pixels
 }
 
-static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
-{
+static int stbi__parse_entropy_coded_data(stbi__jpeg * z) {
     stbi__jpeg_reset(z);
-    if (!z->progressive)
-    {
-        if (z->scan_n == 1)
-        {
+    if (!z->progressive) {
+        if (z->scan_n == 1) {
             int i, j;
             STBI_SIMD_ALIGN(short, data[64]);
             int n = z->order[0];
@@ -3279,17 +3054,15 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
             // component has, independent of interleaved MCU blocking and such
             int w = (z->img_comp[n].x + 7) >> 3;
             int h = (z->img_comp[n].y + 7) >> 3;
-            for (j = 0; j < h; ++j)
-            {
-                for (i = 0; i < w; ++i)
-                {
+            for (j = 0; j < h; ++j) {
+                for (i = 0; i < w; ++i) {
                     int ha = z->img_comp[n].ha;
-                    if (!stbi__jpeg_decode_block(z, data, z->huff_dc + z->img_comp[n].hd, z->huff_ac + ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq]))
+                    if (!stbi__jpeg_decode_block(z, data, z->huff_dc + z->img_comp[n].hd, z->huff_ac + ha, z->fast_ac[ha], n,
+                                                 z->dequant[z->img_comp[n].tq]))
                         return 0;
                     z->idct_block_kernel(z->img_comp[n].data + z->img_comp[n].w2 * j * 8 + i * 8, z->img_comp[n].w2, data);
                     // every data block is an MCU, so countdown the restart interval
-                    if (--z->todo <= 0)
-                    {
+                    if (--z->todo <= 0) {
                         if (z->code_bits < 24)
                             stbi__grow_buffer_unsafe(z);
                         // if it's NOT a restart, then just bail, so we get corrupt data
@@ -3301,38 +3074,32 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
                 }
             }
             return 1;
-        }
-        else
-        { // interleaved
+        } else { // interleaved
             int i, j, k, x, y;
             STBI_SIMD_ALIGN(short, data[64]);
-            for (j = 0; j < z->img_mcu_y; ++j)
-            {
-                for (i = 0; i < z->img_mcu_x; ++i)
-                {
+            for (j = 0; j < z->img_mcu_y; ++j) {
+                for (i = 0; i < z->img_mcu_x; ++i) {
                     // scan an interleaved mcu... process scan_n components in order
-                    for (k = 0; k < z->scan_n; ++k)
-                    {
+                    for (k = 0; k < z->scan_n; ++k) {
                         int n = z->order[k];
                         // scan out an mcu's worth of this component; that's just determined
                         // by the basic H and V specified for the component
-                        for (y = 0; y < z->img_comp[n].v; ++y)
-                        {
-                            for (x = 0; x < z->img_comp[n].h; ++x)
-                            {
+                        for (y = 0; y < z->img_comp[n].v; ++y) {
+                            for (x = 0; x < z->img_comp[n].h; ++x) {
                                 int x2 = (i * z->img_comp[n].h + x) * 8;
                                 int y2 = (j * z->img_comp[n].v + y) * 8;
                                 int ha = z->img_comp[n].ha;
-                                if (!stbi__jpeg_decode_block(z, data, z->huff_dc + z->img_comp[n].hd, z->huff_ac + ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq]))
+                                if (!stbi__jpeg_decode_block(z, data, z->huff_dc + z->img_comp[n].hd, z->huff_ac + ha,
+                                                             z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq]))
                                     return 0;
-                                z->idct_block_kernel(z->img_comp[n].data + z->img_comp[n].w2 * y2 + x2, z->img_comp[n].w2, data);
+                                z->idct_block_kernel(z->img_comp[n].data + z->img_comp[n].w2 * y2 + x2, z->img_comp[n].w2,
+                                                     data);
                             }
                         }
                     }
                     // after all interleaved components, that's an interleaved MCU,
                     // so now count down the restart interval
-                    if (--z->todo <= 0)
-                    {
+                    if (--z->todo <= 0) {
                         if (z->code_bits < 24)
                             stbi__grow_buffer_unsafe(z);
                         if (!STBI__RESTART(z->marker))
@@ -3343,11 +3110,8 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
             }
             return 1;
         }
-    }
-    else
-    {
-        if (z->scan_n == 1)
-        {
+    } else {
+        if (z->scan_n == 1) {
             int i, j;
             int n = z->order[0];
             // non-interleaved data, we just need to process one block at a time,
@@ -3356,25 +3120,19 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
             // component has, independent of interleaved MCU blocking and such
             int w = (z->img_comp[n].x + 7) >> 3;
             int h = (z->img_comp[n].y + 7) >> 3;
-            for (j = 0; j < h; ++j)
-            {
-                for (i = 0; i < w; ++i)
-                {
-                    short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
-                    if (z->spec_start == 0)
-                    {
+            for (j = 0; j < h; ++j) {
+                for (i = 0; i < w; ++i) {
+                    short * data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
+                    if (z->spec_start == 0) {
                         if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
                             return 0;
-                    }
-                    else
-                    {
+                    } else {
                         int ha = z->img_comp[n].ha;
                         if (!stbi__jpeg_decode_block_prog_ac(z, data, &z->huff_ac[ha], z->fast_ac[ha]))
                             return 0;
                     }
                     // every data block is an MCU, so countdown the restart interval
-                    if (--z->todo <= 0)
-                    {
+                    if (--z->todo <= 0) {
                         if (z->code_bits < 24)
                             stbi__grow_buffer_unsafe(z);
                         if (!STBI__RESTART(z->marker))
@@ -3384,27 +3142,20 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
                 }
             }
             return 1;
-        }
-        else
-        { // interleaved
+        } else { // interleaved
             int i, j, k, x, y;
-            for (j = 0; j < z->img_mcu_y; ++j)
-            {
-                for (i = 0; i < z->img_mcu_x; ++i)
-                {
+            for (j = 0; j < z->img_mcu_y; ++j) {
+                for (i = 0; i < z->img_mcu_x; ++i) {
                     // scan an interleaved mcu... process scan_n components in order
-                    for (k = 0; k < z->scan_n; ++k)
-                    {
+                    for (k = 0; k < z->scan_n; ++k) {
                         int n = z->order[k];
                         // scan out an mcu's worth of this component; that's just determined
                         // by the basic H and V specified for the component
-                        for (y = 0; y < z->img_comp[n].v; ++y)
-                        {
-                            for (x = 0; x < z->img_comp[n].h; ++x)
-                            {
+                        for (y = 0; y < z->img_comp[n].v; ++y) {
+                            for (x = 0; x < z->img_comp[n].h; ++x) {
                                 int x2 = (i * z->img_comp[n].h + x);
                                 int y2 = (j * z->img_comp[n].v + y);
-                                short *data = z->img_comp[n].coeff + 64 * (x2 + y2 * z->img_comp[n].coeff_w);
+                                short * data = z->img_comp[n].coeff + 64 * (x2 + y2 * z->img_comp[n].coeff_w);
                                 if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
                                     return 0;
                             }
@@ -3412,8 +3163,7 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
                     }
                     // after all interleaved components, that's an interleaved MCU,
                     // so now count down the restart interval
-                    if (--z->todo <= 0)
-                    {
+                    if (--z->todo <= 0) {
                         if (z->code_bits < 24)
                             stbi__grow_buffer_unsafe(z);
                         if (!STBI__RESTART(z->marker))
@@ -3427,28 +3177,22 @@ static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
     }
 }
 
-static void stbi__jpeg_dequantize(short *data, stbi__uint16 *dequant)
-{
+static void stbi__jpeg_dequantize(short * data, stbi__uint16 * dequant) {
     int i;
     for (i = 0; i < 64; ++i)
         data[i] *= dequant[i];
 }
 
-static void stbi__jpeg_finish(stbi__jpeg *z)
-{
-    if (z->progressive)
-    {
+static void stbi__jpeg_finish(stbi__jpeg * z) {
+    if (z->progressive) {
         // dequantize and idct the data
         int i, j, n;
-        for (n = 0; n < z->s->img_n; ++n)
-        {
+        for (n = 0; n < z->s->img_n; ++n) {
             int w = (z->img_comp[n].x + 7) >> 3;
             int h = (z->img_comp[n].y + 7) >> 3;
-            for (j = 0; j < h; ++j)
-            {
-                for (i = 0; i < w; ++i)
-                {
-                    short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
+            for (j = 0; j < h; ++j) {
+                for (i = 0; i < w; ++i) {
+                    short * data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
                     stbi__jpeg_dequantize(data, z->dequant[z->img_comp[n].tq]);
                     z->idct_block_kernel(z->img_comp[n].data + z->img_comp[n].w2 * j * 8 + i * 8, z->img_comp[n].w2, data);
                 }
@@ -3457,11 +3201,9 @@ static void stbi__jpeg_finish(stbi__jpeg *z)
     }
 }
 
-static int stbi__process_marker(stbi__jpeg *z, int m)
-{
+static int stbi__process_marker(stbi__jpeg * z, int m) {
     int L;
-    switch (m)
-    {
+    switch (m) {
     case STBI__MARKER_none: // no marker found
         return stbi__err("expected marker", "Corrupt JPEG");
 
@@ -3473,8 +3215,7 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
 
     case 0xDB: // DQT - define quantization table
         L = stbi__get16be(z->s) - 2;
-        while (L > 0)
-        {
+        while (L > 0) {
             int q = stbi__get8(z->s);
             int p = q >> 4, sixteen = (p != 0);
             int t = q & 15, i;
@@ -3491,31 +3232,26 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
 
     case 0xC4: // DHT - define huffman table
         L = stbi__get16be(z->s) - 2;
-        while (L > 0)
-        {
-            stbi_uc *v;
+        while (L > 0) {
+            stbi_uc * v;
             int sizes[16], i, n = 0;
             int q = stbi__get8(z->s);
             int tc = q >> 4;
             int th = q & 15;
             if (tc > 1 || th > 3)
                 return stbi__err("bad DHT header", "Corrupt JPEG");
-            for (i = 0; i < 16; ++i)
-            {
+            for (i = 0; i < 16; ++i) {
                 sizes[i] = stbi__get8(z->s);
                 n += sizes[i];
             }
             if (n > 256)
                 return stbi__err("bad DHT header", "Corrupt JPEG"); // Loop over i < n would write past end of values!
             L -= 17;
-            if (tc == 0)
-            {
+            if (tc == 0) {
                 if (!stbi__build_huffman(z->huff_dc + th, sizes))
                     return 0;
                 v = z->huff_dc[th].values;
-            }
-            else
-            {
+            } else {
                 if (!stbi__build_huffman(z->huff_ac + th, sizes))
                     return 0;
                 v = z->huff_ac[th].values;
@@ -3530,11 +3266,9 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
     }
 
     // check for comment block or APP blocks
-    if ((m >= 0xE0 && m <= 0xEF) || m == 0xFE)
-    {
+    if ((m >= 0xE0 && m <= 0xEF) || m == 0xFE) {
         L = stbi__get16be(z->s);
-        if (L < 2)
-        {
+        if (L < 2) {
             if (m == 0xFE)
                 return stbi__err("bad COM len", "Corrupt JPEG");
             else
@@ -3542,8 +3276,7 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
         }
         L -= 2;
 
-        if (m == 0xE0 && L >= 5)
-        { // JFIF APP0 segment
+        if (m == 0xE0 && L >= 5) { // JFIF APP0 segment
             static const unsigned char tag[5] = {'J', 'F', 'I', 'F', '\0'};
             int ok = 1;
             int i;
@@ -3553,9 +3286,7 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
             L -= 5;
             if (ok)
                 z->jfif = 1;
-        }
-        else if (m == 0xEE && L >= 12)
-        { // Adobe APP14 segment
+        } else if (m == 0xEE && L >= 12) { // Adobe APP14 segment
             static const unsigned char tag[6] = {'A', 'd', 'o', 'b', 'e', '\0'};
             int ok = 1;
             int i;
@@ -3563,8 +3294,7 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
                 if (stbi__get8(z->s) != tag[i])
                     ok = 0;
             L -= 6;
-            if (ok)
-            {
+            if (ok) {
                 stbi__get8(z->s);                            // version
                 stbi__get16be(z->s);                         // flags0
                 stbi__get16be(z->s);                         // flags1
@@ -3581,8 +3311,7 @@ static int stbi__process_marker(stbi__jpeg *z, int m)
 }
 
 // after we see SOS
-static int stbi__process_scan_header(stbi__jpeg *z)
-{
+static int stbi__process_scan_header(stbi__jpeg * z) {
     int i;
     int Ls = stbi__get16be(z->s);
     z->scan_n = stbi__get8(z->s);
@@ -3590,8 +3319,7 @@ static int stbi__process_scan_header(stbi__jpeg *z)
         return stbi__err("bad SOS component count", "Corrupt JPEG");
     if (Ls != 6 + 2 * z->scan_n)
         return stbi__err("bad SOS len", "Corrupt JPEG");
-    for (i = 0; i < z->scan_n; ++i)
-    {
+    for (i = 0; i < z->scan_n; ++i) {
         int id = stbi__get8(z->s), which;
         int q = stbi__get8(z->s);
         for (which = 0; which < z->s->img_n; ++which)
@@ -3615,13 +3343,10 @@ static int stbi__process_scan_header(stbi__jpeg *z)
         aa = stbi__get8(z->s);
         z->succ_high = (aa >> 4);
         z->succ_low = (aa & 15);
-        if (z->progressive)
-        {
+        if (z->progressive) {
             if (z->spec_start > 63 || z->spec_end > 63 || z->spec_start > z->spec_end || z->succ_high > 13 || z->succ_low > 13)
                 return stbi__err("bad SOS", "Corrupt JPEG");
-        }
-        else
-        {
+        } else {
             if (z->spec_start != 0)
                 return stbi__err("bad SOS", "Corrupt JPEG");
             if (z->succ_high != 0 || z->succ_low != 0)
@@ -3633,25 +3358,20 @@ static int stbi__process_scan_header(stbi__jpeg *z)
     return 1;
 }
 
-static int stbi__free_jpeg_components(stbi__jpeg *z, int ncomp, int why)
-{
+static int stbi__free_jpeg_components(stbi__jpeg * z, int ncomp, int why) {
     int i;
-    for (i = 0; i < ncomp; ++i)
-    {
-        if (z->img_comp[i].raw_data)
-        {
+    for (i = 0; i < ncomp; ++i) {
+        if (z->img_comp[i].raw_data) {
             STBI_FREE(z->img_comp[i].raw_data);
             z->img_comp[i].raw_data = NULL;
             z->img_comp[i].data = NULL;
         }
-        if (z->img_comp[i].raw_coeff)
-        {
+        if (z->img_comp[i].raw_coeff) {
             STBI_FREE(z->img_comp[i].raw_coeff);
             z->img_comp[i].raw_coeff = 0;
             z->img_comp[i].coeff = 0;
         }
-        if (z->img_comp[i].linebuf)
-        {
+        if (z->img_comp[i].linebuf) {
             STBI_FREE(z->img_comp[i].linebuf);
             z->img_comp[i].linebuf = NULL;
         }
@@ -3659,9 +3379,8 @@ static int stbi__free_jpeg_components(stbi__jpeg *z, int ncomp, int why)
     return why;
 }
 
-static int stbi__process_frame_header(stbi__jpeg *z, int scan)
-{
-    stbi__context *s = z->s;
+static int stbi__process_frame_header(stbi__jpeg * z, int scan) {
+    stbi__context * s = z->s;
     int Lf, p, i, q, h_max = 1, v_max = 1, c;
     Lf = stbi__get16be(s);
     if (Lf < 11)
@@ -3671,7 +3390,8 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
         return stbi__err("only 8-bit", "JPEG format not supported: 8-bit only"); // JPEG baseline
     s->img_y = stbi__get16be(s);
     if (s->img_y == 0)
-        return stbi__err("no header height", "JPEG format not supported: delayed height"); // Legal, but we don't handle it--but neither does IJG
+        return stbi__err("no header height",
+                         "JPEG format not supported: delayed height"); // Legal, but we don't handle it--but neither does IJG
     s->img_x = stbi__get16be(s);
     if (s->img_x == 0)
         return stbi__err("0 width", "Corrupt JPEG"); // JPEG requires
@@ -3683,8 +3403,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
     if (c != 3 && c != 1 && c != 4)
         return stbi__err("bad component count", "Corrupt JPEG");
     s->img_n = c;
-    for (i = 0; i < c; ++i)
-    {
+    for (i = 0; i < c; ++i) {
         z->img_comp[i].data = NULL;
         z->img_comp[i].linebuf = NULL;
     }
@@ -3693,8 +3412,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
         return stbi__err("bad SOF len", "Corrupt JPEG");
 
     z->rgb = 0;
-    for (i = 0; i < s->img_n; ++i)
-    {
+    for (i = 0; i < s->img_n; ++i) {
         static const unsigned char rgb[3] = {'R', 'G', 'B'};
         z->img_comp[i].id = stbi__get8(s);
         if (s->img_n == 3 && z->img_comp[i].id == rgb[i])
@@ -3717,8 +3435,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
     if (!stbi__mad3sizes_valid(s->img_x, s->img_y, s->img_n, 0))
         return stbi__err("too large", "Image too large to decode");
 
-    for (i = 0; i < s->img_n; ++i)
-    {
+    for (i = 0; i < s->img_n; ++i) {
         if (z->img_comp[i].h > h_max)
             h_max = z->img_comp[i].h;
         if (z->img_comp[i].v > v_max)
@@ -3727,8 +3444,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 
     // check that plane subsampling factors are integer ratios; our resamplers can't deal with fractional ratios
     // and I've never seen a non-corrupted JPEG file actually use them
-    for (i = 0; i < s->img_n; ++i)
-    {
+    for (i = 0; i < s->img_n; ++i) {
         if (h_max % z->img_comp[i].h != 0)
             return stbi__err("bad H", "Corrupt JPEG");
         if (v_max % z->img_comp[i].v != 0)
@@ -3744,8 +3460,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
     z->img_mcu_x = (s->img_x + z->img_mcu_w - 1) / z->img_mcu_w;
     z->img_mcu_y = (s->img_y + z->img_mcu_h - 1) / z->img_mcu_h;
 
-    for (i = 0; i < s->img_n; ++i)
-    {
+    for (i = 0; i < s->img_n; ++i) {
         // number of effective pixels (e.g. for non-interleaved MCU)
         z->img_comp[i].x = (s->img_x * z->img_comp[i].h + h_max - 1) / h_max;
         z->img_comp[i].y = (s->img_y * z->img_comp[i].v + v_max - 1) / v_max;
@@ -3766,8 +3481,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
             return stbi__free_jpeg_components(z, i + 1, stbi__err("outofmem", "Out of memory"));
         // align blocks for idct using mmx/sse
         z->img_comp[i].data = (stbi_uc *)(((size_t)z->img_comp[i].raw_data + 15) & ~15);
-        if (z->progressive)
-        {
+        if (z->progressive) {
             // w2, h2 are multiples of 8 (see above)
             z->img_comp[i].coeff_w = z->img_comp[i].w2 / 8;
             z->img_comp[i].coeff_h = z->img_comp[i].h2 / 8;
@@ -3790,8 +3504,7 @@ static int stbi__process_frame_header(stbi__jpeg *z, int scan)
 
 #define stbi__SOF_progressive(x) ((x) == 0xc2)
 
-static int stbi__decode_jpeg_header(stbi__jpeg *z, int scan)
-{
+static int stbi__decode_jpeg_header(stbi__jpeg * z, int scan) {
     int m;
     z->jfif = 0;
     z->app14_color_transform = -1; // valid values are 0,1,2
@@ -3802,13 +3515,11 @@ static int stbi__decode_jpeg_header(stbi__jpeg *z, int scan)
     if (scan == STBI__SCAN_type)
         return 1;
     m = stbi__get_marker(z);
-    while (!stbi__SOF(m))
-    {
+    while (!stbi__SOF(m)) {
         if (!stbi__process_marker(z, m))
             return 0;
         m = stbi__get_marker(z);
-        while (m == STBI__MARKER_none)
-        {
+        while (m == STBI__MARKER_none) {
             // some files have extra padding after their blocks, so ok, we'll scan
             if (stbi__at_eof(z->s))
                 return stbi__err("no SOF", "Corrupt JPEG");
@@ -3821,20 +3532,16 @@ static int stbi__decode_jpeg_header(stbi__jpeg *z, int scan)
     return 1;
 }
 
-static int stbi__skip_jpeg_junk_at_end(stbi__jpeg *j)
-{
+static int stbi__skip_jpeg_junk_at_end(stbi__jpeg * j) {
     // some JPEGs have junk at end, skip over it but if we find what looks
     // like a valid marker, resume there
-    while (!stbi__at_eof(j->s))
-    {
+    while (!stbi__at_eof(j->s)) {
         int x = stbi__get8(j->s);
-        while (x == 255)
-        { // might be a marker
+        while (x == 255) { // might be a marker
             if (stbi__at_eof(j->s))
                 return STBI__MARKER_none;
             x = stbi__get8(j->s);
-            if (x != 0x00 && x != 0xff)
-            {
+            if (x != 0x00 && x != 0xff) {
                 // not a stuffed zero or lead-in to another marker, looks
                 // like an actual marker, return it
                 return x;
@@ -3848,11 +3555,9 @@ static int stbi__skip_jpeg_junk_at_end(stbi__jpeg *j)
 }
 
 // decode image to YCbCr format
-static int stbi__decode_jpeg_image(stbi__jpeg *j)
-{
+static int stbi__decode_jpeg_image(stbi__jpeg * j) {
     int m;
-    for (m = 0; m < 4; m++)
-    {
+    for (m = 0; m < 4; m++) {
         j->img_comp[m].raw_data = NULL;
         j->img_comp[m].raw_coeff = NULL;
     }
@@ -3860,25 +3565,20 @@ static int stbi__decode_jpeg_image(stbi__jpeg *j)
     if (!stbi__decode_jpeg_header(j, STBI__SCAN_load))
         return 0;
     m = stbi__get_marker(j);
-    while (!stbi__EOI(m))
-    {
-        if (stbi__SOS(m))
-        {
+    while (!stbi__EOI(m)) {
+        if (stbi__SOS(m)) {
             if (!stbi__process_scan_header(j))
                 return 0;
             if (!stbi__parse_entropy_coded_data(j))
                 return 0;
-            if (j->marker == STBI__MARKER_none)
-            {
+            if (j->marker == STBI__MARKER_none) {
                 j->marker = stbi__skip_jpeg_junk_at_end(j);
                 // if we reach eof without hitting a marker, stbi__get_marker() below will fail and we'll eventually return 0
             }
             m = stbi__get_marker(j);
             if (STBI__RESTART(m))
                 m = stbi__get_marker(j);
-        }
-        else if (stbi__DNL(m))
-        {
+        } else if (stbi__DNL(m)) {
             int Ld = stbi__get16be(j->s);
             stbi__uint32 NL = stbi__get16be(j->s);
             if (Ld != 4)
@@ -3886,9 +3586,7 @@ static int stbi__decode_jpeg_image(stbi__jpeg *j)
             if (NL != j->s->img_y)
                 return stbi__err("bad DNL height", "Corrupt JPEG");
             m = stbi__get_marker(j);
-        }
-        else
-        {
+        } else {
             if (!stbi__process_marker(j, m))
                 return 1;
             m = stbi__get_marker(j);
@@ -3901,13 +3599,11 @@ static int stbi__decode_jpeg_image(stbi__jpeg *j)
 
 // static jfif-centered resampling (across block boundaries)
 
-typedef stbi_uc *(*resample_row_func)(stbi_uc *out, stbi_uc *in0, stbi_uc *in1,
-                                      int w, int hs);
+typedef stbi_uc * (*resample_row_func)(stbi_uc * out, stbi_uc * in0, stbi_uc * in1, int w, int hs);
 
 #define stbi__div4(x) ((stbi_uc)((x) >> 2))
 
-static stbi_uc *resample_row_1(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
-{
+static stbi_uc * resample_row_1(stbi_uc * out, stbi_uc * in_near, stbi_uc * in_far, int w, int hs) {
     STBI_NOTUSED(out);
     STBI_NOTUSED(in_far);
     STBI_NOTUSED(w);
@@ -3915,8 +3611,7 @@ static stbi_uc *resample_row_1(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, 
     return in_near;
 }
 
-static stbi_uc *stbi__resample_row_v_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
-{
+static stbi_uc * stbi__resample_row_v_2(stbi_uc * out, stbi_uc * in_near, stbi_uc * in_far, int w, int hs) {
     // need to generate two samples vertically for every one in input
     int i;
     STBI_NOTUSED(hs);
@@ -3925,14 +3620,12 @@ static stbi_uc *stbi__resample_row_v_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *
     return out;
 }
 
-static stbi_uc *stbi__resample_row_h_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
-{
+static stbi_uc * stbi__resample_row_h_2(stbi_uc * out, stbi_uc * in_near, stbi_uc * in_far, int w, int hs) {
     // need to generate two samples horizontally for every one in input
     int i;
-    stbi_uc *input = in_near;
+    stbi_uc * input = in_near;
 
-    if (w == 1)
-    {
+    if (w == 1) {
         // if only one sample, can't do any interpolation
         out[0] = out[1] = input[0];
         return out;
@@ -3940,8 +3633,7 @@ static stbi_uc *stbi__resample_row_h_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *
 
     out[0] = input[0];
     out[1] = stbi__div4(input[0] * 3 + input[1] + 2);
-    for (i = 1; i < w - 1; ++i)
-    {
+    for (i = 1; i < w - 1; ++i) {
         int n = 3 * input[i] + 2;
         out[i * 2 + 0] = stbi__div4(n + input[i - 1]);
         out[i * 2 + 1] = stbi__div4(n + input[i + 1]);
@@ -3957,20 +3649,17 @@ static stbi_uc *stbi__resample_row_h_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *
 
 #define stbi__div16(x) ((stbi_uc)((x) >> 4))
 
-static stbi_uc *stbi__resample_row_hv_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
-{
+static stbi_uc * stbi__resample_row_hv_2(stbi_uc * out, stbi_uc * in_near, stbi_uc * in_far, int w, int hs) {
     // need to generate 2x2 samples for every one in input
     int i, t0, t1;
-    if (w == 1)
-    {
+    if (w == 1) {
         out[0] = out[1] = stbi__div4(3 * in_near[0] + in_far[0] + 2);
         return out;
     }
 
     t1 = 3 * in_near[0] + in_far[0];
     out[0] = stbi__div4(t1 + 2);
-    for (i = 1; i < w; ++i)
-    {
+    for (i = 1; i < w; ++i) {
         t0 = t1;
         t1 = 3 * in_near[i] + in_far[i];
         out[i * 2 - 1] = stbi__div16(3 * t0 + t1 + 8);
@@ -3984,13 +3673,11 @@ static stbi_uc *stbi__resample_row_hv_2(stbi_uc *out, stbi_uc *in_near, stbi_uc 
 }
 
 #if defined(STBI_SSE2) || defined(STBI_NEON)
-static stbi_uc *stbi__resample_row_hv_2_simd(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
-{
+static stbi_uc * stbi__resample_row_hv_2_simd(stbi_uc * out, stbi_uc * in_near, stbi_uc * in_far, int w, int hs) {
     // need to generate 2x2 samples for every one in input
     int i = 0, t0, t1;
 
-    if (w == 1)
-    {
+    if (w == 1) {
         out[0] = out[1] = stbi__div4(3 * in_near[0] + in_far[0] + 2);
         return out;
     }
@@ -3999,8 +3686,7 @@ static stbi_uc *stbi__resample_row_hv_2_simd(stbi_uc *out, stbi_uc *in_near, stb
     // process groups of 8 pixels for as long as we can.
     // note we can't handle the last pixel in a row in this loop
     // because we need to handle the filter boundary conditions.
-    for (; i < ((w - 1) & ~7); i += 8)
-    {
+    for (; i < ((w - 1) & ~7); i += 8) {
 #if defined(STBI_SSE2)
         // load and perform the vertical filtering pass
         // this uses 3*x + y = 4*x + (y - x)
@@ -4088,8 +3774,7 @@ static stbi_uc *stbi__resample_row_hv_2_simd(stbi_uc *out, stbi_uc *in_near, stb
     t1 = 3 * in_near[i] + in_far[i];
     out[i * 2] = stbi__div16(3 * t1 + t0 + 8);
 
-    for (++i; i < w; ++i)
-    {
+    for (++i; i < w; ++i) {
         t0 = t1;
         t1 = 3 * in_near[i] + in_far[i];
         out[i * 2 - 1] = stbi__div16(3 * t0 + t1 + 8);
@@ -4103,8 +3788,7 @@ static stbi_uc *stbi__resample_row_hv_2_simd(stbi_uc *out, stbi_uc *in_near, stb
 }
 #endif
 
-static stbi_uc *stbi__resample_row_generic(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
-{
+static stbi_uc * stbi__resample_row_generic(stbi_uc * out, stbi_uc * in_near, stbi_uc * in_far, int w, int hs) {
     // resample with nearest-neighbor
     int i, j;
     STBI_NOTUSED(in_far);
@@ -4117,11 +3801,10 @@ static stbi_uc *stbi__resample_row_generic(stbi_uc *out, stbi_uc *in_near, stbi_
 // this is a reduced-precision calculation of YCbCr-to-RGB introduced
 // to make sure the code produces the same results in both SIMD and scalar
 #define stbi__float2fixed(x) (((int)((x)*4096.0f + 0.5f)) << 8)
-static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step)
-{
+static void stbi__YCbCr_to_RGB_row(stbi_uc * out, const stbi_uc * y, const stbi_uc * pcb, const stbi_uc * pcr, int count,
+                                   int step) {
     int i;
-    for (i = 0; i < count; ++i)
-    {
+    for (i = 0; i < count; ++i) {
         int y_fixed = (y[i] << 20) + (1 << 19); // rounding
         int r, g, b;
         int cr = pcr[i] - 128;
@@ -4132,22 +3815,19 @@ static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc
         r >>= 20;
         g >>= 20;
         b >>= 20;
-        if ((unsigned)r > 255)
-        {
+        if ((unsigned)r > 255) {
             if (r < 0)
                 r = 0;
             else
                 r = 255;
         }
-        if ((unsigned)g > 255)
-        {
+        if ((unsigned)g > 255) {
             if (g < 0)
                 g = 0;
             else
                 g = 255;
         }
-        if ((unsigned)b > 255)
-        {
+        if ((unsigned)b > 255) {
             if (b < 0)
                 b = 0;
             else
@@ -4162,16 +3842,15 @@ static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc
 }
 
 #if defined(STBI_SSE2) || defined(STBI_NEON)
-static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc const *pcb, stbi_uc const *pcr, int count, int step)
-{
+static void stbi__YCbCr_to_RGB_simd(stbi_uc * out, stbi_uc const * y, stbi_uc const * pcb, stbi_uc const * pcr, int count,
+                                    int step) {
     int i = 0;
 
 #ifdef STBI_SSE2
     // step == 3 is pretty ugly on the final interleave, and i'm not convinced
     // it's useful in practice (you wouldn't use it for textures, for example).
     // so just accelerate step == 4 case.
-    if (step == 4)
-    {
+    if (step == 4) {
         // this is a fairly straightforward implementation and not super-optimized.
         __m128i signflip = _mm_set1_epi8(-0x80);
         __m128i cr_const0 = _mm_set1_epi16((short)(1.40200f * 4096.0f + 0.5f));
@@ -4181,8 +3860,7 @@ static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc cons
         __m128i y_bias = _mm_set1_epi8((char)(unsigned char)128);
         __m128i xw = _mm_set1_epi16(255); // alpha channel
 
-        for (; i + 7 < count; i += 8)
-        {
+        for (; i + 7 < count; i += 8) {
             // load
             __m128i y_bytes = _mm_loadl_epi64((__m128i *)(y + i));
             __m128i cr_bytes = _mm_loadl_epi64((__m128i *)(pcr + i));
@@ -4231,8 +3909,7 @@ static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc cons
 
 #ifdef STBI_NEON
     // in this version, step=3 support would be easy to add. but is there demand?
-    if (step == 4)
-    {
+    if (step == 4) {
         // this is a fairly straightforward implementation and not super-optimized.
         uint8x8_t signflip = vdup_n_u8(0x80);
         int16x8_t cr_const0 = vdupq_n_s16((short)(1.40200f * 4096.0f + 0.5f));
@@ -4240,8 +3917,7 @@ static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc cons
         int16x8_t cb_const0 = vdupq_n_s16(-(short)(0.34414f * 4096.0f + 0.5f));
         int16x8_t cb_const1 = vdupq_n_s16((short)(1.77200f * 4096.0f + 0.5f));
 
-        for (; i + 7 < count; i += 8)
-        {
+        for (; i + 7 < count; i += 8) {
             // load
             uint8x8_t y_bytes = vld1_u8(y + i);
             uint8x8_t cr_bytes = vld1_u8(pcr + i);
@@ -4277,8 +3953,7 @@ static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc cons
     }
 #endif
 
-    for (; i < count; ++i)
-    {
+    for (; i < count; ++i) {
         int y_fixed = (y[i] << 20) + (1 << 19); // rounding
         int r, g, b;
         int cr = pcr[i] - 128;
@@ -4289,22 +3964,19 @@ static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc cons
         r >>= 20;
         g >>= 20;
         b >>= 20;
-        if ((unsigned)r > 255)
-        {
+        if ((unsigned)r > 255) {
             if (r < 0)
                 r = 0;
             else
                 r = 255;
         }
-        if ((unsigned)g > 255)
-        {
+        if ((unsigned)g > 255) {
             if (g < 0)
                 g = 0;
             else
                 g = 255;
         }
-        if ((unsigned)b > 255)
-        {
+        if ((unsigned)b > 255) {
             if (b < 0)
                 b = 0;
             else
@@ -4320,15 +3992,13 @@ static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc cons
 #endif
 
 // set up the kernels
-static void stbi__setup_jpeg(stbi__jpeg *j)
-{
+static void stbi__setup_jpeg(stbi__jpeg * j) {
     j->idct_block_kernel = stbi__idct_block;
     j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_row;
     j->resample_row_hv_2_kernel = stbi__resample_row_hv_2;
 
 #ifdef STBI_SSE2
-    if (stbi__sse2_available())
-    {
+    if (stbi__sse2_available()) {
         j->idct_block_kernel = stbi__idct_simd;
         j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
         j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
@@ -4343,13 +4013,9 @@ static void stbi__setup_jpeg(stbi__jpeg *j)
 }
 
 // clean up the temporary component buffers
-static void stbi__cleanup_jpeg(stbi__jpeg *j)
-{
-    stbi__free_jpeg_components(j, j->s->img_n, 0);
-}
+static void stbi__cleanup_jpeg(stbi__jpeg * j) { stbi__free_jpeg_components(j, j->s->img_n, 0); }
 
-typedef struct
-{
+typedef struct {
     resample_row_func resample;
     stbi_uc *line0, *line1;
     int hs, vs;  // expansion factor in each axis
@@ -4359,14 +4025,12 @@ typedef struct
 } stbi__resample;
 
 // fast 0..255 * 0..255 => 0..255 rounded multiplication
-static stbi_uc stbi__blinn_8x8(stbi_uc x, stbi_uc y)
-{
+static stbi_uc stbi__blinn_8x8(stbi_uc x, stbi_uc y) {
     unsigned int t = x * y + 128;
     return (stbi_uc)((t + (t >> 8)) >> 8);
 }
 
-static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp, int req_comp)
-{
+static stbi_uc * load_jpeg_image(stbi__jpeg * z, int * out_x, int * out_y, int * comp, int req_comp) {
     int n, decode_n, is_rgb;
     z->s->img_n = 0; // make stbi__cleanup_jpeg safe
 
@@ -4375,15 +4039,13 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
         return stbi__errpuc("bad req_comp", "Internal error");
 
     // load a jpeg image from whichever source, but leave in YCbCr format
-    if (!stbi__decode_jpeg_image(z))
-    {
+    if (!stbi__decode_jpeg_image(z)) {
         stbi__cleanup_jpeg(z);
         return NULL;
     }
 
     // determine actual number of components to generate
-    n = req_comp ? req_comp : z->s->img_n >= 3 ? 3
-                                               : 1;
+    n = req_comp ? req_comp : z->s->img_n >= 3 ? 3 : 1;
 
     is_rgb = z->s->img_n == 3 && (z->rgb == 3 || (z->app14_color_transform == 0 && !z->jfif));
 
@@ -4394,8 +4056,7 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
 
     // nothing to do if no components requested; check this now to avoid
     // accessing uninitialized coutput[0] later
-    if (decode_n <= 0)
-    {
+    if (decode_n <= 0) {
         stbi__cleanup_jpeg(z);
         return NULL;
     }
@@ -4404,20 +4065,18 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
     {
         int k;
         unsigned int i, j;
-        stbi_uc *output;
-        stbi_uc *coutput[4] = {NULL, NULL, NULL, NULL};
+        stbi_uc * output;
+        stbi_uc * coutput[4] = {NULL, NULL, NULL, NULL};
 
         stbi__resample res_comp[4];
 
-        for (k = 0; k < decode_n; ++k)
-        {
-            stbi__resample *r = &res_comp[k];
+        for (k = 0; k < decode_n; ++k) {
+            stbi__resample * r = &res_comp[k];
 
             // allocate line buffer big enough for upsampling off the edges
             // with upsample factor of 4
             z->img_comp[k].linebuf = (stbi_uc *)stbi__malloc(z->s->img_x + 3);
-            if (!z->img_comp[k].linebuf)
-            {
+            if (!z->img_comp[k].linebuf) {
                 stbi__cleanup_jpeg(z);
                 return stbi__errpuc("outofmem", "Out of memory");
             }
@@ -4443,59 +4102,43 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
 
         // can't error after this so, this is safe
         output = (stbi_uc *)stbi__malloc_mad3(n, z->s->img_x, z->s->img_y, 1);
-        if (!output)
-        {
+        if (!output) {
             stbi__cleanup_jpeg(z);
             return stbi__errpuc("outofmem", "Out of memory");
         }
 
         // now go ahead and resample
-        for (j = 0; j < z->s->img_y; ++j)
-        {
-            stbi_uc *out = output + n * z->s->img_x * j;
-            for (k = 0; k < decode_n; ++k)
-            {
-                stbi__resample *r = &res_comp[k];
+        for (j = 0; j < z->s->img_y; ++j) {
+            stbi_uc * out = output + n * z->s->img_x * j;
+            for (k = 0; k < decode_n; ++k) {
+                stbi__resample * r = &res_comp[k];
                 int y_bot = r->ystep >= (r->vs >> 1);
-                coutput[k] = r->resample(z->img_comp[k].linebuf,
-                                         y_bot ? r->line1 : r->line0,
-                                         y_bot ? r->line0 : r->line1,
+                coutput[k] = r->resample(z->img_comp[k].linebuf, y_bot ? r->line1 : r->line0, y_bot ? r->line0 : r->line1,
                                          r->w_lores, r->hs);
-                if (++r->ystep >= r->vs)
-                {
+                if (++r->ystep >= r->vs) {
                     r->ystep = 0;
                     r->line0 = r->line1;
                     if (++r->ypos < z->img_comp[k].y)
                         r->line1 += z->img_comp[k].w2;
                 }
             }
-            if (n >= 3)
-            {
-                stbi_uc *y = coutput[0];
-                if (z->s->img_n == 3)
-                {
-                    if (is_rgb)
-                    {
-                        for (i = 0; i < z->s->img_x; ++i)
-                        {
+            if (n >= 3) {
+                stbi_uc * y = coutput[0];
+                if (z->s->img_n == 3) {
+                    if (is_rgb) {
+                        for (i = 0; i < z->s->img_x; ++i) {
                             out[0] = y[i];
                             out[1] = coutput[1][i];
                             out[2] = coutput[2][i];
                             out[3] = 255;
                             out += n;
                         }
-                    }
-                    else
-                    {
+                    } else {
                         z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
                     }
-                }
-                else if (z->s->img_n == 4)
-                {
-                    if (z->app14_color_transform == 0)
-                    { // CMYK
-                        for (i = 0; i < z->s->img_x; ++i)
-                        {
+                } else if (z->s->img_n == 4) {
+                    if (z->app14_color_transform == 0) { // CMYK
+                        for (i = 0; i < z->s->img_x; ++i) {
                             stbi_uc m = coutput[3][i];
                             out[0] = stbi__blinn_8x8(coutput[0][i], m);
                             out[1] = stbi__blinn_8x8(coutput[1][i], m);
@@ -4503,52 +4146,37 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
                             out[3] = 255;
                             out += n;
                         }
-                    }
-                    else if (z->app14_color_transform == 2)
-                    { // YCCK
+                    } else if (z->app14_color_transform == 2) { // YCCK
                         z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
-                        for (i = 0; i < z->s->img_x; ++i)
-                        {
+                        for (i = 0; i < z->s->img_x; ++i) {
                             stbi_uc m = coutput[3][i];
                             out[0] = stbi__blinn_8x8(255 - out[0], m);
                             out[1] = stbi__blinn_8x8(255 - out[1], m);
                             out[2] = stbi__blinn_8x8(255 - out[2], m);
                             out += n;
                         }
-                    }
-                    else
-                    { // YCbCr + alpha?  Ignore the fourth channel for now
+                    } else { // YCbCr + alpha?  Ignore the fourth channel for now
                         z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
                     }
-                }
-                else
-                    for (i = 0; i < z->s->img_x; ++i)
-                    {
+                } else
+                    for (i = 0; i < z->s->img_x; ++i) {
                         out[0] = out[1] = out[2] = y[i];
                         out[3] = 255; // not used if n==3
                         out += n;
                     }
-            }
-            else
-            {
-                if (is_rgb)
-                {
+            } else {
+                if (is_rgb) {
                     if (n == 1)
                         for (i = 0; i < z->s->img_x; ++i)
                             *out++ = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
-                    else
-                    {
-                        for (i = 0; i < z->s->img_x; ++i, out += 2)
-                        {
+                    else {
+                        for (i = 0; i < z->s->img_x; ++i, out += 2) {
                             out[0] = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
                             out[1] = 255;
                         }
                     }
-                }
-                else if (z->s->img_n == 4 && z->app14_color_transform == 0)
-                {
-                    for (i = 0; i < z->s->img_x; ++i)
-                    {
+                } else if (z->s->img_n == 4 && z->app14_color_transform == 0) {
+                    for (i = 0; i < z->s->img_x; ++i) {
                         stbi_uc m = coutput[3][i];
                         stbi_uc r = stbi__blinn_8x8(coutput[0][i], m);
                         stbi_uc g = stbi__blinn_8x8(coutput[1][i], m);
@@ -4557,25 +4185,19 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
                         out[1] = 255;
                         out += n;
                     }
-                }
-                else if (z->s->img_n == 4 && z->app14_color_transform == 2)
-                {
-                    for (i = 0; i < z->s->img_x; ++i)
-                    {
+                } else if (z->s->img_n == 4 && z->app14_color_transform == 2) {
+                    for (i = 0; i < z->s->img_x; ++i) {
                         out[0] = stbi__blinn_8x8(255 - coutput[0][i], coutput[3][i]);
                         out[1] = 255;
                         out += n;
                     }
-                }
-                else
-                {
-                    stbi_uc *y = coutput[0];
+                } else {
+                    stbi_uc * y = coutput[0];
                     if (n == 1)
                         for (i = 0; i < z->s->img_x; ++i)
                             out[i] = y[i];
                     else
-                        for (i = 0; i < z->s->img_x; ++i)
-                        {
+                        for (i = 0; i < z->s->img_x; ++i) {
                             *out++ = y[i];
                             *out++ = 255;
                         }
@@ -4591,10 +4213,9 @@ static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp
     }
 }
 
-static void *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
-{
-    unsigned char *result;
-    stbi__jpeg *j = (stbi__jpeg *)stbi__malloc(sizeof(stbi__jpeg));
+static void * stbi__jpeg_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri) {
+    unsigned char * result;
+    stbi__jpeg * j = (stbi__jpeg *)stbi__malloc(sizeof(stbi__jpeg));
     if (!j)
         return stbi__errpuc("outofmem", "Out of memory");
     memset(j, 0, sizeof(stbi__jpeg));
@@ -4606,10 +4227,9 @@ static void *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int re
     return result;
 }
 
-static int stbi__jpeg_test(stbi__context *s)
-{
+static int stbi__jpeg_test(stbi__context * s) {
     int r;
-    stbi__jpeg *j = (stbi__jpeg *)stbi__malloc(sizeof(stbi__jpeg));
+    stbi__jpeg * j = (stbi__jpeg *)stbi__malloc(sizeof(stbi__jpeg));
     if (!j)
         return stbi__err("outofmem", "Out of memory");
     memset(j, 0, sizeof(stbi__jpeg));
@@ -4621,10 +4241,8 @@ static int stbi__jpeg_test(stbi__context *s)
     return r;
 }
 
-static int stbi__jpeg_info_raw(stbi__jpeg *j, int *x, int *y, int *comp)
-{
-    if (!stbi__decode_jpeg_header(j, STBI__SCAN_header))
-    {
+static int stbi__jpeg_info_raw(stbi__jpeg * j, int * x, int * y, int * comp) {
+    if (!stbi__decode_jpeg_header(j, STBI__SCAN_header)) {
         stbi__rewind(j->s);
         return 0;
     }
@@ -4637,10 +4255,9 @@ static int stbi__jpeg_info_raw(stbi__jpeg *j, int *x, int *y, int *comp)
     return 1;
 }
 
-static int stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp)
-{
+static int stbi__jpeg_info(stbi__context * s, int * x, int * y, int * comp) {
     int result;
-    stbi__jpeg *j = (stbi__jpeg *)(stbi__malloc(sizeof(stbi__jpeg)));
+    stbi__jpeg * j = (stbi__jpeg *)(stbi__malloc(sizeof(stbi__jpeg)));
     if (!j)
         return stbi__err("outofmem", "Out of memory");
     memset(j, 0, sizeof(stbi__jpeg));
@@ -4667,8 +4284,7 @@ static int stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp)
 
 // zlib-style huffman encoding
 // (jpegs packs from left, zlib from right, so can't share code)
-typedef struct
-{
+typedef struct {
     stbi__uint16 fast[1 << STBI__ZFAST_BITS];
     stbi__uint16 firstcode[16];
     int maxcode[17];
@@ -4677,8 +4293,7 @@ typedef struct
     stbi__uint16 value[STBI__ZNSYMS];
 } stbi__zhuffman;
 
-stbi_inline static int stbi__bitreverse16(int n)
-{
+stbi_inline static int stbi__bitreverse16(int n) {
     n = ((n & 0xAAAA) >> 1) | ((n & 0x5555) << 1);
     n = ((n & 0xCCCC) >> 2) | ((n & 0x3333) << 2);
     n = ((n & 0xF0F0) >> 4) | ((n & 0x0F0F) << 4);
@@ -4686,16 +4301,14 @@ stbi_inline static int stbi__bitreverse16(int n)
     return n;
 }
 
-stbi_inline static int stbi__bit_reverse(int v, int bits)
-{
+stbi_inline static int stbi__bit_reverse(int v, int bits) {
     STBI_ASSERT(bits <= 16);
     // to bit reverse n bits, reverse 16 and shift
     // e.g. 11 bits, bit reverse and shift away 5
     return stbi__bitreverse16(v) >> (16 - bits);
 }
 
-static int stbi__zbuild_huffman(stbi__zhuffman *z, const stbi_uc *sizelist, int num)
-{
+static int stbi__zbuild_huffman(stbi__zhuffman * z, const stbi_uc * sizelist, int num) {
     int i, k = 0;
     int code, next_code[16], sizes[17];
 
@@ -4709,8 +4322,7 @@ static int stbi__zbuild_huffman(stbi__zhuffman *z, const stbi_uc *sizelist, int 
         if (sizes[i] > (1 << i))
             return stbi__err("bad sizes", "Corrupt PNG");
     code = 0;
-    for (i = 1; i < 16; ++i)
-    {
+    for (i = 1; i < 16; ++i) {
         next_code[i] = code;
         z->firstcode[i] = (stbi__uint16)code;
         z->firstsymbol[i] = (stbi__uint16)k;
@@ -4723,20 +4335,16 @@ static int stbi__zbuild_huffman(stbi__zhuffman *z, const stbi_uc *sizelist, int 
         k += sizes[i];
     }
     z->maxcode[16] = 0x10000; // sentinel
-    for (i = 0; i < num; ++i)
-    {
+    for (i = 0; i < num; ++i) {
         int s = sizelist[i];
-        if (s)
-        {
+        if (s) {
             int c = next_code[s] - z->firstcode[s] + z->firstsymbol[s];
             stbi__uint16 fastv = (stbi__uint16)((s << 9) | i);
             z->size[c] = (stbi_uc)s;
             z->value[c] = (stbi__uint16)i;
-            if (s <= STBI__ZFAST_BITS)
-            {
+            if (s <= STBI__ZFAST_BITS) {
                 int j = stbi__bit_reverse(next_code[s], s);
-                while (j < (1 << STBI__ZFAST_BITS))
-                {
+                while (j < (1 << STBI__ZFAST_BITS)) {
                     z->fast[j] = fastv;
                     j += (1 << s);
                 }
@@ -4753,36 +4361,26 @@ static int stbi__zbuild_huffman(stbi__zhuffman *z, const stbi_uc *sizelist, int 
 //    we require PNG read all the IDATs and combine them into a single
 //    memory buffer
 
-typedef struct
-{
+typedef struct {
     stbi_uc *zbuffer, *zbuffer_end;
     int num_bits;
     stbi__uint32 code_buffer;
 
-    char *zout;
-    char *zout_start;
-    char *zout_end;
+    char * zout;
+    char * zout_start;
+    char * zout_end;
     int z_expandable;
 
     stbi__zhuffman z_length, z_distance;
 } stbi__zbuf;
 
-stbi_inline static int stbi__zeof(stbi__zbuf *z)
-{
-    return (z->zbuffer >= z->zbuffer_end);
-}
+stbi_inline static int stbi__zeof(stbi__zbuf * z) { return (z->zbuffer >= z->zbuffer_end); }
 
-stbi_inline static stbi_uc stbi__zget8(stbi__zbuf *z)
-{
-    return stbi__zeof(z) ? 0 : *z->zbuffer++;
-}
+stbi_inline static stbi_uc stbi__zget8(stbi__zbuf * z) { return stbi__zeof(z) ? 0 : *z->zbuffer++; }
 
-static void stbi__fill_bits(stbi__zbuf *z)
-{
-    do
-    {
-        if (z->code_buffer >= (1U << z->num_bits))
-        {
+static void stbi__fill_bits(stbi__zbuf * z) {
+    do {
+        if (z->code_buffer >= (1U << z->num_bits)) {
             z->zbuffer = z->zbuffer_end; /* treat this as EOF so we fail. */
             return;
         }
@@ -4791,8 +4389,7 @@ static void stbi__fill_bits(stbi__zbuf *z)
     } while (z->num_bits <= 24);
 }
 
-stbi_inline static unsigned int stbi__zreceive(stbi__zbuf *z, int n)
-{
+stbi_inline static unsigned int stbi__zreceive(stbi__zbuf * z, int n) {
     unsigned int k;
     if (z->num_bits < n)
         stbi__fill_bits(z);
@@ -4802,8 +4399,7 @@ stbi_inline static unsigned int stbi__zreceive(stbi__zbuf *z, int n)
     return k;
 }
 
-static int stbi__zhuffman_decode_slowpath(stbi__zbuf *a, stbi__zhuffman *z)
-{
+static int stbi__zhuffman_decode_slowpath(stbi__zbuf * a, stbi__zhuffman * z) {
     int b, s, k;
     // not resolved by fast table, so compute it the slow way
     // use jpeg approach, which requires MSbits at top
@@ -4824,20 +4420,16 @@ static int stbi__zhuffman_decode_slowpath(stbi__zbuf *a, stbi__zhuffman *z)
     return z->value[b];
 }
 
-stbi_inline static int stbi__zhuffman_decode(stbi__zbuf *a, stbi__zhuffman *z)
-{
+stbi_inline static int stbi__zhuffman_decode(stbi__zbuf * a, stbi__zhuffman * z) {
     int b, s;
-    if (a->num_bits < 16)
-    {
-        if (stbi__zeof(a))
-        {
+    if (a->num_bits < 16) {
+        if (stbi__zeof(a)) {
             return -1; /* report error for unexpected end of data. */
         }
         stbi__fill_bits(a);
     }
     b = z->fast[a->code_buffer & STBI__ZFAST_MASK];
-    if (b)
-    {
+    if (b) {
         s = b >> 9;
         a->code_buffer >>= s;
         a->num_bits -= s;
@@ -4846,9 +4438,9 @@ stbi_inline static int stbi__zhuffman_decode(stbi__zbuf *a, stbi__zhuffman *z)
     return stbi__zhuffman_decode_slowpath(a, z);
 }
 
-static int stbi__zexpand(stbi__zbuf *z, char *zout, int n) // need to make room for n bytes
+static int stbi__zexpand(stbi__zbuf * z, char * zout, int n) // need to make room for n bytes
 {
-    char *q;
+    char * q;
     unsigned int cur, limit, old_limit;
     z->zout = zout;
     if (!z->z_expandable)
@@ -4857,8 +4449,7 @@ static int stbi__zexpand(stbi__zbuf *z, char *zout, int n) // need to make room 
     limit = old_limit = (unsigned)(z->zout_end - z->zout_start);
     if (UINT_MAX - cur < (unsigned)n)
         return stbi__err("outofmem", "Out of memory");
-    while (cur + n > limit)
-    {
+    while (cur + n > limit) {
         if (limit > UINT_MAX / 2)
             return stbi__err("outofmem", "Out of memory");
         limit *= 2;
@@ -4873,82 +4464,70 @@ static int stbi__zexpand(stbi__zbuf *z, char *zout, int n) // need to make room 
     return 1;
 }
 
-static const int stbi__zlength_base[31] = {
-    3, 4, 5, 6, 7, 8, 9, 10, 11, 13,
-    15, 17, 19, 23, 27, 31, 35, 43, 51, 59,
-    67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0};
+static const int stbi__zlength_base[31] = {3,  4,  5,  6,  7,  8,  9,  10,  11,  13,  15,  17,  19,  23, 27, 31,
+                                           35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0,  0};
 
-static const int stbi__zlength_extra[31] =
-    {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0};
+static const int stbi__zlength_extra[31] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
+                                            3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0};
 
-static const int stbi__zdist_base[32] = {1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193,
-                                         257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577, 0, 0};
+static const int stbi__zdist_base[32] = {1,    2,    3,    4,    5,    7,     9,     13,    17,  25,   33,
+                                         49,   65,   97,   129,  193,  257,   385,   513,   769, 1025, 1537,
+                                         2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577, 0,   0};
 
-static const int stbi__zdist_extra[32] =
-    {0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13};
+static const int stbi__zdist_extra[32] = {0, 0, 0, 0, 1, 1, 2, 2,  3,  3,  4,  4,  5,  5,  6,
+                                          6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13};
 
-static int stbi__parse_huffman_block(stbi__zbuf *a)
-{
-    char *zout = a->zout;
-    for (;;)
-    {
+static int stbi__parse_huffman_block(stbi__zbuf * a) {
+    char * zout = a->zout;
+    for (;;) {
         int z = stbi__zhuffman_decode(a, &a->z_length);
-        if (z < 256)
-        {
+        if (z < 256) {
             if (z < 0)
                 return stbi__err("bad huffman code", "Corrupt PNG"); // error in huffman codes
-            if (zout >= a->zout_end)
-            {
+            if (zout >= a->zout_end) {
                 if (!stbi__zexpand(a, zout, 1))
                     return 0;
                 zout = a->zout;
             }
             *zout++ = (char)z;
-        }
-        else
-        {
-            stbi_uc *p;
+        } else {
+            stbi_uc * p;
             int len, dist;
-            if (z == 256)
-            {
+            if (z == 256) {
                 a->zout = zout;
                 return 1;
             }
             if (z >= 286)
-                return stbi__err("bad huffman code", "Corrupt PNG"); // per DEFLATE, length codes 286 and 287 must not appear in compressed data
+                return stbi__err("bad huffman code",
+                                 "Corrupt PNG"); // per DEFLATE, length codes 286 and 287 must not appear in compressed data
             z -= 257;
             len = stbi__zlength_base[z];
             if (stbi__zlength_extra[z])
                 len += stbi__zreceive(a, stbi__zlength_extra[z]);
             z = stbi__zhuffman_decode(a, &a->z_distance);
             if (z < 0 || z >= 30)
-                return stbi__err("bad huffman code", "Corrupt PNG"); // per DEFLATE, distance codes 30 and 31 must not appear in compressed data
+                return stbi__err("bad huffman code",
+                                 "Corrupt PNG"); // per DEFLATE, distance codes 30 and 31 must not appear in compressed data
             dist = stbi__zdist_base[z];
             if (stbi__zdist_extra[z])
                 dist += stbi__zreceive(a, stbi__zdist_extra[z]);
             if (zout - a->zout_start < dist)
                 return stbi__err("bad dist", "Corrupt PNG");
-            if (zout + len > a->zout_end)
-            {
+            if (zout + len > a->zout_end) {
                 if (!stbi__zexpand(a, zout, len))
                     return 0;
                 zout = a->zout;
             }
             p = (stbi_uc *)(zout - dist);
-            if (dist == 1)
-            { // run of one byte; common in images.
+            if (dist == 1) { // run of one byte; common in images.
                 stbi_uc v = *p;
-                if (len)
-                {
+                if (len) {
                     do
                         *zout++ = v;
                     while (--len);
                 }
-            }
-            else
-            {
-                if (len)
-                {
+            } else {
+                if (len) {
                     do
                         *zout++ = *p++;
                     while (--len);
@@ -4958,8 +4537,7 @@ static int stbi__parse_huffman_block(stbi__zbuf *a)
     }
 }
 
-static int stbi__compute_huffman_codes(stbi__zbuf *a)
-{
+static int stbi__compute_huffman_codes(stbi__zbuf * a) {
     static const stbi_uc length_dezigzag[19] = {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
     stbi__zhuffman z_codelength;
     stbi_uc lencodes[286 + 32 + 137]; // padding for maximum single op
@@ -4972,8 +4550,7 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a)
     int ntot = hlit + hdist;
 
     memset(codelength_sizes, 0, sizeof(codelength_sizes));
-    for (i = 0; i < hclen; ++i)
-    {
+    for (i = 0; i < hclen; ++i) {
         int s = stbi__zreceive(a, 3);
         codelength_sizes[length_dezigzag[i]] = (stbi_uc)s;
     }
@@ -4981,33 +4558,24 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a)
         return 0;
 
     n = 0;
-    while (n < ntot)
-    {
+    while (n < ntot) {
         int c = stbi__zhuffman_decode(a, &z_codelength);
         if (c < 0 || c >= 19)
             return stbi__err("bad codelengths", "Corrupt PNG");
         if (c < 16)
             lencodes[n++] = (stbi_uc)c;
-        else
-        {
+        else {
             stbi_uc fill = 0;
-            if (c == 16)
-            {
+            if (c == 16) {
                 c = stbi__zreceive(a, 2) + 3;
                 if (n == 0)
                     return stbi__err("bad codelengths", "Corrupt PNG");
                 fill = lencodes[n - 1];
-            }
-            else if (c == 17)
-            {
+            } else if (c == 17) {
                 c = stbi__zreceive(a, 3) + 3;
-            }
-            else if (c == 18)
-            {
+            } else if (c == 18) {
                 c = stbi__zreceive(a, 7) + 11;
-            }
-            else
-            {
+            } else {
                 return stbi__err("bad codelengths", "Corrupt PNG");
             }
             if (ntot - n < c)
@@ -5025,16 +4593,14 @@ static int stbi__compute_huffman_codes(stbi__zbuf *a)
     return 1;
 }
 
-static int stbi__parse_uncompressed_block(stbi__zbuf *a)
-{
+static int stbi__parse_uncompressed_block(stbi__zbuf * a) {
     stbi_uc header[4];
     int len, nlen, k;
     if (a->num_bits & 7)
         stbi__zreceive(a, a->num_bits & 7); // discard
     // drain the bit-packed data into header
     k = 0;
-    while (a->num_bits > 0)
-    {
+    while (a->num_bits > 0) {
         header[k++] = (stbi_uc)(a->code_buffer & 255); // suppress MSVC run-time check
         a->code_buffer >>= 8;
         a->num_bits -= 8;
@@ -5059,8 +4625,7 @@ static int stbi__parse_uncompressed_block(stbi__zbuf *a)
     return 1;
 }
 
-static int stbi__parse_zlib_header(stbi__zbuf *a)
-{
+static int stbi__parse_zlib_header(stbi__zbuf * a) {
     int cmf = stbi__zget8(a);
     int cm = cmf & 15;
     /* int cinfo = cmf >> 4; */
@@ -5077,20 +4642,17 @@ static int stbi__parse_zlib_header(stbi__zbuf *a)
     return 1;
 }
 
-static const stbi_uc stbi__zdefault_length[STBI__ZNSYMS] =
-    {
-        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
-        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
-        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
-        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
-        8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-        9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-        9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-        9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8};
-static const stbi_uc stbi__zdefault_distance[32] =
-    {
-        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5};
+static const stbi_uc stbi__zdefault_length[STBI__ZNSYMS] = {
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+    9, 9, 9, 9, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8};
+static const stbi_uc stbi__zdefault_distance[32] = {5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+                                                    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 /*
 Init algorithm:
 {
@@ -5104,39 +4666,29 @@ Init algorithm:
 }
 */
 
-static int stbi__parse_zlib(stbi__zbuf *a, int parse_header)
-{
+static int stbi__parse_zlib(stbi__zbuf * a, int parse_header) {
     int final, type;
     if (parse_header)
         if (!stbi__parse_zlib_header(a))
             return 0;
     a->num_bits = 0;
     a->code_buffer = 0;
-    do
-    {
+    do {
         final = stbi__zreceive(a, 1);
         type = stbi__zreceive(a, 2);
-        if (type == 0)
-        {
+        if (type == 0) {
             if (!stbi__parse_uncompressed_block(a))
                 return 0;
-        }
-        else if (type == 3)
-        {
+        } else if (type == 3) {
             return 0;
-        }
-        else
-        {
-            if (type == 1)
-            {
+        } else {
+            if (type == 1) {
                 // use fixed code lengths
                 if (!stbi__zbuild_huffman(&a->z_length, stbi__zdefault_length, STBI__ZNSYMS))
                     return 0;
                 if (!stbi__zbuild_huffman(&a->z_distance, stbi__zdefault_distance, 32))
                     return 0;
-            }
-            else
-            {
+            } else {
                 if (!stbi__compute_huffman_codes(a))
                     return 0;
             }
@@ -5147,8 +4699,7 @@ static int stbi__parse_zlib(stbi__zbuf *a, int parse_header)
     return 1;
 }
 
-static int stbi__do_zlib(stbi__zbuf *a, char *obuf, int olen, int exp, int parse_header)
-{
+static int stbi__do_zlib(stbi__zbuf * a, char * obuf, int olen, int exp, int parse_header) {
     a->zout_start = obuf;
     a->zout = obuf;
     a->zout_end = obuf + olen;
@@ -5157,55 +4708,46 @@ static int stbi__do_zlib(stbi__zbuf *a, char *obuf, int olen, int exp, int parse
     return stbi__parse_zlib(a, parse_header);
 }
 
-STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen)
-{
+STBIDEF char * stbi_zlib_decode_malloc_guesssize(const char * buffer, int len, int initial_size, int * outlen) {
     stbi__zbuf a;
-    char *p = (char *)stbi__malloc(initial_size);
+    char * p = (char *)stbi__malloc(initial_size);
     if (p == NULL)
         return NULL;
     a.zbuffer = (stbi_uc *)buffer;
     a.zbuffer_end = (stbi_uc *)buffer + len;
-    if (stbi__do_zlib(&a, p, initial_size, 1, 1))
-    {
+    if (stbi__do_zlib(&a, p, initial_size, 1, 1)) {
         if (outlen)
             *outlen = (int)(a.zout - a.zout_start);
         return a.zout_start;
-    }
-    else
-    {
+    } else {
         STBI_FREE(a.zout_start);
         return NULL;
     }
 }
 
-STBIDEF char *stbi_zlib_decode_malloc(char const *buffer, int len, int *outlen)
-{
+STBIDEF char * stbi_zlib_decode_malloc(char const * buffer, int len, int * outlen) {
     return stbi_zlib_decode_malloc_guesssize(buffer, len, 16384, outlen);
 }
 
-STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header)
-{
+STBIDEF char * stbi_zlib_decode_malloc_guesssize_headerflag(const char * buffer, int len, int initial_size, int * outlen,
+                                                            int parse_header) {
     stbi__zbuf a;
-    char *p = (char *)stbi__malloc(initial_size);
+    char * p = (char *)stbi__malloc(initial_size);
     if (p == NULL)
         return NULL;
     a.zbuffer = (stbi_uc *)buffer;
     a.zbuffer_end = (stbi_uc *)buffer + len;
-    if (stbi__do_zlib(&a, p, initial_size, 1, parse_header))
-    {
+    if (stbi__do_zlib(&a, p, initial_size, 1, parse_header)) {
         if (outlen)
             *outlen = (int)(a.zout - a.zout_start);
         return a.zout_start;
-    }
-    else
-    {
+    } else {
         STBI_FREE(a.zout_start);
         return NULL;
     }
 }
 
-STBIDEF int stbi_zlib_decode_buffer(char *obuffer, int olen, char const *ibuffer, int ilen)
-{
+STBIDEF int stbi_zlib_decode_buffer(char * obuffer, int olen, char const * ibuffer, int ilen) {
     stbi__zbuf a;
     a.zbuffer = (stbi_uc *)ibuffer;
     a.zbuffer_end = (stbi_uc *)ibuffer + ilen;
@@ -5215,29 +4757,24 @@ STBIDEF int stbi_zlib_decode_buffer(char *obuffer, int olen, char const *ibuffer
         return -1;
 }
 
-STBIDEF char *stbi_zlib_decode_noheader_malloc(char const *buffer, int len, int *outlen)
-{
+STBIDEF char * stbi_zlib_decode_noheader_malloc(char const * buffer, int len, int * outlen) {
     stbi__zbuf a;
-    char *p = (char *)stbi__malloc(16384);
+    char * p = (char *)stbi__malloc(16384);
     if (p == NULL)
         return NULL;
     a.zbuffer = (stbi_uc *)buffer;
     a.zbuffer_end = (stbi_uc *)buffer + len;
-    if (stbi__do_zlib(&a, p, 16384, 1, 0))
-    {
+    if (stbi__do_zlib(&a, p, 16384, 1, 0)) {
         if (outlen)
             *outlen = (int)(a.zout - a.zout_start);
         return a.zout_start;
-    }
-    else
-    {
+    } else {
         STBI_FREE(a.zout_start);
         return NULL;
     }
 }
 
-STBIDEF int stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen)
-{
+STBIDEF int stbi_zlib_decode_noheader_buffer(char * obuffer, int olen, const char * ibuffer, int ilen) {
     stbi__zbuf a;
     a.zbuffer = (stbi_uc *)ibuffer;
     a.zbuffer_end = (stbi_uc *)ibuffer + ilen;
@@ -5259,22 +4796,19 @@ STBIDEF int stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char
 //      - uses stb_zlib, a PD zlib implementation with fast huffman decoding
 
 #ifndef STBI_NO_PNG
-typedef struct
-{
+typedef struct {
     stbi__uint32 length;
     stbi__uint32 type;
 } stbi__pngchunk;
 
-static stbi__pngchunk stbi__get_chunk_header(stbi__context *s)
-{
+static stbi__pngchunk stbi__get_chunk_header(stbi__context * s) {
     stbi__pngchunk c;
     c.length = stbi__get32be(s);
     c.type = stbi__get32be(s);
     return c;
 }
 
-static int stbi__check_png_header(stbi__context *s)
-{
+static int stbi__check_png_header(stbi__context * s) {
     static const stbi_uc png_sig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
     int i;
     for (i = 0; i < 8; ++i)
@@ -5283,15 +4817,13 @@ static int stbi__check_png_header(stbi__context *s)
     return 1;
 }
 
-typedef struct
-{
-    stbi__context *s;
+typedef struct {
+    stbi__context * s;
     stbi_uc *idata, *expanded, *out;
     int depth;
 } stbi__png;
 
-enum
-{
+enum {
     STBI__F_none = 0,
     STBI__F_sub = 1,
     STBI__F_up = 2,
@@ -5302,16 +4834,9 @@ enum
     STBI__F_paeth_first
 };
 
-static stbi_uc first_row_filter[5] =
-    {
-        STBI__F_none,
-        STBI__F_sub,
-        STBI__F_none,
-        STBI__F_avg_first,
-        STBI__F_paeth_first};
+static stbi_uc first_row_filter[5] = {STBI__F_none, STBI__F_sub, STBI__F_none, STBI__F_avg_first, STBI__F_paeth_first};
 
-static int stbi__paeth(int a, int b, int c)
-{
+static int stbi__paeth(int a, int b, int c) {
     int p = a + b - c;
     int pa = abs(p - a);
     int pb = abs(p - b);
@@ -5326,10 +4851,10 @@ static int stbi__paeth(int a, int b, int c)
 static const stbi_uc stbi__depth_scale_table[9] = {0, 0xff, 0x55, 0, 0x11, 0, 0, 0, 0x01};
 
 // create the png data from post-deflated data
-static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 raw_len, int out_n, stbi__uint32 x, stbi__uint32 y, int depth, int color)
-{
+static int stbi__create_png_image_raw(stbi__png * a, stbi_uc * raw, stbi__uint32 raw_len, int out_n, stbi__uint32 x,
+                                      stbi__uint32 y, int depth, int color) {
     int bytes = (depth == 16 ? 2 : 1);
-    stbi__context *s = a->s;
+    stbi__context * s = a->s;
     stbi__uint32 i, j, stride = x * out_n * bytes;
     stbi__uint32 img_len, img_width_bytes;
     int k;
@@ -5355,17 +4880,15 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
     if (raw_len < img_len)
         return stbi__err("not enough pixels", "Corrupt PNG");
 
-    for (j = 0; j < y; ++j)
-    {
-        stbi_uc *cur = a->out + stride * j;
-        stbi_uc *prior;
+    for (j = 0; j < y; ++j) {
+        stbi_uc * cur = a->out + stride * j;
+        stbi_uc * prior;
         int filter = *raw++;
 
         if (filter > 4)
             return stbi__err("invalid filter", "Corrupt PNG");
 
-        if (depth < 8)
-        {
+        if (depth < 8) {
             if (img_width_bytes > x)
                 return stbi__err("invalid width", "Corrupt PNG");
             cur += x * out_n - img_width_bytes; // store output to the rightmost img_len bytes, so we can decode in place
@@ -5379,10 +4902,8 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
             filter = first_row_filter[filter];
 
         // handle first byte explicitly
-        for (k = 0; k < filter_bytes; ++k)
-        {
-            switch (filter)
-            {
+        for (k = 0; k < filter_bytes; ++k) {
+            switch (filter) {
             case STBI__F_none:
                 cur[k] = raw[k];
                 break;
@@ -5407,41 +4928,33 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
             }
         }
 
-        if (depth == 8)
-        {
+        if (depth == 8) {
             if (img_n != out_n)
                 cur[img_n] = 255; // first pixel
             raw += img_n;
             cur += out_n;
             prior += out_n;
-        }
-        else if (depth == 16)
-        {
-            if (img_n != out_n)
-            {
+        } else if (depth == 16) {
+            if (img_n != out_n) {
                 cur[filter_bytes] = 255;     // first pixel top byte
                 cur[filter_bytes + 1] = 255; // first pixel bottom byte
             }
             raw += filter_bytes;
             cur += output_bytes;
             prior += output_bytes;
-        }
-        else
-        {
+        } else {
             raw += 1;
             cur += 1;
             prior += 1;
         }
 
         // this is a little gross, so that we don't switch per-pixel or per-component
-        if (depth < 8 || img_n == out_n)
-        {
+        if (depth < 8 || img_n == out_n) {
             int nk = (width - 1) * filter_bytes;
-#define STBI__CASE(f) \
-    case f:           \
+#define STBI__CASE(f)                                                                                                          \
+    case f:                                                                                                                    \
         for (k = 0; k < nk; ++k)
-            switch (filter)
-            {
+            switch (filter) {
             // "none" filter turns into a memcpy here; make that explicit.
             case STBI__F_none:
                 memcpy(cur, raw, nk);
@@ -5452,7 +4965,9 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
                 break;
                 STBI__CASE(STBI__F_avg) { cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k - filter_bytes]) >> 1)); }
                 break;
-                STBI__CASE(STBI__F_paeth) { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k - filter_bytes], prior[k], prior[k - filter_bytes])); }
+                STBI__CASE(STBI__F_paeth) {
+                    cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k - filter_bytes], prior[k], prior[k - filter_bytes]));
+                }
                 break;
                 STBI__CASE(STBI__F_avg_first) { cur[k] = STBI__BYTECAST(raw[k] + (cur[k - filter_bytes] >> 1)); }
                 break;
@@ -5461,16 +4976,13 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
             }
 #undef STBI__CASE
             raw += nk;
-        }
-        else
-        {
+        } else {
             STBI_ASSERT(img_n + 1 == out_n);
 #define STBI__CASE(f)                                                                                                          \
     case f:                                                                                                                    \
         for (i = x - 1; i >= 1; --i, cur[filter_bytes] = 255, raw += filter_bytes, cur += output_bytes, prior += output_bytes) \
             for (k = 0; k < filter_bytes; ++k)
-            switch (filter)
-            {
+            switch (filter) {
                 STBI__CASE(STBI__F_none) { cur[k] = raw[k]; }
                 break;
                 STBI__CASE(STBI__F_sub) { cur[k] = STBI__BYTECAST(raw[k] + cur[k - output_bytes]); }
@@ -5479,7 +4991,9 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
                 break;
                 STBI__CASE(STBI__F_avg) { cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k - output_bytes]) >> 1)); }
                 break;
-                STBI__CASE(STBI__F_paeth) { cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k - output_bytes], prior[k], prior[k - output_bytes])); }
+                STBI__CASE(STBI__F_paeth) {
+                    cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k - output_bytes], prior[k], prior[k - output_bytes]));
+                }
                 break;
                 STBI__CASE(STBI__F_avg_first) { cur[k] = STBI__BYTECAST(raw[k] + (cur[k - output_bytes] >> 1)); }
                 break;
@@ -5490,11 +5004,9 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
 
             // the loop above sets the high byte of the pixels' alpha, but for
             // 16 bit png files we also need the low byte set. we'll do that here.
-            if (depth == 16)
-            {
+            if (depth == 16) {
                 cur = a->out + stride * j; // start at the beginning of the row again
-                for (i = 0; i < x; ++i, cur += output_bytes)
-                {
+                for (i = 0; i < x; ++i, cur += output_bytes) {
                     cur[filter_bytes + 1] = 255;
                 }
             }
@@ -5504,14 +5016,13 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
     // we make a separate pass to expand bits to pixels; for performance,
     // this could run two scanlines behind the above code, so it won't
     // intefere with filtering but will still be in the cache.
-    if (depth < 8)
-    {
-        for (j = 0; j < y; ++j)
-        {
-            stbi_uc *cur = a->out + stride * j;
-            stbi_uc *in = a->out + stride * j + x * out_n - img_width_bytes;
-            // unpack 1/2/4-bit into a 8-bit buffer. allows us to keep the common 8-bit path optimal at minimal cost for 1/2/4-bit
-            // png guarante byte alignment, if width is not multiple of 8/4/2 we'll decode dummy trailing data that will be skipped in the later loop
+    if (depth < 8) {
+        for (j = 0; j < y; ++j) {
+            stbi_uc * cur = a->out + stride * j;
+            stbi_uc * in = a->out + stride * j + x * out_n - img_width_bytes;
+            // unpack 1/2/4-bit into a 8-bit buffer. allows us to keep the common 8-bit path optimal at minimal cost for
+            // 1/2/4-bit png guarante byte alignment, if width is not multiple of 8/4/2 we'll decode dummy trailing data that
+            // will be skipped in the later loop
             stbi_uc scale = (color == 0) ? stbi__depth_scale_table[depth] : 1; // scale grayscale values to 0..255 range
 
             // note that the final byte might overshoot and write more data than desired.
@@ -5520,20 +5031,15 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
             // on the next scanline? yes, consider 1-pixel-wide scanlines with 1-bit-per-pixel.
             // so we need to explicitly clamp the final ones
 
-            if (depth == 4)
-            {
-                for (k = x * img_n; k >= 2; k -= 2, ++in)
-                {
+            if (depth == 4) {
+                for (k = x * img_n; k >= 2; k -= 2, ++in) {
                     *cur++ = scale * ((*in >> 4));
                     *cur++ = scale * ((*in) & 0x0f);
                 }
                 if (k > 0)
                     *cur++ = scale * ((*in >> 4));
-            }
-            else if (depth == 2)
-            {
-                for (k = x * img_n; k >= 4; k -= 4, ++in)
-                {
+            } else if (depth == 2) {
+                for (k = x * img_n; k >= 4; k -= 4, ++in) {
                     *cur++ = scale * ((*in >> 6));
                     *cur++ = scale * ((*in >> 4) & 0x03);
                     *cur++ = scale * ((*in >> 2) & 0x03);
@@ -5545,11 +5051,8 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
                     *cur++ = scale * ((*in >> 4) & 0x03);
                 if (k > 2)
                     *cur++ = scale * ((*in >> 2) & 0x03);
-            }
-            else if (depth == 1)
-            {
-                for (k = x * img_n; k >= 8; k -= 8, ++in)
-                {
+            } else if (depth == 1) {
+                for (k = x * img_n; k >= 8; k -= 8, ++in) {
                     *cur++ = scale * ((*in >> 7));
                     *cur++ = scale * ((*in >> 6) & 0x01);
                     *cur++ = scale * ((*in >> 5) & 0x01);
@@ -5574,24 +5077,18 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
                 if (k > 6)
                     *cur++ = scale * ((*in >> 1) & 0x01);
             }
-            if (img_n != out_n)
-            {
+            if (img_n != out_n) {
                 int q;
                 // insert alpha = 255
                 cur = a->out + stride * j;
-                if (img_n == 1)
-                {
-                    for (q = x - 1; q >= 0; --q)
-                    {
+                if (img_n == 1) {
+                    for (q = x - 1; q >= 0; --q) {
                         cur[q * 2 + 1] = 255;
                         cur[q * 2 + 0] = cur[q];
                     }
-                }
-                else
-                {
+                } else {
                     STBI_ASSERT(img_n == 3);
-                    for (q = x - 1; q >= 0; --q)
-                    {
+                    for (q = x - 1; q >= 0; --q) {
                         cur[q * 4 + 3] = 255;
                         cur[q * 4 + 2] = cur[q * 3 + 2];
                         cur[q * 4 + 1] = cur[q * 3 + 1];
@@ -5600,18 +5097,15 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
                 }
             }
         }
-    }
-    else if (depth == 16)
-    {
+    } else if (depth == 16) {
         // force the image data from big-endian to platform-native.
         // this is done in a separate pass due to the decoding relying
         // on the data being untouched, but could probably be done
         // per-line during decode if care is taken.
-        stbi_uc *cur = a->out;
-        stbi__uint16 *cur16 = (stbi__uint16 *)cur;
+        stbi_uc * cur = a->out;
+        stbi__uint16 * cur16 = (stbi__uint16 *)cur;
 
-        for (i = 0; i < x * y * out_n; ++i, cur16++, cur += 2)
-        {
+        for (i = 0; i < x * y * out_n; ++i, cur16++, cur += 2) {
             *cur16 = (cur[0] << 8) | cur[1];
         }
     }
@@ -5619,11 +5113,11 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
     return 1;
 }
 
-static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint32 image_data_len, int out_n, int depth, int color, int interlaced)
-{
+static int stbi__create_png_image(stbi__png * a, stbi_uc * image_data, stbi__uint32 image_data_len, int out_n, int depth,
+                                  int color, int interlaced) {
     int bytes = (depth == 16 ? 2 : 1);
     int out_bytes = out_n * bytes;
-    stbi_uc *final;
+    stbi_uc * final;
     int p;
     if (!interlaced)
         return stbi__create_png_image_raw(a, image_data, image_data_len, out_n, a->s->img_x, a->s->img_y, depth, color);
@@ -5632,8 +5126,7 @@ static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint3
     final = (stbi_uc *)stbi__malloc_mad3(a->s->img_x, a->s->img_y, out_bytes, 0);
     if (!final)
         return stbi__err("outofmem", "Out of memory");
-    for (p = 0; p < 7; ++p)
-    {
+    for (p = 0; p < 7; ++p) {
         int xorig[] = {0, 4, 0, 2, 0, 1, 0};
         int yorig[] = {0, 0, 4, 0, 2, 0, 1};
         int xspc[] = {8, 8, 4, 4, 2, 2, 1};
@@ -5642,22 +5135,18 @@ static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint3
         // pass1_x[4] = 0, pass1_x[5] = 1, pass1_x[12] = 1
         x = (a->s->img_x - xorig[p] + xspc[p] - 1) / xspc[p];
         y = (a->s->img_y - yorig[p] + yspc[p] - 1) / yspc[p];
-        if (x && y)
-        {
+        if (x && y) {
             stbi__uint32 img_len = ((((a->s->img_n * x * depth) + 7) >> 3) + 1) * y;
-            if (!stbi__create_png_image_raw(a, image_data, image_data_len, out_n, x, y, depth, color))
-            {
+            if (!stbi__create_png_image_raw(a, image_data, image_data_len, out_n, x, y, depth, color)) {
                 STBI_FREE(final);
                 return 0;
             }
-            for (j = 0; j < y; ++j)
-            {
-                for (i = 0; i < x; ++i)
-                {
+            for (j = 0; j < y; ++j) {
+                for (i = 0; i < x; ++i) {
                     int out_y = j * yspc[p] + yorig[p];
                     int out_x = i * xspc[p] + xorig[p];
-                    memcpy(final + out_y * a->s->img_x * out_bytes + out_x * out_bytes,
-                           a->out + (j * x + i) * out_bytes, out_bytes);
+                    memcpy(final + out_y * a->s->img_x * out_bytes + out_x * out_bytes, a->out + (j * x + i) * out_bytes,
+                           out_bytes);
                 }
             }
             STBI_FREE(a->out);
@@ -5670,28 +5159,22 @@ static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint3
     return 1;
 }
 
-static int stbi__compute_transparency(stbi__png *z, stbi_uc tc[3], int out_n)
-{
-    stbi__context *s = z->s;
+static int stbi__compute_transparency(stbi__png * z, stbi_uc tc[3], int out_n) {
+    stbi__context * s = z->s;
     stbi__uint32 i, pixel_count = s->img_x * s->img_y;
-    stbi_uc *p = z->out;
+    stbi_uc * p = z->out;
 
     // compute color-based transparency, assuming we've
     // already got 255 as the alpha value in the output
     STBI_ASSERT(out_n == 2 || out_n == 4);
 
-    if (out_n == 2)
-    {
-        for (i = 0; i < pixel_count; ++i)
-        {
+    if (out_n == 2) {
+        for (i = 0; i < pixel_count; ++i) {
             p[1] = (p[0] == tc[0] ? 0 : 255);
             p += 2;
         }
-    }
-    else
-    {
-        for (i = 0; i < pixel_count; ++i)
-        {
+    } else {
+        for (i = 0; i < pixel_count; ++i) {
             if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
                 p[3] = 0;
             p += 4;
@@ -5700,28 +5183,22 @@ static int stbi__compute_transparency(stbi__png *z, stbi_uc tc[3], int out_n)
     return 1;
 }
 
-static int stbi__compute_transparency16(stbi__png *z, stbi__uint16 tc[3], int out_n)
-{
-    stbi__context *s = z->s;
+static int stbi__compute_transparency16(stbi__png * z, stbi__uint16 tc[3], int out_n) {
+    stbi__context * s = z->s;
     stbi__uint32 i, pixel_count = s->img_x * s->img_y;
-    stbi__uint16 *p = (stbi__uint16 *)z->out;
+    stbi__uint16 * p = (stbi__uint16 *)z->out;
 
     // compute color-based transparency, assuming we've
     // already got 65535 as the alpha value in the output
     STBI_ASSERT(out_n == 2 || out_n == 4);
 
-    if (out_n == 2)
-    {
-        for (i = 0; i < pixel_count; ++i)
-        {
+    if (out_n == 2) {
+        for (i = 0; i < pixel_count; ++i) {
             p[1] = (p[0] == tc[0] ? 0 : 65535);
             p += 2;
         }
-    }
-    else
-    {
-        for (i = 0; i < pixel_count; ++i)
-        {
+    } else {
+        for (i = 0; i < pixel_count; ++i) {
             if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
                 p[3] = 0;
             p += 4;
@@ -5730,8 +5207,7 @@ static int stbi__compute_transparency16(stbi__png *z, stbi__uint16 tc[3], int ou
     return 1;
 }
 
-static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int pal_img_n)
-{
+static int stbi__expand_png_palette(stbi__png * a, stbi_uc * palette, int len, int pal_img_n) {
     stbi__uint32 i, pixel_count = a->s->img_x * a->s->img_y;
     stbi_uc *p, *temp_out, *orig = a->out;
 
@@ -5742,21 +5218,16 @@ static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int
     // between here and free(out) below, exitting would leak
     temp_out = p;
 
-    if (pal_img_n == 3)
-    {
-        for (i = 0; i < pixel_count; ++i)
-        {
+    if (pal_img_n == 3) {
+        for (i = 0; i < pixel_count; ++i) {
             int n = orig[i] * 4;
             p[0] = palette[n];
             p[1] = palette[n + 1];
             p[2] = palette[n + 2];
             p += 3;
         }
-    }
-    else
-    {
-        for (i = 0; i < pixel_count; ++i)
-        {
+    } else {
+        for (i = 0; i < pixel_count; ++i) {
             int n = orig[i] * 4;
             p[0] = palette[n];
             p[1] = palette[n + 1];
@@ -5776,13 +5247,11 @@ static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int
 static int stbi__unpremultiply_on_load_global = 0;
 static int stbi__de_iphone_flag_global = 0;
 
-STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply)
-{
+STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply) {
     stbi__unpremultiply_on_load_global = flag_true_if_should_unpremultiply;
 }
 
-STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert)
-{
+STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert) {
     stbi__de_iphone_flag_global = flag_true_if_should_convert;
 }
 
@@ -5793,72 +5262,54 @@ STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert)
 static STBI_THREAD_LOCAL int stbi__unpremultiply_on_load_local, stbi__unpremultiply_on_load_set;
 static STBI_THREAD_LOCAL int stbi__de_iphone_flag_local, stbi__de_iphone_flag_set;
 
-STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply)
-{
+STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply) {
     stbi__unpremultiply_on_load_local = flag_true_if_should_unpremultiply;
     stbi__unpremultiply_on_load_set = 1;
 }
 
-STBIDEF void stbi_convert_iphone_png_to_rgb_thread(int flag_true_if_should_convert)
-{
+STBIDEF void stbi_convert_iphone_png_to_rgb_thread(int flag_true_if_should_convert) {
     stbi__de_iphone_flag_local = flag_true_if_should_convert;
     stbi__de_iphone_flag_set = 1;
 }
 
-#define stbi__unpremultiply_on_load (stbi__unpremultiply_on_load_set         \
-                                         ? stbi__unpremultiply_on_load_local \
-                                         : stbi__unpremultiply_on_load_global)
-#define stbi__de_iphone_flag (stbi__de_iphone_flag_set         \
-                                  ? stbi__de_iphone_flag_local \
-                                  : stbi__de_iphone_flag_global)
+#define stbi__unpremultiply_on_load                                                                                            \
+    (stbi__unpremultiply_on_load_set ? stbi__unpremultiply_on_load_local : stbi__unpremultiply_on_load_global)
+#define stbi__de_iphone_flag (stbi__de_iphone_flag_set ? stbi__de_iphone_flag_local : stbi__de_iphone_flag_global)
 #endif // STBI_THREAD_LOCAL
 
-static void stbi__de_iphone(stbi__png *z)
-{
-    stbi__context *s = z->s;
+static void stbi__de_iphone(stbi__png * z) {
+    stbi__context * s = z->s;
     stbi__uint32 i, pixel_count = s->img_x * s->img_y;
-    stbi_uc *p = z->out;
+    stbi_uc * p = z->out;
 
-    if (s->img_out_n == 3)
-    { // convert bgr to rgb
-        for (i = 0; i < pixel_count; ++i)
-        {
+    if (s->img_out_n == 3) { // convert bgr to rgb
+        for (i = 0; i < pixel_count; ++i) {
             stbi_uc t = p[0];
             p[0] = p[2];
             p[2] = t;
             p += 3;
         }
-    }
-    else
-    {
+    } else {
         STBI_ASSERT(s->img_out_n == 4);
-        if (stbi__unpremultiply_on_load)
-        {
+        if (stbi__unpremultiply_on_load) {
             // convert bgr to rgb and unpremultiply
-            for (i = 0; i < pixel_count; ++i)
-            {
+            for (i = 0; i < pixel_count; ++i) {
                 stbi_uc a = p[3];
                 stbi_uc t = p[0];
-                if (a)
-                {
+                if (a) {
                     stbi_uc half = a / 2;
                     p[0] = (p[2] * 255 + half) / a;
                     p[1] = (p[1] * 255 + half) / a;
                     p[2] = (t * 255 + half) / a;
-                }
-                else
-                {
+                } else {
                     p[0] = p[2];
                     p[2] = t;
                 }
                 p += 4;
             }
-        }
-        else
-        {
+        } else {
             // convert bgr to rgb
-            for (i = 0; i < pixel_count; ++i)
-            {
+            for (i = 0; i < pixel_count; ++i) {
                 stbi_uc t = p[0];
                 p[0] = p[2];
                 p[2] = t;
@@ -5870,14 +5321,13 @@ static void stbi__de_iphone(stbi__png *z)
 
 #define STBI__PNG_TYPE(a, b, c, d) (((unsigned)(a) << 24) + ((unsigned)(b) << 16) + ((unsigned)(c) << 8) + (unsigned)(d))
 
-static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
-{
+static int stbi__parse_png_file(stbi__png * z, int scan, int req_comp) {
     stbi_uc palette[1024], pal_img_n = 0;
     stbi_uc has_trans = 0, tc[3] = {0};
     stbi__uint16 tc16[3];
     stbi__uint32 ioff = 0, idata_limit = 0, i, pal_len = 0;
     int first = 1, k, interlace = 0, color = 0, is_iphone = 0;
-    stbi__context *s = z->s;
+    stbi__context * s = z->s;
 
     z->expanded = NULL;
     z->idata = NULL;
@@ -5889,17 +5339,14 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
     if (scan == STBI__SCAN_type)
         return 1;
 
-    for (;;)
-    {
+    for (;;) {
         stbi__pngchunk c = stbi__get_chunk_header(s);
-        switch (c.type)
-        {
+        switch (c.type) {
         case STBI__PNG_TYPE('C', 'g', 'B', 'I'):
             is_iphone = 1;
             stbi__skip(s, c.length);
             break;
-        case STBI__PNG_TYPE('I', 'H', 'D', 'R'):
-        {
+        case STBI__PNG_TYPE('I', 'H', 'D', 'R'): {
             int comp, filter;
             if (!first)
                 return stbi__err("multiple IHDR", "Corrupt PNG");
@@ -5935,14 +5382,11 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                 return stbi__err("bad interlace method", "Corrupt PNG");
             if (!s->img_x || !s->img_y)
                 return stbi__err("0-pixel image", "Corrupt PNG");
-            if (!pal_img_n)
-            {
+            if (!pal_img_n) {
                 s->img_n = (color & 2 ? 3 : 1) + (color & 4 ? 1 : 0);
                 if ((1 << 30) / s->img_x / s->img_n < s->img_y)
                     return stbi__err("too large", "Image too large to decode");
-            }
-            else
-            {
+            } else {
                 // if paletted, then pal_n is our final components, and
                 // img_n is # components to decompress/filter.
                 s->img_n = 1;
@@ -5953,8 +5397,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             break;
         }
 
-        case STBI__PNG_TYPE('P', 'L', 'T', 'E'):
-        {
+        case STBI__PNG_TYPE('P', 'L', 'T', 'E'): {
             if (first)
                 return stbi__err("first not IHDR", "Corrupt PNG");
             if (c.length > 256 * 3)
@@ -5962,8 +5405,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             pal_len = c.length / 3;
             if (pal_len * 3 != c.length)
                 return stbi__err("invalid PLTE", "Corrupt PNG");
-            for (i = 0; i < pal_len; ++i)
-            {
+            for (i = 0; i < pal_len; ++i) {
                 palette[i * 4 + 0] = stbi__get8(s);
                 palette[i * 4 + 1] = stbi__get8(s);
                 palette[i * 4 + 2] = stbi__get8(s);
@@ -5972,16 +5414,13 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             break;
         }
 
-        case STBI__PNG_TYPE('t', 'R', 'N', 'S'):
-        {
+        case STBI__PNG_TYPE('t', 'R', 'N', 'S'): {
             if (first)
                 return stbi__err("first not IHDR", "Corrupt PNG");
             if (z->idata)
                 return stbi__err("tRNS after IDAT", "Corrupt PNG");
-            if (pal_img_n)
-            {
-                if (scan == STBI__SCAN_header)
-                {
+            if (pal_img_n) {
+                if (scan == STBI__SCAN_header) {
                     s->img_n = 4;
                     return 1;
                 }
@@ -5992,42 +5431,35 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                 pal_img_n = 4;
                 for (i = 0; i < c.length; ++i)
                     palette[i * 4 + 3] = stbi__get8(s);
-            }
-            else
-            {
+            } else {
                 if (!(s->img_n & 1))
                     return stbi__err("tRNS with alpha", "Corrupt PNG");
                 if (c.length != (stbi__uint32)s->img_n * 2)
                     return stbi__err("bad tRNS len", "Corrupt PNG");
                 has_trans = 1;
                 // non-paletted with tRNS = constant alpha. if header-scanning, we can stop now.
-                if (scan == STBI__SCAN_header)
-                {
+                if (scan == STBI__SCAN_header) {
                     ++s->img_n;
                     return 1;
                 }
-                if (z->depth == 16)
-                {
+                if (z->depth == 16) {
                     for (k = 0; k < s->img_n; ++k)
                         tc16[k] = (stbi__uint16)stbi__get16be(s); // copy the values as-is
-                }
-                else
-                {
+                } else {
                     for (k = 0; k < s->img_n; ++k)
-                        tc[k] = (stbi_uc)(stbi__get16be(s) & 255) * stbi__depth_scale_table[z->depth]; // non 8-bit images will be larger
+                        tc[k] = (stbi_uc)(stbi__get16be(s) & 255) *
+                                stbi__depth_scale_table[z->depth]; // non 8-bit images will be larger
                 }
             }
             break;
         }
 
-        case STBI__PNG_TYPE('I', 'D', 'A', 'T'):
-        {
+        case STBI__PNG_TYPE('I', 'D', 'A', 'T'): {
             if (first)
                 return stbi__err("first not IHDR", "Corrupt PNG");
             if (pal_img_n && !pal_len)
                 return stbi__err("no PLTE", "Corrupt PNG");
-            if (scan == STBI__SCAN_header)
-            {
+            if (scan == STBI__SCAN_header) {
                 // header scan definitely stops at first IDAT
                 if (pal_img_n)
                     s->img_n = pal_img_n;
@@ -6037,10 +5469,9 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                 return stbi__err("IDAT size limit", "IDAT section larger than 2^30 bytes");
             if ((int)(ioff + c.length) < (int)ioff)
                 return 0;
-            if (ioff + c.length > idata_limit)
-            {
+            if (ioff + c.length > idata_limit) {
                 stbi__uint32 idata_limit_old = idata_limit;
-                stbi_uc *p;
+                stbi_uc * p;
                 if (idata_limit == 0)
                     idata_limit = c.length > 4096 ? c.length : 4096;
                 while (ioff + c.length > idata_limit)
@@ -6057,8 +5488,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             break;
         }
 
-        case STBI__PNG_TYPE('I', 'E', 'N', 'D'):
-        {
+        case STBI__PNG_TYPE('I', 'E', 'N', 'D'): {
             stbi__uint32 raw_len, bpl;
             if (first)
                 return stbi__err("first not IHDR", "Corrupt PNG");
@@ -6069,7 +5499,8 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             // initial guess for decoded data size to avoid unnecessary reallocs
             bpl = (s->img_x * z->depth + 7) / 8; // bytes per line, per component
             raw_len = bpl * s->img_y * s->img_n /* pixels */ + s->img_y /* filter mode per row */;
-            z->expanded = (stbi_uc *)stbi_zlib_decode_malloc_guesssize_headerflag((char *)z->idata, ioff, raw_len, (int *)&raw_len, !is_iphone);
+            z->expanded = (stbi_uc *)stbi_zlib_decode_malloc_guesssize_headerflag((char *)z->idata, ioff, raw_len,
+                                                                                  (int *)&raw_len, !is_iphone);
             if (z->expanded == NULL)
                 return 0; // zlib should set error
             STBI_FREE(z->idata);
@@ -6080,23 +5511,18 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                 s->img_out_n = s->img_n;
             if (!stbi__create_png_image(z, z->expanded, raw_len, s->img_out_n, z->depth, color, interlace))
                 return 0;
-            if (has_trans)
-            {
-                if (z->depth == 16)
-                {
+            if (has_trans) {
+                if (z->depth == 16) {
                     if (!stbi__compute_transparency16(z, tc16, s->img_out_n))
                         return 0;
-                }
-                else
-                {
+                } else {
                     if (!stbi__compute_transparency(z, tc, s->img_out_n))
                         return 0;
                 }
             }
             if (is_iphone && stbi__de_iphone_flag && s->img_out_n > 2)
                 stbi__de_iphone(z);
-            if (pal_img_n)
-            {
+            if (pal_img_n) {
                 // pal_img_n == 3 or 4
                 s->img_n = pal_img_n; // record the actual colors we had
                 s->img_out_n = pal_img_n;
@@ -6104,9 +5530,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                     s->img_out_n = req_comp;
                 if (!stbi__expand_png_palette(z, palette, pal_len, s->img_out_n))
                     return 0;
-            }
-            else if (has_trans)
-            {
+            } else if (has_trans) {
                 // non-paletted image with tRNS -> source image has (constant) alpha
                 ++s->img_n;
             }
@@ -6121,8 +5545,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
             // if critical, fail
             if (first)
                 return stbi__err("first not IHDR", "Corrupt PNG");
-            if ((c.type & (1 << 29)) == 0)
-            {
+            if ((c.type & (1 << 29)) == 0) {
 #ifndef STBI_NO_FAILURE_STRINGS
                 // not threadsafe
                 static char invalid_chunk[] = "XXXX PNG chunk not known";
@@ -6141,13 +5564,11 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
     }
 }
 
-static void *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp, stbi__result_info *ri)
-{
-    void *result = NULL;
+static void * stbi__do_png(stbi__png * p, int * x, int * y, int * n, int req_comp, stbi__result_info * ri) {
+    void * result = NULL;
     if (req_comp < 0 || req_comp > 4)
         return stbi__errpuc("bad req_comp", "Internal error");
-    if (stbi__parse_png_file(p, STBI__SCAN_load, req_comp))
-    {
+    if (stbi__parse_png_file(p, STBI__SCAN_load, req_comp)) {
         if (p->depth <= 8)
             ri->bits_per_channel = 8;
         else if (p->depth == 16)
@@ -6156,8 +5577,7 @@ static void *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp, st
             return stbi__errpuc("bad bits_per_channel", "PNG not supported: unsupported color depth");
         result = p->out;
         p->out = NULL;
-        if (req_comp && req_comp != p->s->img_out_n)
-        {
+        if (req_comp && req_comp != p->s->img_out_n) {
             if (ri->bits_per_channel == 8)
                 result = stbi__convert_format((unsigned char *)result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
             else
@@ -6181,25 +5601,21 @@ static void *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp, st
     return result;
 }
 
-static void *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
-{
+static void * stbi__png_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri) {
     stbi__png p;
     p.s = s;
     return stbi__do_png(&p, x, y, comp, req_comp, ri);
 }
 
-static int stbi__png_test(stbi__context *s)
-{
+static int stbi__png_test(stbi__context * s) {
     int r;
     r = stbi__check_png_header(s);
     stbi__rewind(s);
     return r;
 }
 
-static int stbi__png_info_raw(stbi__png *p, int *x, int *y, int *comp)
-{
-    if (!stbi__parse_png_file(p, STBI__SCAN_header, 0))
-    {
+static int stbi__png_info_raw(stbi__png * p, int * x, int * y, int * comp) {
+    if (!stbi__parse_png_file(p, STBI__SCAN_header, 0)) {
         stbi__rewind(p->s);
         return 0;
     }
@@ -6212,21 +5628,18 @@ static int stbi__png_info_raw(stbi__png *p, int *x, int *y, int *comp)
     return 1;
 }
 
-static int stbi__png_info(stbi__context *s, int *x, int *y, int *comp)
-{
+static int stbi__png_info(stbi__context * s, int * x, int * y, int * comp) {
     stbi__png p;
     p.s = s;
     return stbi__png_info_raw(&p, x, y, comp);
 }
 
-static int stbi__png_is16(stbi__context *s)
-{
+static int stbi__png_is16(stbi__context * s) {
     stbi__png p;
     p.s = s;
     if (!stbi__png_info_raw(&p, NULL, NULL, NULL))
         return 0;
-    if (p.depth != 16)
-    {
+    if (p.depth != 16) {
         stbi__rewind(p.s);
         return 0;
     }
@@ -6237,8 +5650,7 @@ static int stbi__png_is16(stbi__context *s)
 // Microsoft/Windows BMP image
 
 #ifndef STBI_NO_BMP
-static int stbi__bmp_test_raw(stbi__context *s)
-{
+static int stbi__bmp_test_raw(stbi__context * s) {
     int r;
     int sz;
     if (stbi__get8(s) != 'B')
@@ -6254,48 +5666,40 @@ static int stbi__bmp_test_raw(stbi__context *s)
     return r;
 }
 
-static int stbi__bmp_test(stbi__context *s)
-{
+static int stbi__bmp_test(stbi__context * s) {
     int r = stbi__bmp_test_raw(s);
     stbi__rewind(s);
     return r;
 }
 
 // returns 0..31 for the highest set bit
-static int stbi__high_bit(unsigned int z)
-{
+static int stbi__high_bit(unsigned int z) {
     int n = 0;
     if (z == 0)
         return -1;
-    if (z >= 0x10000)
-    {
+    if (z >= 0x10000) {
         n += 16;
         z >>= 16;
     }
-    if (z >= 0x00100)
-    {
+    if (z >= 0x00100) {
         n += 8;
         z >>= 8;
     }
-    if (z >= 0x00010)
-    {
+    if (z >= 0x00010) {
         n += 4;
         z >>= 4;
     }
-    if (z >= 0x00004)
-    {
+    if (z >= 0x00004) {
         n += 2;
         z >>= 2;
     }
-    if (z >= 0x00002)
-    {
+    if (z >= 0x00002) {
         n += 1; /* >>=  1;*/
     }
     return n;
 }
 
-static int stbi__bitcount(unsigned int a)
-{
+static int stbi__bitcount(unsigned int a) {
     a = (a & 0x55555555) + ((a >> 1) & 0x55555555); // max 2
     a = (a & 0x33333333) + ((a >> 2) & 0x33333333); // max 4
     a = (a + (a >> 4)) & 0x0f0f0f0f;                // max 8 per 4, now 8 bits
@@ -6307,8 +5711,7 @@ static int stbi__bitcount(unsigned int a)
 // extract an arbitrarily-aligned N-bit value (N=bits)
 // from v, and then make it 8-bits long and fractionally
 // extend it to full full range.
-static int stbi__shiftsigned(unsigned int v, int shift, int bits)
-{
+static int stbi__shiftsigned(unsigned int v, int shift, int bits) {
     static unsigned int mul_table[9] = {
         0,
         0xff /*0b11111111*/,
@@ -6321,15 +5724,7 @@ static int stbi__shiftsigned(unsigned int v, int shift, int bits)
         0x01 /*0b00000001*/,
     };
     static unsigned int shift_table[9] = {
-        0,
-        0,
-        0,
-        1,
-        0,
-        2,
-        4,
-        6,
-        0,
+        0, 0, 0, 1, 0, 2, 4, 6, 0,
     };
     if (shift < 0)
         v <<= -shift;
@@ -6341,37 +5736,29 @@ static int stbi__shiftsigned(unsigned int v, int shift, int bits)
     return (int)((unsigned)v * mul_table[bits]) >> shift_table[bits];
 }
 
-typedef struct
-{
+typedef struct {
     int bpp, offset, hsz;
     unsigned int mr, mg, mb, ma, all_a;
     int extra_read;
 } stbi__bmp_data;
 
-static int stbi__bmp_set_mask_defaults(stbi__bmp_data *info, int compress)
-{
+static int stbi__bmp_set_mask_defaults(stbi__bmp_data * info, int compress) {
     // BI_BITFIELDS specifies masks explicitly, don't override
     if (compress == 3)
         return 1;
 
-    if (compress == 0)
-    {
-        if (info->bpp == 16)
-        {
+    if (compress == 0) {
+        if (info->bpp == 16) {
             info->mr = 31u << 10;
             info->mg = 31u << 5;
             info->mb = 31u << 0;
-        }
-        else if (info->bpp == 32)
-        {
+        } else if (info->bpp == 32) {
             info->mr = 0xffu << 16;
             info->mg = 0xffu << 8;
             info->mb = 0xffu << 0;
             info->ma = 0xffu << 24;
             info->all_a = 0; // if all_a is 0 at end, then we loaded alpha channel but it was all 0
-        }
-        else
-        {
+        } else {
             // otherwise, use defaults, which is all-0
             info->mr = info->mg = info->mb = info->ma = 0;
         }
@@ -6380,8 +5767,7 @@ static int stbi__bmp_set_mask_defaults(stbi__bmp_data *info, int compress)
     return 0; // error
 }
 
-static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
-{
+static void * stbi__bmp_parse_header(stbi__context * s, stbi__bmp_data * info) {
     int hsz;
     if (stbi__get8(s) != 'B' || stbi__get8(s) != 'M')
         return stbi__errpuc("not BMP", "Corrupt BMP");
@@ -6398,26 +5784,23 @@ static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
 
     if (hsz != 12 && hsz != 40 && hsz != 56 && hsz != 108 && hsz != 124)
         return stbi__errpuc("unknown BMP", "BMP type not supported: unknown");
-    if (hsz == 12)
-    {
+    if (hsz == 12) {
         s->img_x = stbi__get16le(s);
         s->img_y = stbi__get16le(s);
-    }
-    else
-    {
+    } else {
         s->img_x = stbi__get32le(s);
         s->img_y = stbi__get32le(s);
     }
     if (stbi__get16le(s) != 1)
         return stbi__errpuc("bad BMP", "bad BMP");
     info->bpp = stbi__get16le(s);
-    if (hsz != 12)
-    {
+    if (hsz != 12) {
         int compress = stbi__get32le(s);
         if (compress == 1 || compress == 2)
             return stbi__errpuc("BMP RLE", "BMP type not supported: RLE");
         if (compress >= 4)
-            return stbi__errpuc("BMP JPEG/PNG", "BMP type not supported: unsupported compression"); // this includes PNG/JPEG modes
+            return stbi__errpuc("BMP JPEG/PNG",
+                                "BMP type not supported: unsupported compression"); // this includes PNG/JPEG modes
         if (compress == 3 && info->bpp != 16 && info->bpp != 32)
             return stbi__errpuc("bad BMP", "bad BMP"); // bitfields requires 16 or 32 bits/pixel
         stbi__get32le(s);                              // discard sizeof
@@ -6425,40 +5808,30 @@ static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
         stbi__get32le(s);                              // discard vres
         stbi__get32le(s);                              // discard colorsused
         stbi__get32le(s);                              // discard max important
-        if (hsz == 40 || hsz == 56)
-        {
-            if (hsz == 56)
-            {
+        if (hsz == 40 || hsz == 56) {
+            if (hsz == 56) {
                 stbi__get32le(s);
                 stbi__get32le(s);
                 stbi__get32le(s);
                 stbi__get32le(s);
             }
-            if (info->bpp == 16 || info->bpp == 32)
-            {
-                if (compress == 0)
-                {
+            if (info->bpp == 16 || info->bpp == 32) {
+                if (compress == 0) {
                     stbi__bmp_set_mask_defaults(info, compress);
-                }
-                else if (compress == 3)
-                {
+                } else if (compress == 3) {
                     info->mr = stbi__get32le(s);
                     info->mg = stbi__get32le(s);
                     info->mb = stbi__get32le(s);
                     info->extra_read += 12;
                     // not documented, but generated by photoshop and handled by mspaint
-                    if (info->mr == info->mg && info->mg == info->mb)
-                    {
+                    if (info->mr == info->mg && info->mg == info->mb) {
                         // ?!?!?
                         return stbi__errpuc("bad BMP", "bad BMP");
                     }
-                }
-                else
+                } else
                     return stbi__errpuc("bad BMP", "bad BMP");
             }
-        }
-        else
-        {
+        } else {
             // V4/V5 header
             int i;
             if (hsz != 108 && hsz != 124)
@@ -6472,8 +5845,7 @@ static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
             stbi__get32le(s); // discard color space
             for (i = 0; i < 12; ++i)
                 stbi__get32le(s); // discard color space parameters
-            if (hsz == 124)
-            {
+            if (hsz == 124) {
                 stbi__get32le(s); // discard rendering intent
                 stbi__get32le(s); // discard offset of profile data
                 stbi__get32le(s); // discard size of profile data
@@ -6484,9 +5856,8 @@ static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
     return (void *)1;
 }
 
-static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
-{
-    stbi_uc *out;
+static void * stbi__bmp_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri) {
+    stbi_uc * out;
     unsigned int mr = 0, mg = 0, mb = 0, ma = 0, all_a;
     stbi_uc pal[256][4];
     int psize = 0, i, j, width;
@@ -6512,37 +5883,29 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
     ma = info.ma;
     all_a = info.all_a;
 
-    if (info.hsz == 12)
-    {
+    if (info.hsz == 12) {
         if (info.bpp < 24)
             psize = (info.offset - info.extra_read - 24) / 3;
-    }
-    else
-    {
+    } else {
         if (info.bpp < 16)
             psize = (info.offset - info.extra_read - info.hsz) >> 2;
     }
-    if (psize == 0)
-    {
+    if (psize == 0) {
         // accept some number of extra bytes after the header, but if the offset points either to before
         // the header ends or implies a large amount of extra data, reject the file as malformed
         int bytes_read_so_far = s->callback_already_read + (int)(s->img_buffer - s->img_buffer_original);
         int header_limit = 1024;        // max we actually read is below 256 bytes currently.
         int extra_data_limit = 256 * 4; // what ordinarily goes here is a palette; 256 entries*4 bytes is its max size.
-        if (bytes_read_so_far <= 0 || bytes_read_so_far > header_limit)
-        {
+        if (bytes_read_so_far <= 0 || bytes_read_so_far > header_limit) {
             return stbi__errpuc("bad header", "Corrupt BMP");
         }
         // we established that bytes_read_so_far is positive and sensible.
         // the first half of this test rejects offsets that are either too small positives, or
         // negative, and guarantees that info.offset >= bytes_read_so_far > 0. this in turn
         // ensures the number computed in the second half of the test can't overflow.
-        if (info.offset < bytes_read_so_far || info.offset - bytes_read_so_far > extra_data_limit)
-        {
+        if (info.offset < bytes_read_so_far || info.offset - bytes_read_so_far > extra_data_limit) {
             return stbi__errpuc("bad offset", "Corrupt BMP");
-        }
-        else
-        {
+        } else {
             stbi__skip(s, info.offset - bytes_read_so_far);
         }
     }
@@ -6563,16 +5926,13 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
     out = (stbi_uc *)stbi__malloc_mad3(target, s->img_x, s->img_y, 0);
     if (!out)
         return stbi__errpuc("outofmem", "Out of memory");
-    if (info.bpp < 16)
-    {
+    if (info.bpp < 16) {
         int z = 0;
-        if (psize == 0 || psize > 256)
-        {
+        if (psize == 0 || psize > 256) {
             STBI_FREE(out);
             return stbi__errpuc("invalid", "Corrupt BMP");
         }
-        for (i = 0; i < psize; ++i)
-        {
+        for (i = 0; i < psize; ++i) {
             pal[i][2] = stbi__get8(s);
             pal[i][1] = stbi__get8(s);
             pal[i][0] = stbi__get8(s);
@@ -6587,19 +5947,15 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
             width = (s->img_x + 1) >> 1;
         else if (info.bpp == 8)
             width = s->img_x;
-        else
-        {
+        else {
             STBI_FREE(out);
             return stbi__errpuc("bad bpp", "Corrupt BMP");
         }
         pad = (-width) & 3;
-        if (info.bpp == 1)
-        {
-            for (j = 0; j < (int)s->img_y; ++j)
-            {
+        if (info.bpp == 1) {
+            for (j = 0; j < (int)s->img_y; ++j) {
                 int bit_offset = 7, v = stbi__get8(s);
-                for (i = 0; i < (int)s->img_x; ++i)
-                {
+                for (i = 0; i < (int)s->img_x; ++i) {
                     int color = (v >> bit_offset) & 0x1;
                     out[z++] = pal[color][0];
                     out[z++] = pal[color][1];
@@ -6608,24 +5964,18 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
                         out[z++] = 255;
                     if (i + 1 == (int)s->img_x)
                         break;
-                    if ((--bit_offset) < 0)
-                    {
+                    if ((--bit_offset) < 0) {
                         bit_offset = 7;
                         v = stbi__get8(s);
                     }
                 }
                 stbi__skip(s, pad);
             }
-        }
-        else
-        {
-            for (j = 0; j < (int)s->img_y; ++j)
-            {
-                for (i = 0; i < (int)s->img_x; i += 2)
-                {
+        } else {
+            for (j = 0; j < (int)s->img_y; ++j) {
+                for (i = 0; i < (int)s->img_x; i += 2) {
                     int v = stbi__get8(s), v2 = 0;
-                    if (info.bpp == 4)
-                    {
+                    if (info.bpp == 4) {
                         v2 = v & 15;
                         v >>= 4;
                     }
@@ -6646,9 +5996,7 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
                 stbi__skip(s, pad);
             }
         }
-    }
-    else
-    {
+    } else {
         int rshift = 0, gshift = 0, bshift = 0, ashift = 0, rcount = 0, gcount = 0, bcount = 0, acount = 0;
         int z = 0;
         int easy = 0;
@@ -6660,19 +6008,14 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
         else /* bpp = 32 and pad = 0 */
             width = 0;
         pad = (-width) & 3;
-        if (info.bpp == 24)
-        {
+        if (info.bpp == 24) {
             easy = 1;
-        }
-        else if (info.bpp == 32)
-        {
+        } else if (info.bpp == 32) {
             if (mb == 0xff && mg == 0xff00 && mr == 0x00ff0000 && ma == 0xff000000)
                 easy = 2;
         }
-        if (!easy)
-        {
-            if (!mr || !mg || !mb)
-            {
+        if (!easy) {
+            if (!mr || !mg || !mb) {
                 STBI_FREE(out);
                 return stbi__errpuc("bad masks", "Corrupt BMP");
             }
@@ -6685,18 +6028,14 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
             bcount = stbi__bitcount(mb);
             ashift = stbi__high_bit(ma) - 7;
             acount = stbi__bitcount(ma);
-            if (rcount > 8 || gcount > 8 || bcount > 8 || acount > 8)
-            {
+            if (rcount > 8 || gcount > 8 || bcount > 8 || acount > 8) {
                 STBI_FREE(out);
                 return stbi__errpuc("bad masks", "Corrupt BMP");
             }
         }
-        for (j = 0; j < (int)s->img_y; ++j)
-        {
-            if (easy)
-            {
-                for (i = 0; i < (int)s->img_x; ++i)
-                {
+        for (j = 0; j < (int)s->img_y; ++j) {
+            if (easy) {
+                for (i = 0; i < (int)s->img_x; ++i) {
                     unsigned char a;
                     out[z + 2] = stbi__get8(s);
                     out[z + 1] = stbi__get8(s);
@@ -6707,12 +6046,9 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
                     if (target == 4)
                         out[z++] = a;
                 }
-            }
-            else
-            {
+            } else {
                 int bpp = info.bpp;
-                for (i = 0; i < (int)s->img_x; ++i)
-                {
+                for (i = 0; i < (int)s->img_x; ++i) {
                     stbi__uint32 v = (bpp == 16 ? (stbi__uint32)stbi__get16le(s) : stbi__get32le(s));
                     unsigned int a;
                     out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mr, rshift, rcount));
@@ -6733,15 +6069,12 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
         for (i = 4 * s->img_x * s->img_y - 1; i >= 0; i -= 4)
             out[i] = 255;
 
-    if (flip_vertically)
-    {
+    if (flip_vertically) {
         stbi_uc t;
-        for (j = 0; j < (int)s->img_y >> 1; ++j)
-        {
-            stbi_uc *p1 = out + j * s->img_x * target;
-            stbi_uc *p2 = out + (s->img_y - 1 - j) * s->img_x * target;
-            for (i = 0; i < (int)s->img_x * target; ++i)
-            {
+        for (j = 0; j < (int)s->img_y >> 1; ++j) {
+            stbi_uc * p1 = out + j * s->img_x * target;
+            stbi_uc * p2 = out + (s->img_y - 1 - j) * s->img_x * target;
+            for (i = 0; i < (int)s->img_x * target; ++i) {
                 t = p1[i];
                 p1[i] = p2[i];
                 p2[i] = t;
@@ -6749,8 +6082,7 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
         }
     }
 
-    if (req_comp && req_comp != target)
-    {
+    if (req_comp && req_comp != target) {
         out = stbi__convert_format(out, target, req_comp, s->img_x, s->img_y);
         if (out == NULL)
             return out; // stbi__convert_format frees input on failure
@@ -6768,13 +6100,11 @@ static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req
 // by Jonathan Dummer
 #ifndef STBI_NO_TGA
 // returns STBI_rgb or whatever, 0 on error
-static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int *is_rgb16)
-{
+static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int * is_rgb16) {
     // only RGB or RGBA (incl. 16bit) or grey allowed
     if (is_rgb16)
         *is_rgb16 = 0;
-    switch (bits_per_pixel)
-    {
+    switch (bits_per_pixel) {
     case 8:
         return STBI_grey;
     case 16:
@@ -6793,39 +6123,31 @@ static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int *is_rgb16)
     }
 }
 
-static int stbi__tga_info(stbi__context *s, int *x, int *y, int *comp)
-{
+static int stbi__tga_info(stbi__context * s, int * x, int * y, int * comp) {
     int tga_w, tga_h, tga_comp, tga_image_type, tga_bits_per_pixel, tga_colormap_bpp;
     int sz, tga_colormap_type;
     stbi__get8(s);                     // discard Offset
     tga_colormap_type = stbi__get8(s); // colormap type
-    if (tga_colormap_type > 1)
-    {
+    if (tga_colormap_type > 1) {
         stbi__rewind(s);
         return 0; // only RGB or indexed allowed
     }
     tga_image_type = stbi__get8(s); // image type
-    if (tga_colormap_type == 1)
-    { // colormapped (paletted) image
-        if (tga_image_type != 1 && tga_image_type != 9)
-        {
+    if (tga_colormap_type == 1) {   // colormapped (paletted) image
+        if (tga_image_type != 1 && tga_image_type != 9) {
             stbi__rewind(s);
             return 0;
         }
         stbi__skip(s, 4);   // skip index of first colormap entry and number of entries
         sz = stbi__get8(s); //   check bits per palette color entry
-        if ((sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32))
-        {
+        if ((sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32)) {
             stbi__rewind(s);
             return 0;
         }
         stbi__skip(s, 4); // skip image x and y origin
         tga_colormap_bpp = sz;
-    }
-    else
-    { // "normal" image w/o colormap - only RGB or grey allowed, +/- RLE
-        if ((tga_image_type != 2) && (tga_image_type != 3) && (tga_image_type != 10) && (tga_image_type != 11))
-        {
+    } else { // "normal" image w/o colormap - only RGB or grey allowed, +/- RLE
+        if ((tga_image_type != 2) && (tga_image_type != 3) && (tga_image_type != 10) && (tga_image_type != 11)) {
             stbi__rewind(s);
             return 0; // only RGB or grey allowed, +/- RLE
         }
@@ -6833,36 +6155,29 @@ static int stbi__tga_info(stbi__context *s, int *x, int *y, int *comp)
         tga_colormap_bpp = 0;
     }
     tga_w = stbi__get16le(s);
-    if (tga_w < 1)
-    {
+    if (tga_w < 1) {
         stbi__rewind(s);
         return 0; // test width
     }
     tga_h = stbi__get16le(s);
-    if (tga_h < 1)
-    {
+    if (tga_h < 1) {
         stbi__rewind(s);
         return 0; // test height
     }
     tga_bits_per_pixel = stbi__get8(s); // bits per pixel
     stbi__get8(s);                      // ignore alpha bits
-    if (tga_colormap_bpp != 0)
-    {
-        if ((tga_bits_per_pixel != 8) && (tga_bits_per_pixel != 16))
-        {
+    if (tga_colormap_bpp != 0) {
+        if ((tga_bits_per_pixel != 8) && (tga_bits_per_pixel != 16)) {
             // when using a colormap, tga_bits_per_pixel is the size of the indexes
             // I don't think anything but 8 or 16bit indexes makes sense
             stbi__rewind(s);
             return 0;
         }
         tga_comp = stbi__tga_get_comp(tga_colormap_bpp, 0, NULL);
-    }
-    else
-    {
+    } else {
         tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3) || (tga_image_type == 11), NULL);
     }
-    if (!tga_comp)
-    {
+    if (!tga_comp) {
         stbi__rewind(s);
         return 0;
     }
@@ -6875,17 +6190,15 @@ static int stbi__tga_info(stbi__context *s, int *x, int *y, int *comp)
     return 1; // seems to have passed everything
 }
 
-static int stbi__tga_test(stbi__context *s)
-{
+static int stbi__tga_test(stbi__context * s) {
     int res = 0;
     int sz, tga_color_type;
     stbi__get8(s);                  //   discard Offset
     tga_color_type = stbi__get8(s); //   color type
     if (tga_color_type > 1)
-        goto errorEnd;  //   only RGB or indexed allowed
-    sz = stbi__get8(s); //   image type
-    if (tga_color_type == 1)
-    { // colormapped (paletted) image
+        goto errorEnd;         //   only RGB or indexed allowed
+    sz = stbi__get8(s);        //   image type
+    if (tga_color_type == 1) { // colormapped (paletted) image
         if (sz != 1 && sz != 9)
             goto errorEnd;  // colortype 1 demands image type 1 or 9
         stbi__skip(s, 4);   // skip index of first colormap entry and number of entries
@@ -6893,9 +6206,7 @@ static int stbi__tga_test(stbi__context *s)
         if ((sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32))
             goto errorEnd;
         stbi__skip(s, 4); // skip image x and y origin
-    }
-    else
-    { // "normal" image w/o colormap
+    } else {              // "normal" image w/o colormap
         if ((sz != 2) && (sz != 3) && (sz != 10) && (sz != 11))
             goto errorEnd; // only RGB or grey allowed, +/- RLE
         stbi__skip(s, 9);  // skip colormap specification and image x/y origin
@@ -6918,8 +6229,7 @@ errorEnd:
 }
 
 // read 16bit value and convert to 24bit RGB
-static void stbi__tga_read_rgb16(stbi__context *s, stbi_uc *out)
-{
+static void stbi__tga_read_rgb16(stbi__context * s, stbi_uc * out) {
     stbi__uint16 px = (stbi__uint16)stbi__get16le(s);
     stbi__uint16 fiveBitMask = 31;
     // we have 3 channels with 5bits each
@@ -6937,8 +6247,7 @@ static void stbi__tga_read_rgb16(stbi__context *s, stbi_uc *out)
     // so let's treat all 15 and 16bit TGAs as RGB with no alpha.
 }
 
-static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
-{
+static void * stbi__tga_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri) {
     //   read in the TGA header stuff
     int tga_offset = stbi__get8(s);
     int tga_indexed = stbi__get8(s);
@@ -6956,8 +6265,8 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
     int tga_inverted = stbi__get8(s);
     // int tga_alpha_bits = tga_inverted & 15; // the 4 lowest bits - unused (useless?)
     //   image data
-    unsigned char *tga_data;
-    unsigned char *tga_palette = NULL;
+    unsigned char * tga_data;
+    unsigned char * tga_palette = NULL;
     int i, j;
     unsigned char raw_data[4] = {0};
     int RLE_count = 0;
@@ -6973,8 +6282,7 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
         return stbi__errpuc("too large", "Very large image (corrupt?)");
 
     //   do a tiny bit of precessing
-    if (tga_image_type >= 8)
-    {
+    if (tga_image_type >= 8) {
         tga_image_type -= 8;
         tga_is_RLE = 1;
     }
@@ -7005,22 +6313,16 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
     // skip to the data's starting position (offset usually = 0)
     stbi__skip(s, tga_offset);
 
-    if (!tga_indexed && !tga_is_RLE && !tga_rgb16)
-    {
-        for (i = 0; i < tga_height; ++i)
-        {
+    if (!tga_indexed && !tga_is_RLE && !tga_rgb16) {
+        for (i = 0; i < tga_height; ++i) {
             int row = tga_inverted ? tga_height - i - 1 : i;
-            stbi_uc *tga_row = tga_data + row * tga_width * tga_comp;
+            stbi_uc * tga_row = tga_data + row * tga_width * tga_comp;
             stbi__getn(s, tga_row, tga_width * tga_comp);
         }
-    }
-    else
-    {
+    } else {
         //   do I need to load a palette?
-        if (tga_indexed)
-        {
-            if (tga_palette_len == 0)
-            { /* you have to have at least one entry! */
+        if (tga_indexed) {
+            if (tga_palette_len == 0) { /* you have to have at least one entry! */
                 STBI_FREE(tga_data);
                 return stbi__errpuc("bad palette", "Corrupt TGA");
             }
@@ -7029,80 +6331,59 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
             stbi__skip(s, tga_palette_start);
             //   load the palette
             tga_palette = (unsigned char *)stbi__malloc_mad2(tga_palette_len, tga_comp, 0);
-            if (!tga_palette)
-            {
+            if (!tga_palette) {
                 STBI_FREE(tga_data);
                 return stbi__errpuc("outofmem", "Out of memory");
             }
-            if (tga_rgb16)
-            {
-                stbi_uc *pal_entry = tga_palette;
+            if (tga_rgb16) {
+                stbi_uc * pal_entry = tga_palette;
                 STBI_ASSERT(tga_comp == STBI_rgb);
-                for (i = 0; i < tga_palette_len; ++i)
-                {
+                for (i = 0; i < tga_palette_len; ++i) {
                     stbi__tga_read_rgb16(s, pal_entry);
                     pal_entry += tga_comp;
                 }
-            }
-            else if (!stbi__getn(s, tga_palette, tga_palette_len * tga_comp))
-            {
+            } else if (!stbi__getn(s, tga_palette, tga_palette_len * tga_comp)) {
                 STBI_FREE(tga_data);
                 STBI_FREE(tga_palette);
                 return stbi__errpuc("bad palette", "Corrupt TGA");
             }
         }
         //   load the data
-        for (i = 0; i < tga_width * tga_height; ++i)
-        {
+        for (i = 0; i < tga_width * tga_height; ++i) {
             //   if I'm in RLE mode, do I need to get a RLE stbi__pngchunk?
-            if (tga_is_RLE)
-            {
-                if (RLE_count == 0)
-                {
+            if (tga_is_RLE) {
+                if (RLE_count == 0) {
                     //   yep, get the next byte as a RLE command
                     int RLE_cmd = stbi__get8(s);
                     RLE_count = 1 + (RLE_cmd & 127);
                     RLE_repeating = RLE_cmd >> 7;
                     read_next_pixel = 1;
-                }
-                else if (!RLE_repeating)
-                {
+                } else if (!RLE_repeating) {
                     read_next_pixel = 1;
                 }
-            }
-            else
-            {
+            } else {
                 read_next_pixel = 1;
             }
             //   OK, if I need to read a pixel, do it now
-            if (read_next_pixel)
-            {
+            if (read_next_pixel) {
                 //   load however much data we did have
-                if (tga_indexed)
-                {
+                if (tga_indexed) {
                     // read in index, then perform the lookup
                     int pal_idx = (tga_bits_per_pixel == 8) ? stbi__get8(s) : stbi__get16le(s);
-                    if (pal_idx >= tga_palette_len)
-                    {
+                    if (pal_idx >= tga_palette_len) {
                         // invalid index
                         pal_idx = 0;
                     }
                     pal_idx *= tga_comp;
-                    for (j = 0; j < tga_comp; ++j)
-                    {
+                    for (j = 0; j < tga_comp; ++j) {
                         raw_data[j] = tga_palette[pal_idx + j];
                     }
-                }
-                else if (tga_rgb16)
-                {
+                } else if (tga_rgb16) {
                     STBI_ASSERT(tga_comp == STBI_rgb);
                     stbi__tga_read_rgb16(s, raw_data);
-                }
-                else
-                {
+                } else {
                     //   read in the data raw
-                    for (j = 0; j < tga_comp; ++j)
-                    {
+                    for (j = 0; j < tga_comp; ++j) {
                         raw_data[j] = stbi__get8(s);
                     }
                 }
@@ -7118,14 +6399,11 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
             --RLE_count;
         }
         //   do I need to invert the image?
-        if (tga_inverted)
-        {
-            for (j = 0; j * 2 < tga_height; ++j)
-            {
+        if (tga_inverted) {
+            for (j = 0; j * 2 < tga_height; ++j) {
                 int index1 = j * tga_width * tga_comp;
                 int index2 = (tga_height - 1 - j) * tga_width * tga_comp;
-                for (i = tga_width * tga_comp; i > 0; --i)
-                {
+                for (i = tga_width * tga_comp; i > 0; --i) {
                     unsigned char temp = tga_data[index1];
                     tga_data[index1] = tga_data[index2];
                     tga_data[index2] = temp;
@@ -7135,18 +6413,15 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
             }
         }
         //   clear my palette, if I had one
-        if (tga_palette != NULL)
-        {
+        if (tga_palette != NULL) {
             STBI_FREE(tga_palette);
         }
     }
 
     // swap RGB - if the source data was RGB16, it already is in the right order
-    if (tga_comp >= 3 && !tga_rgb16)
-    {
-        unsigned char *tga_pixel = tga_data;
-        for (i = 0; i < tga_width * tga_height; ++i)
-        {
+    if (tga_comp >= 3 && !tga_rgb16) {
+        unsigned char * tga_pixel = tga_data;
+        for (i = 0; i < tga_width * tga_height; ++i) {
             unsigned char temp = tga_pixel[0];
             tga_pixel[0] = tga_pixel[2];
             tga_pixel[2] = temp;
@@ -7160,8 +6435,7 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
 
     //   the things I do to get rid of an error message, and yet keep
     //   Microsoft's C compilers happy... [8^(
-    tga_palette_start = tga_palette_len = tga_palette_bits =
-        tga_x_origin = tga_y_origin = 0;
+    tga_palette_start = tga_palette_len = tga_palette_bits = tga_x_origin = tga_y_origin = 0;
     STBI_NOTUSED(tga_palette_start);
     //   OK, done
     return tga_data;
@@ -7172,41 +6446,32 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
 // Photoshop PSD loader -- PD by Thatcher Ulrich, integration by Nicolas Schulz, tweaked by STB
 
 #ifndef STBI_NO_PSD
-static int stbi__psd_test(stbi__context *s)
-{
+static int stbi__psd_test(stbi__context * s) {
     int r = (stbi__get32be(s) == 0x38425053);
     stbi__rewind(s);
     return r;
 }
 
-static int stbi__psd_decode_rle(stbi__context *s, stbi_uc *p, int pixelCount)
-{
+static int stbi__psd_decode_rle(stbi__context * s, stbi_uc * p, int pixelCount) {
     int count, nleft, len;
 
     count = 0;
-    while ((nleft = pixelCount - count) > 0)
-    {
+    while ((nleft = pixelCount - count) > 0) {
         len = stbi__get8(s);
-        if (len == 128)
-        {
+        if (len == 128) {
             // No-op.
-        }
-        else if (len < 128)
-        {
+        } else if (len < 128) {
             // Copy next len+1 bytes literally.
             len++;
             if (len > nleft)
                 return 0; // corrupt data
             count += len;
-            while (len)
-            {
+            while (len) {
                 *p = stbi__get8(s);
                 p += 4;
                 len--;
             }
-        }
-        else if (len > 128)
-        {
+        } else if (len > 128) {
             stbi_uc val;
             // Next -len+1 bytes in the dest are replicated from next source byte.
             // (Interpret len as a negative 8-bit int.)
@@ -7215,8 +6480,7 @@ static int stbi__psd_decode_rle(stbi__context *s, stbi_uc *p, int pixelCount)
                 return 0; // corrupt data
             val = stbi__get8(s);
             count += len;
-            while (len)
-            {
+            while (len) {
                 *p = val;
                 p += 4;
                 len--;
@@ -7227,14 +6491,13 @@ static int stbi__psd_decode_rle(stbi__context *s, stbi_uc *p, int pixelCount)
     return 1;
 }
 
-static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
-{
+static void * stbi__psd_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri, int bpc) {
     int pixelCount;
     int channelCount, compression;
     int channel, i;
     int bitdepth;
     int w, h;
-    stbi_uc *out;
+    stbi_uc * out;
     STBI_NOTUSED(ri);
 
     // Check identifier
@@ -7303,12 +6566,10 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
 
     // Create the destination image.
 
-    if (!compression && bitdepth == 16 && bpc == 16)
-    {
+    if (!compression && bitdepth == 16 && bpc == 16) {
         out = (stbi_uc *)stbi__malloc_mad3(8, w, h, 0);
         ri->bits_per_channel = 16;
-    }
-    else
+    } else
         out = (stbi_uc *)stbi__malloc(4 * w * h);
 
     if (!out)
@@ -7319,8 +6580,7 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
     // memset( out, 0, pixelCount * 4 );
 
     // Finally, the image data.
-    if (compression)
-    {
+    if (compression) {
         // RLE as used by .PSD and .TIFF
         // Loop until you get the number of unpacked bytes you are expecting:
         //     Read the next source byte into n.
@@ -7334,72 +6594,52 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
         stbi__skip(s, h * channelCount * 2);
 
         // Read the RLE data by channel.
-        for (channel = 0; channel < 4; channel++)
-        {
-            stbi_uc *p;
+        for (channel = 0; channel < 4; channel++) {
+            stbi_uc * p;
 
             p = out + channel;
-            if (channel >= channelCount)
-            {
+            if (channel >= channelCount) {
                 // Fill this channel with default data.
                 for (i = 0; i < pixelCount; i++, p += 4)
                     *p = (channel == 3 ? 255 : 0);
-            }
-            else
-            {
+            } else {
                 // Read the RLE data.
-                if (!stbi__psd_decode_rle(s, p, pixelCount))
-                {
+                if (!stbi__psd_decode_rle(s, p, pixelCount)) {
                     STBI_FREE(out);
                     return stbi__errpuc("corrupt", "bad RLE data");
                 }
             }
         }
-    }
-    else
-    {
+    } else {
         // We're at the raw image data.  It's each channel in order (Red, Green, Blue, Alpha, ...)
         // where each channel consists of an 8-bit (or 16-bit) value for each pixel in the image.
 
         // Read the data by channel.
-        for (channel = 0; channel < 4; channel++)
-        {
-            if (channel >= channelCount)
-            {
+        for (channel = 0; channel < 4; channel++) {
+            if (channel >= channelCount) {
                 // Fill this channel with default data.
-                if (bitdepth == 16 && bpc == 16)
-                {
-                    stbi__uint16 *q = ((stbi__uint16 *)out) + channel;
+                if (bitdepth == 16 && bpc == 16) {
+                    stbi__uint16 * q = ((stbi__uint16 *)out) + channel;
                     stbi__uint16 val = channel == 3 ? 65535 : 0;
                     for (i = 0; i < pixelCount; i++, q += 4)
                         *q = val;
-                }
-                else
-                {
-                    stbi_uc *p = out + channel;
+                } else {
+                    stbi_uc * p = out + channel;
                     stbi_uc val = channel == 3 ? 255 : 0;
                     for (i = 0; i < pixelCount; i++, p += 4)
                         *p = val;
                 }
-            }
-            else
-            {
-                if (ri->bits_per_channel == 16)
-                { // output bpc
-                    stbi__uint16 *q = ((stbi__uint16 *)out) + channel;
+            } else {
+                if (ri->bits_per_channel == 16) { // output bpc
+                    stbi__uint16 * q = ((stbi__uint16 *)out) + channel;
                     for (i = 0; i < pixelCount; i++, q += 4)
                         *q = (stbi__uint16)stbi__get16be(s);
-                }
-                else
-                {
-                    stbi_uc *p = out + channel;
-                    if (bitdepth == 16)
-                    { // input bpc
+                } else {
+                    stbi_uc * p = out + channel;
+                    if (bitdepth == 16) { // input bpc
                         for (i = 0; i < pixelCount; i++, p += 4)
                             *p = (stbi_uc)(stbi__get16be(s) >> 8);
-                    }
-                    else
-                    {
+                    } else {
                         for (i = 0; i < pixelCount; i++, p += 4)
                             *p = stbi__get8(s);
                     }
@@ -7409,15 +6649,11 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
     }
 
     // remove weird white matte from PSD
-    if (channelCount >= 4)
-    {
-        if (ri->bits_per_channel == 16)
-        {
-            for (i = 0; i < w * h; ++i)
-            {
-                stbi__uint16 *pixel = (stbi__uint16 *)out + 4 * i;
-                if (pixel[3] != 0 && pixel[3] != 65535)
-                {
+    if (channelCount >= 4) {
+        if (ri->bits_per_channel == 16) {
+            for (i = 0; i < w * h; ++i) {
+                stbi__uint16 * pixel = (stbi__uint16 *)out + 4 * i;
+                if (pixel[3] != 0 && pixel[3] != 65535) {
                     float a = pixel[3] / 65535.0f;
                     float ra = 1.0f / a;
                     float inv_a = 65535.0f * (1 - ra);
@@ -7426,14 +6662,10 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
                     pixel[2] = (stbi__uint16)(pixel[2] * ra + inv_a);
                 }
             }
-        }
-        else
-        {
-            for (i = 0; i < w * h; ++i)
-            {
-                unsigned char *pixel = out + 4 * i;
-                if (pixel[3] != 0 && pixel[3] != 255)
-                {
+        } else {
+            for (i = 0; i < w * h; ++i) {
+                unsigned char * pixel = out + 4 * i;
+                if (pixel[3] != 0 && pixel[3] != 255) {
                     float a = pixel[3] / 255.0f;
                     float ra = 1.0f / a;
                     float inv_a = 255.0f * (1 - ra);
@@ -7446,8 +6678,7 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
     }
 
     // convert to desired output format
-    if (req_comp && req_comp != 4)
-    {
+    if (req_comp && req_comp != 4) {
         if (ri->bits_per_channel == 16)
             out = (stbi_uc *)stbi__convert_format16((stbi__uint16 *)out, 4, req_comp, w, h);
         else
@@ -7473,8 +6704,7 @@ static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req
 // See http://ozviz.wasp.uwa.edu.au/~pbourke/dataformats/softimagepic/
 
 #ifndef STBI_NO_PIC
-static int stbi__pic_is4(stbi__context *s, const char *str)
-{
+static int stbi__pic_is4(stbi__context * s, const char * str) {
     int i;
     for (i = 0; i < 4; ++i)
         if (stbi__get8(s) != (stbi_uc)str[i])
@@ -7483,8 +6713,7 @@ static int stbi__pic_is4(stbi__context *s, const char *str)
     return 1;
 }
 
-static int stbi__pic_test_core(stbi__context *s)
-{
+static int stbi__pic_test_core(stbi__context * s) {
     int i;
 
     if (!stbi__pic_is4(s, "\x53\x80\xF6\x34"))
@@ -7499,19 +6728,15 @@ static int stbi__pic_test_core(stbi__context *s)
     return 1;
 }
 
-typedef struct
-{
+typedef struct {
     stbi_uc size, type, channel;
 } stbi__pic_packet;
 
-static stbi_uc *stbi__readval(stbi__context *s, int channel, stbi_uc *dest)
-{
+static stbi_uc * stbi__readval(stbi__context * s, int channel, stbi_uc * dest) {
     int mask = 0x80, i;
 
-    for (i = 0; i < 4; ++i, mask >>= 1)
-    {
-        if (channel & mask)
-        {
+    for (i = 0; i < 4; ++i, mask >>= 1) {
+        if (channel & mask) {
             if (stbi__at_eof(s))
                 return stbi__errpuc("bad file", "PIC file too short");
             dest[i] = stbi__get8(s);
@@ -7521,8 +6746,7 @@ static stbi_uc *stbi__readval(stbi__context *s, int channel, stbi_uc *dest)
     return dest;
 }
 
-static void stbi__copyval(int channel, stbi_uc *dest, const stbi_uc *src)
-{
+static void stbi__copyval(int channel, stbi_uc * dest, const stbi_uc * src) {
     int mask = 0x80, i;
 
     for (i = 0; i < 4; ++i, mask >>= 1)
@@ -7530,16 +6754,14 @@ static void stbi__copyval(int channel, stbi_uc *dest, const stbi_uc *src)
             dest[i] = src[i];
 }
 
-static stbi_uc *stbi__pic_load_core(stbi__context *s, int width, int height, int *comp, stbi_uc *result)
-{
+static stbi_uc * stbi__pic_load_core(stbi__context * s, int width, int height, int * comp, stbi_uc * result) {
     int act_comp = 0, num_packets = 0, y, chained;
     stbi__pic_packet packets[10];
 
     // this will (should...) cater for even some bizarre stuff like having data
     // for the same channel in multiple packets.
-    do
-    {
-        stbi__pic_packet *packet;
+    do {
+        stbi__pic_packet * packet;
 
         if (num_packets == sizeof(packets) / sizeof(packets[0]))
             return stbi__errpuc("bad format", "too many packets");
@@ -7561,22 +6783,18 @@ static stbi_uc *stbi__pic_load_core(stbi__context *s, int width, int height, int
 
     *comp = (act_comp & 0x10 ? 4 : 3); // has alpha channel?
 
-    for (y = 0; y < height; ++y)
-    {
+    for (y = 0; y < height; ++y) {
         int packet_idx;
 
-        for (packet_idx = 0; packet_idx < num_packets; ++packet_idx)
-        {
-            stbi__pic_packet *packet = &packets[packet_idx];
-            stbi_uc *dest = result + y * width * 4;
+        for (packet_idx = 0; packet_idx < num_packets; ++packet_idx) {
+            stbi__pic_packet * packet = &packets[packet_idx];
+            stbi_uc * dest = result + y * width * 4;
 
-            switch (packet->type)
-            {
+            switch (packet->type) {
             default:
                 return stbi__errpuc("bad format", "packet has bad compression type");
 
-            case 0:
-            { // uncompressed
+            case 0: { // uncompressed
                 int x;
 
                 for (x = 0; x < width; ++x, dest += 4)
@@ -7589,8 +6807,7 @@ static stbi_uc *stbi__pic_load_core(stbi__context *s, int width, int height, int
             {
                 int left = width, i;
 
-                while (left > 0)
-                {
+                while (left > 0) {
                     stbi_uc count, value[4];
 
                     count = stbi__get8(s);
@@ -7607,20 +6824,16 @@ static stbi_uc *stbi__pic_load_core(stbi__context *s, int width, int height, int
                         stbi__copyval(packet->channel, dest, value);
                     left -= count;
                 }
-            }
-            break;
+            } break;
 
-            case 2:
-            { // Mixed RLE
+            case 2: { // Mixed RLE
                 int left = width;
-                while (left > 0)
-                {
+                while (left > 0) {
                     int count = stbi__get8(s), i;
                     if (stbi__at_eof(s))
                         return stbi__errpuc("bad file", "file too short (mixed read count)");
 
-                    if (count >= 128)
-                    { // Repeated
+                    if (count >= 128) { // Repeated
                         stbi_uc value[4];
 
                         if (count == 128)
@@ -7635,9 +6848,7 @@ static stbi_uc *stbi__pic_load_core(stbi__context *s, int width, int height, int
 
                         for (i = 0; i < count; ++i, dest += 4)
                             stbi__copyval(packet->channel, dest, value);
-                    }
-                    else
-                    { // Raw
+                    } else { // Raw
                         ++count;
                         if (count > left)
                             return stbi__errpuc("bad file", "scanline overrun");
@@ -7657,9 +6868,8 @@ static stbi_uc *stbi__pic_load_core(stbi__context *s, int width, int height, int
     return result;
 }
 
-static void *stbi__pic_load(stbi__context *s, int *px, int *py, int *comp, int req_comp, stbi__result_info *ri)
-{
-    stbi_uc *result;
+static void * stbi__pic_load(stbi__context * s, int * px, int * py, int * comp, int req_comp, stbi__result_info * ri) {
+    stbi_uc * result;
     int i, x, y, internal_comp;
     STBI_NOTUSED(ri);
 
@@ -7692,8 +6902,7 @@ static void *stbi__pic_load(stbi__context *s, int *px, int *py, int *comp, int r
         return stbi__errpuc("outofmem", "Out of memory");
     memset(result, 0xff, x * y * 4);
 
-    if (!stbi__pic_load_core(s, x, y, comp, result))
-    {
+    if (!stbi__pic_load_core(s, x, y, comp, result)) {
         STBI_FREE(result);
         result = 0;
     }
@@ -7706,8 +6915,7 @@ static void *stbi__pic_load(stbi__context *s, int *px, int *py, int *comp, int r
     return result;
 }
 
-static int stbi__pic_test(stbi__context *s)
-{
+static int stbi__pic_test(stbi__context * s) {
     int r = stbi__pic_test_core(s);
     stbi__rewind(s);
     return r;
@@ -7718,24 +6926,22 @@ static int stbi__pic_test(stbi__context *s)
 // GIF loader -- public domain by Jean-Marc Lienher -- simplified/shrunk by stb
 
 #ifndef STBI_NO_GIF
-typedef struct
-{
+typedef struct {
     stbi__int16 prefix;
     stbi_uc first;
     stbi_uc suffix;
 } stbi__gif_lzw;
 
-typedef struct
-{
+typedef struct {
     int w, h;
-    stbi_uc *out;        // output buffer (always 4 components)
-    stbi_uc *background; // The current "background" as far as a gif is concerned
-    stbi_uc *history;
+    stbi_uc * out;        // output buffer (always 4 components)
+    stbi_uc * background; // The current "background" as far as a gif is concerned
+    stbi_uc * history;
     int flags, bgindex, ratio, transparent, eflags;
     stbi_uc pal[256][4];
     stbi_uc lpal[256][4];
     stbi__gif_lzw codes[8192];
-    stbi_uc *color_table;
+    stbi_uc * color_table;
     int parse, step;
     int lflags;
     int start_x, start_y;
@@ -7745,8 +6951,7 @@ typedef struct
     int delay;
 } stbi__gif;
 
-static int stbi__gif_test_raw(stbi__context *s)
-{
+static int stbi__gif_test_raw(stbi__context * s) {
     int sz;
     if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8')
         return 0;
@@ -7758,18 +6963,15 @@ static int stbi__gif_test_raw(stbi__context *s)
     return 1;
 }
 
-static int stbi__gif_test(stbi__context *s)
-{
+static int stbi__gif_test(stbi__context * s) {
     int r = stbi__gif_test_raw(s);
     stbi__rewind(s);
     return r;
 }
 
-static void stbi__gif_parse_colortable(stbi__context *s, stbi_uc pal[256][4], int num_entries, int transp)
-{
+static void stbi__gif_parse_colortable(stbi__context * s, stbi_uc pal[256][4], int num_entries, int transp) {
     int i;
-    for (i = 0; i < num_entries; ++i)
-    {
+    for (i = 0; i < num_entries; ++i) {
         pal[i][2] = stbi__get8(s);
         pal[i][1] = stbi__get8(s);
         pal[i][0] = stbi__get8(s);
@@ -7777,8 +6979,7 @@ static void stbi__gif_parse_colortable(stbi__context *s, stbi_uc pal[256][4], in
     }
 }
 
-static int stbi__gif_header(stbi__context *s, stbi__gif *g, int *comp, int is_info)
-{
+static int stbi__gif_header(stbi__context * s, stbi__gif * g, int * comp, int is_info) {
     stbi_uc version;
     if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8')
         return stbi__err("not GIF", "Corrupt GIF");
@@ -7814,13 +7015,11 @@ static int stbi__gif_header(stbi__context *s, stbi__gif *g, int *comp, int is_in
     return 1;
 }
 
-static int stbi__gif_info_raw(stbi__context *s, int *x, int *y, int *comp)
-{
-    stbi__gif *g = (stbi__gif *)stbi__malloc(sizeof(stbi__gif));
+static int stbi__gif_info_raw(stbi__context * s, int * x, int * y, int * comp) {
+    stbi__gif * g = (stbi__gif *)stbi__malloc(sizeof(stbi__gif));
     if (!g)
         return stbi__err("outofmem", "Out of memory");
-    if (!stbi__gif_header(s, g, comp, 1))
-    {
+    if (!stbi__gif_header(s, g, comp, 1)) {
         STBI_FREE(g);
         stbi__rewind(s);
         return 0;
@@ -7833,8 +7032,7 @@ static int stbi__gif_info_raw(stbi__context *s, int *x, int *y, int *comp)
     return 1;
 }
 
-static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
-{
+static void stbi__out_gif_code(stbi__gif * g, stbi__uint16 code) {
     stbi_uc *p, *c;
     int idx;
 
@@ -7851,8 +7049,7 @@ static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
     g->history[idx / 4] = 1;
 
     c = &g->color_table[g->codes[code].suffix * 4];
-    if (c[3] > 128)
-    { // don't render transparent pixels;
+    if (c[3] > 128) { // don't render transparent pixels;
         p[0] = c[2];
         p[1] = c[1];
         p[2] = c[0];
@@ -7860,13 +7057,11 @@ static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
     }
     g->cur_x += 4;
 
-    if (g->cur_x >= g->max_x)
-    {
+    if (g->cur_x >= g->max_x) {
         g->cur_x = g->start_x;
         g->cur_y += g->step;
 
-        while (g->cur_y >= g->max_y && g->parse > 0)
-        {
+        while (g->cur_y >= g->max_y && g->parse > 0) {
             g->step = (1 << g->parse) * g->line_size;
             g->cur_y = g->start_y + (g->step >> 1);
             --g->parse;
@@ -7874,13 +7069,12 @@ static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
     }
 }
 
-static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
-{
+static stbi_uc * stbi__process_gif_raster(stbi__context * s, stbi__gif * g) {
     stbi_uc lzw_cs;
     stbi__int32 len, init_code;
     stbi__uint32 first;
     stbi__int32 codesize, codemask, avail, oldcode, bits, valid_bits, clear;
-    stbi__gif_lzw *p;
+    stbi__gif_lzw * p;
 
     lzw_cs = stbi__get8(s);
     if (lzw_cs > 12)
@@ -7891,8 +7085,7 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
     codemask = (1 << codesize) - 1;
     bits = 0;
     valid_bits = 0;
-    for (init_code = 0; init_code < clear; init_code++)
-    {
+    for (init_code = 0; init_code < clear; init_code++) {
         g->codes[init_code].prefix = -1;
         g->codes[init_code].first = (stbi_uc)init_code;
         g->codes[init_code].suffix = (stbi_uc)init_code;
@@ -7903,12 +7096,9 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
     oldcode = -1;
 
     len = 0;
-    for (;;)
-    {
-        if (valid_bits < codesize)
-        {
-            if (len == 0)
-            {
+    for (;;) {
+        if (valid_bits < codesize) {
+            if (len == 0) {
                 len = stbi__get8(s); // start new block
                 if (len == 0)
                     return g->out;
@@ -7916,62 +7106,48 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
             --len;
             bits |= (stbi__int32)stbi__get8(s) << valid_bits;
             valid_bits += 8;
-        }
-        else
-        {
+        } else {
             stbi__int32 code = bits & codemask;
             bits >>= codesize;
             valid_bits -= codesize;
             // @OPTIMIZE: is there some way we can accelerate the non-clear path?
-            if (code == clear)
-            { // clear code
+            if (code == clear) { // clear code
                 codesize = lzw_cs + 1;
                 codemask = (1 << codesize) - 1;
                 avail = clear + 2;
                 oldcode = -1;
                 first = 0;
-            }
-            else if (code == clear + 1)
-            { // end of stream code
+            } else if (code == clear + 1) { // end of stream code
                 stbi__skip(s, len);
                 while ((len = stbi__get8(s)) > 0)
                     stbi__skip(s, len);
                 return g->out;
-            }
-            else if (code <= avail)
-            {
-                if (first)
-                {
+            } else if (code <= avail) {
+                if (first) {
                     return stbi__errpuc("no clear code", "Corrupt GIF");
                 }
 
-                if (oldcode >= 0)
-                {
+                if (oldcode >= 0) {
                     p = &g->codes[avail++];
-                    if (avail > 8192)
-                    {
+                    if (avail > 8192) {
                         return stbi__errpuc("too many codes", "Corrupt GIF");
                     }
 
                     p->prefix = (stbi__int16)oldcode;
                     p->first = g->codes[oldcode].first;
                     p->suffix = (code == avail) ? p->first : g->codes[code].first;
-                }
-                else if (code == avail)
+                } else if (code == avail)
                     return stbi__errpuc("illegal code in raster", "Corrupt GIF");
 
                 stbi__out_gif_code(g, (stbi__uint16)code);
 
-                if ((avail & codemask) == 0 && avail <= 0x0FFF)
-                {
+                if ((avail & codemask) == 0 && avail <= 0x0FFF) {
                     codesize++;
                     codemask = (1 << codesize) - 1;
                 }
 
                 oldcode = code;
-            }
-            else
-            {
+            } else {
                 return stbi__errpuc("illegal code in raster", "Corrupt GIF");
             }
         }
@@ -7980,8 +7156,7 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
 
 // this function is designed to support animated gifs, although stb_image doesn't support it
 // two back is the image from two frames ago, used for a very specific disposal format
-static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
-{
+static stbi_uc * stbi__gif_load_next(stbi__context * s, stbi__gif * g, int * comp, int req_comp, stbi_uc * two_back) {
     int dispose;
     int first_frame;
     int pi;
@@ -7990,8 +7165,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
 
     // on first frame, any non-written pixels get the background colour (non-transparent)
     first_frame = 0;
-    if (g->out == 0)
-    {
+    if (g->out == 0) {
         if (!stbi__gif_header(s, g, comp, 0))
             return 0; // stbi__g_failure_reason set by stbi__gif_header
         if (!stbi__mad3sizes_valid(4, g->w, g->h, 0))
@@ -8010,41 +7184,29 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
         memset(g->background, 0x00, 4 * pcount); // state of the background (starts transparent)
         memset(g->history, 0x00, pcount);        // pixels that were affected previous frame
         first_frame = 1;
-    }
-    else
-    {
+    } else {
         // second frame - how do we dispose of the previous one?
         dispose = (g->eflags & 0x1C) >> 2;
         pcount = g->w * g->h;
 
-        if ((dispose == 3) && (two_back == 0))
-        {
+        if ((dispose == 3) && (two_back == 0)) {
             dispose = 2; // if I don't have an image to revert back to, default to the old background
         }
 
-        if (dispose == 3)
-        { // use previous graphic
-            for (pi = 0; pi < pcount; ++pi)
-            {
-                if (g->history[pi])
-                {
+        if (dispose == 3) { // use previous graphic
+            for (pi = 0; pi < pcount; ++pi) {
+                if (g->history[pi]) {
                     memcpy(&g->out[pi * 4], &two_back[pi * 4], 4);
                 }
             }
-        }
-        else if (dispose == 2)
-        {
+        } else if (dispose == 2) {
             // restore what was changed last frame to background before that frame;
-            for (pi = 0; pi < pcount; ++pi)
-            {
-                if (g->history[pi])
-                {
+            for (pi = 0; pi < pcount; ++pi) {
+                if (g->history[pi]) {
                     memcpy(&g->out[pi * 4], &g->background[pi * 4], 4);
                 }
             }
-        }
-        else
-        {
+        } else {
             // This is a non-disposal case eithe way, so just
             // leave the pixels as is, and they will become the new background
             // 1: do not dispose
@@ -8058,15 +7220,13 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
     // clear my history;
     memset(g->history, 0x00, g->w * g->h); // pixels that were affected previous frame
 
-    for (;;)
-    {
+    for (;;) {
         int tag = stbi__get8(s);
-        switch (tag)
-        {
+        switch (tag) {
         case 0x2C: /* Image Descriptor */
         {
             stbi__int32 x, y, w, h;
-            stbi_uc *o;
+            stbi_uc * o;
 
             x = stbi__get16le(s);
             y = stbi__get16le(s);
@@ -8092,27 +7252,20 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
 
             g->lflags = stbi__get8(s);
 
-            if (g->lflags & 0x40)
-            {
+            if (g->lflags & 0x40) {
                 g->step = 8 * g->line_size; // first interlaced spacing
                 g->parse = 3;
-            }
-            else
-            {
+            } else {
                 g->step = g->line_size;
                 g->parse = 0;
             }
 
-            if (g->lflags & 0x80)
-            {
+            if (g->lflags & 0x80) {
                 stbi__gif_parse_colortable(s, g->lpal, 2 << (g->lflags & 7), g->eflags & 0x01 ? g->transparent : -1);
                 g->color_table = (stbi_uc *)g->lpal;
-            }
-            else if (g->flags & 0x80)
-            {
+            } else if (g->flags & 0x80) {
                 g->color_table = (stbi_uc *)g->pal;
-            }
-            else
+            } else
                 return stbi__errpuc("missing color table", "Corrupt GIF");
 
             o = stbi__process_gif_raster(s, g);
@@ -8121,14 +7274,12 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
 
             // if this was the first frame,
             pcount = g->w * g->h;
-            if (first_frame && (g->bgindex > 0))
-            {
+            if (first_frame && (g->bgindex > 0)) {
                 // if first frame, any pixel not drawn to gets the background color
-                for (pi = 0; pi < pcount; ++pi)
-                {
-                    if (g->history[pi] == 0)
-                    {
-                        g->pal[g->bgindex][3] = 255; // just in case it was made transparent, undo that; It will be reset next frame if need be;
+                for (pi = 0; pi < pcount; ++pi) {
+                    if (g->history[pi] == 0) {
+                        g->pal[g->bgindex][3] =
+                            255; // just in case it was made transparent, undo that; It will be reset next frame if need be;
                         memcpy(&g->out[pi * 4], &g->pal[g->bgindex], 4);
                     }
                 }
@@ -8141,42 +7292,32 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
         {
             int len;
             int ext = stbi__get8(s);
-            if (ext == 0xF9)
-            { // Graphic Control Extension.
+            if (ext == 0xF9) { // Graphic Control Extension.
                 len = stbi__get8(s);
-                if (len == 4)
-                {
+                if (len == 4) {
                     g->eflags = stbi__get8(s);
                     g->delay = 10 * stbi__get16le(s); // delay - 1/100th of a second, saving as 1/1000ths.
 
                     // unset old transparent
-                    if (g->transparent >= 0)
-                    {
+                    if (g->transparent >= 0) {
                         g->pal[g->transparent][3] = 255;
                     }
-                    if (g->eflags & 0x01)
-                    {
+                    if (g->eflags & 0x01) {
                         g->transparent = stbi__get8(s);
-                        if (g->transparent >= 0)
-                        {
+                        if (g->transparent >= 0) {
                             g->pal[g->transparent][3] = 0;
                         }
-                    }
-                    else
-                    {
+                    } else {
                         // don't need transparent
                         stbi__skip(s, 1);
                         g->transparent = -1;
                     }
-                }
-                else
-                {
+                } else {
                     stbi__skip(s, len);
                     break;
                 }
             }
-            while ((len = stbi__get8(s)) != 0)
-            {
+            while ((len = stbi__get8(s)) != 0) {
                 stbi__skip(s, len);
             }
             break;
@@ -8191,8 +7332,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
     }
 }
 
-static void *stbi__load_gif_main_outofmem(stbi__gif *g, stbi_uc *out, int **delays)
-{
+static void * stbi__load_gif_main_outofmem(stbi__gif * g, stbi_uc * out, int ** delays) {
     STBI_FREE(g->out);
     STBI_FREE(g->history);
     STBI_FREE(g->background);
@@ -8204,14 +7344,12 @@ static void *stbi__load_gif_main_outofmem(stbi__gif *g, stbi_uc *out, int **dela
     return stbi__errpuc("outofmem", "Out of memory");
 }
 
-static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
-{
-    if (stbi__gif_test(s))
-    {
+static void * stbi__load_gif_main(stbi__context * s, int ** delays, int * x, int * y, int * z, int * comp, int req_comp) {
+    if (stbi__gif_test(s)) {
         int layers = 0;
-        stbi_uc *u = 0;
-        stbi_uc *out = 0;
-        stbi_uc *two_back = 0;
+        stbi_uc * u = 0;
+        stbi_uc * out = 0;
+        stbi_uc * two_back = 0;
         stbi__gif g;
         int stride;
         int out_size = 0;
@@ -8221,52 +7359,43 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
         STBI_NOTUSED(delays_size);
 
         memset(&g, 0, sizeof(g));
-        if (delays)
-        {
+        if (delays) {
             *delays = 0;
         }
 
-        do
-        {
+        do {
             u = stbi__gif_load_next(s, &g, comp, req_comp, two_back);
             if (u == (stbi_uc *)s)
                 u = 0; // end of animated gif marker
 
-            if (u)
-            {
+            if (u) {
                 *x = g.w;
                 *y = g.h;
                 ++layers;
                 stride = g.w * g.h * 4;
 
-                if (out)
-                {
-                    void *tmp = (stbi_uc *)STBI_REALLOC_SIZED(out, out_size, layers * stride);
+                if (out) {
+                    void * tmp = (stbi_uc *)STBI_REALLOC_SIZED(out, out_size, layers * stride);
                     if (!tmp)
                         return stbi__load_gif_main_outofmem(&g, out, delays);
-                    else
-                    {
+                    else {
                         out = (stbi_uc *)tmp;
                         out_size = layers * stride;
                     }
 
-                    if (delays)
-                    {
-                        int *new_delays = (int *)STBI_REALLOC_SIZED(*delays, delays_size, sizeof(int) * layers);
+                    if (delays) {
+                        int * new_delays = (int *)STBI_REALLOC_SIZED(*delays, delays_size, sizeof(int) * layers);
                         if (!new_delays)
                             return stbi__load_gif_main_outofmem(&g, out, delays);
                         *delays = new_delays;
                         delays_size = layers * sizeof(int);
                     }
-                }
-                else
-                {
+                } else {
                     out = (stbi_uc *)stbi__malloc(layers * stride);
                     if (!out)
                         return stbi__load_gif_main_outofmem(&g, out, delays);
                     out_size = layers * stride;
-                    if (delays)
-                    {
+                    if (delays) {
                         *delays = (int *)stbi__malloc(layers * sizeof(int));
                         if (!*delays)
                             return stbi__load_gif_main_outofmem(&g, out, delays);
@@ -8274,13 +7403,11 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
                     }
                 }
                 memcpy(out + ((layers - 1) * stride), u, stride);
-                if (layers >= 2)
-                {
+                if (layers >= 2) {
                     two_back = out - 2 * stride;
                 }
 
-                if (delays)
-                {
+                if (delays) {
                     (*delays)[layers - 1U] = g.delay;
                 }
             }
@@ -8297,16 +7424,13 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
 
         *z = layers;
         return out;
-    }
-    else
-    {
+    } else {
         return stbi__errpuc("not GIF", "Image was not as a gif type.");
     }
 }
 
-static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
-{
-    stbi_uc *u = 0;
+static void * stbi__gif_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri) {
+    stbi_uc * u = 0;
     stbi__gif g;
     memset(&g, 0, sizeof(g));
     STBI_NOTUSED(ri);
@@ -8314,8 +7438,7 @@ static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req
     u = stbi__gif_load_next(s, &g, comp, req_comp, 0);
     if (u == (stbi_uc *)s)
         u = 0; // end of animated gif marker
-    if (u)
-    {
+    if (u) {
         *x = g.w;
         *y = g.h;
 
@@ -8323,9 +7446,7 @@ static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req
         // can be done for multiple frames.
         if (req_comp && req_comp != 4)
             u = stbi__convert_format(u, 4, req_comp, g.w, g.h);
-    }
-    else if (g.out)
-    {
+    } else if (g.out) {
         // if there was an error and we allocated an image buffer, free it!
         STBI_FREE(g.out);
     }
@@ -8337,18 +7458,14 @@ static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req
     return u;
 }
 
-static int stbi__gif_info(stbi__context *s, int *x, int *y, int *comp)
-{
-    return stbi__gif_info_raw(s, x, y, comp);
-}
+static int stbi__gif_info(stbi__context * s, int * x, int * y, int * comp) { return stbi__gif_info_raw(s, x, y, comp); }
 #endif
 
 // *************************************************************************************************
 // Radiance RGBE HDR loader
 // originally by Nicolas Schulz
 #ifndef STBI_NO_HDR
-static int stbi__hdr_test_core(stbi__context *s, const char *signature)
-{
+static int stbi__hdr_test_core(stbi__context * s, const char * signature) {
     int i;
     for (i = 0; signature[i]; ++i)
         if (stbi__get8(s) != signature[i])
@@ -8357,12 +7474,10 @@ static int stbi__hdr_test_core(stbi__context *s, const char *signature)
     return 1;
 }
 
-static int stbi__hdr_test(stbi__context *s)
-{
+static int stbi__hdr_test(stbi__context * s) {
     int r = stbi__hdr_test_core(s, "#?RADIANCE\n");
     stbi__rewind(s);
-    if (!r)
-    {
+    if (!r) {
         r = stbi__hdr_test_core(s, "#?RGBE\n");
         stbi__rewind(s);
     }
@@ -8370,18 +7485,15 @@ static int stbi__hdr_test(stbi__context *s)
 }
 
 #define STBI__HDR_BUFLEN 1024
-static char *stbi__hdr_gettoken(stbi__context *z, char *buffer)
-{
+static char * stbi__hdr_gettoken(stbi__context * z, char * buffer) {
     int len = 0;
     char c = '\0';
 
     c = (char)stbi__get8(z);
 
-    while (!stbi__at_eof(z) && c != '\n')
-    {
+    while (!stbi__at_eof(z) && c != '\n') {
         buffer[len++] = c;
-        if (len == STBI__HDR_BUFLEN - 1)
-        {
+        if (len == STBI__HDR_BUFLEN - 1) {
             // flush to end of line
             while (!stbi__at_eof(z) && stbi__get8(z) != '\n')
                 ;
@@ -8394,17 +7506,14 @@ static char *stbi__hdr_gettoken(stbi__context *z, char *buffer)
     return buffer;
 }
 
-static void stbi__hdr_convert(float *output, stbi_uc *input, int req_comp)
-{
-    if (input[3] != 0)
-    {
+static void stbi__hdr_convert(float * output, stbi_uc * input, int req_comp) {
+    if (input[3] != 0) {
         float f1;
         // Exponent
         f1 = (float)ldexp(1.0f, input[3] - (int)(128 + 8));
         if (req_comp <= 2)
             output[0] = (input[0] + input[1] + input[2]) * f1 / 3;
-        else
-        {
+        else {
             output[0] = input[0] * f1;
             output[1] = input[1] * f1;
             output[2] = input[2] * f1;
@@ -8413,11 +7522,8 @@ static void stbi__hdr_convert(float *output, stbi_uc *input, int req_comp)
             output[1] = 1;
         if (req_comp == 4)
             output[3] = 1;
-    }
-    else
-    {
-        switch (req_comp)
-        {
+    } else {
+        switch (req_comp) {
         case 4:
             output[3] = 1; /* fallthrough */
         case 3:
@@ -8432,18 +7538,17 @@ static void stbi__hdr_convert(float *output, stbi_uc *input, int req_comp)
     }
 }
 
-static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
-{
+static float * stbi__hdr_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri) {
     char buffer[STBI__HDR_BUFLEN];
-    char *token;
+    char * token;
     int valid = 0;
     int width, height;
-    stbi_uc *scanline;
-    float *hdr_data;
+    stbi_uc * scanline;
+    float * hdr_data;
     int len;
     unsigned char count, value;
     int i, j, k, c1, c2, z;
-    const char *headerToken;
+    const char * headerToken;
     STBI_NOTUSED(ri);
 
     // Check identifier
@@ -8452,8 +7557,7 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
         return stbi__errpf("not HDR", "Corrupt HDR image");
 
     // Parse header
-    for (;;)
-    {
+    for (;;) {
         token = stbi__hdr_gettoken(s, buffer);
         if (token[0] == 0)
             break;
@@ -8501,32 +7605,25 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
 
     // Load image data
     // image data is stored as some number of sca
-    if (width < 8 || width >= 32768)
-    {
+    if (width < 8 || width >= 32768) {
         // Read flat data
-        for (j = 0; j < height; ++j)
-        {
-            for (i = 0; i < width; ++i)
-            {
+        for (j = 0; j < height; ++j) {
+            for (i = 0; i < width; ++i) {
                 stbi_uc rgbe[4];
             main_decode_loop:
                 stbi__getn(s, rgbe, 4);
                 stbi__hdr_convert(hdr_data + j * width * req_comp + i * req_comp, rgbe, req_comp);
             }
         }
-    }
-    else
-    {
+    } else {
         // Read RLE-encoded data
         scanline = NULL;
 
-        for (j = 0; j < height; ++j)
-        {
+        for (j = 0; j < height; ++j) {
             c1 = stbi__get8(s);
             c2 = stbi__get8(s);
             len = stbi__get8(s);
-            if (c1 != 2 || c2 != 2 || (len & 0x80))
-            {
+            if (c1 != 2 || c2 != 2 || (len & 0x80)) {
                 // not run-length encoded, so we have to actually use THIS data as a decoded
                 // pixel (note this can't be a valid pixel--one of RGB must be >= 128)
                 stbi_uc rgbe[4];
@@ -8542,48 +7639,38 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
             }
             len <<= 8;
             len |= stbi__get8(s);
-            if (len != width)
-            {
+            if (len != width) {
                 STBI_FREE(hdr_data);
                 STBI_FREE(scanline);
                 return stbi__errpf("invalid decoded scanline length", "corrupt HDR");
             }
-            if (scanline == NULL)
-            {
+            if (scanline == NULL) {
                 scanline = (stbi_uc *)stbi__malloc_mad2(width, 4, 0);
-                if (!scanline)
-                {
+                if (!scanline) {
                     STBI_FREE(hdr_data);
                     return stbi__errpf("outofmem", "Out of memory");
                 }
             }
 
-            for (k = 0; k < 4; ++k)
-            {
+            for (k = 0; k < 4; ++k) {
                 int nleft;
                 i = 0;
-                while ((nleft = width - i) > 0)
-                {
+                while ((nleft = width - i) > 0) {
                     count = stbi__get8(s);
-                    if (count > 128)
-                    {
+                    if (count > 128) {
                         // Run
                         value = stbi__get8(s);
                         count -= 128;
-                        if ((count == 0) || (count > nleft))
-                        {
+                        if ((count == 0) || (count > nleft)) {
                             STBI_FREE(hdr_data);
                             STBI_FREE(scanline);
                             return stbi__errpf("corrupt", "bad RLE data in HDR");
                         }
                         for (z = 0; z < count; ++z)
                             scanline[i++ * 4 + k] = value;
-                    }
-                    else
-                    {
+                    } else {
                         // Dump
-                        if ((count == 0) || (count > nleft))
-                        {
+                        if ((count == 0) || (count > nleft)) {
                             STBI_FREE(hdr_data);
                             STBI_FREE(scanline);
                             return stbi__errpf("corrupt", "bad RLE data in HDR");
@@ -8603,10 +7690,9 @@ static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int re
     return hdr_data;
 }
 
-static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
-{
+static int stbi__hdr_info(stbi__context * s, int * x, int * y, int * comp) {
     char buffer[STBI__HDR_BUFLEN];
-    char *token;
+    char * token;
     int valid = 0;
     int dummy;
 
@@ -8617,14 +7703,12 @@ static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
     if (!comp)
         comp = &dummy;
 
-    if (stbi__hdr_test(s) == 0)
-    {
+    if (stbi__hdr_test(s) == 0) {
         stbi__rewind(s);
         return 0;
     }
 
-    for (;;)
-    {
+    for (;;) {
         token = stbi__hdr_gettoken(s, buffer);
         if (token[0] == 0)
             break;
@@ -8632,14 +7716,12 @@ static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
             valid = 1;
     }
 
-    if (!valid)
-    {
+    if (!valid) {
         stbi__rewind(s);
         return 0;
     }
     token = stbi__hdr_gettoken(s, buffer);
-    if (strncmp(token, "-Y ", 3))
-    {
+    if (strncmp(token, "-Y ", 3)) {
         stbi__rewind(s);
         return 0;
     }
@@ -8647,8 +7729,7 @@ static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
     *y = (int)strtol(token, &token, 10);
     while (*token == ' ')
         ++token;
-    if (strncmp(token, "+X ", 3))
-    {
+    if (strncmp(token, "+X ", 3)) {
         stbi__rewind(s);
         return 0;
     }
@@ -8660,15 +7741,13 @@ static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
 #endif // STBI_NO_HDR
 
 #ifndef STBI_NO_BMP
-static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp)
-{
-    void *p;
+static int stbi__bmp_info(stbi__context * s, int * x, int * y, int * comp) {
+    void * p;
     stbi__bmp_data info;
 
     info.all_a = 255;
     p = stbi__bmp_parse_header(s, &info);
-    if (p == NULL)
-    {
+    if (p == NULL) {
         stbi__rewind(s);
         return 0;
     }
@@ -8676,8 +7755,7 @@ static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp)
         *x = s->img_x;
     if (y)
         *y = s->img_y;
-    if (comp)
-    {
+    if (comp) {
         if (info.bpp == 24 && info.ma == 0xff000000)
             *comp = 3;
         else
@@ -8688,8 +7766,7 @@ static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp)
 #endif
 
 #ifndef STBI_NO_PSD
-static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
-{
+static int stbi__psd_info(stbi__context * s, int * x, int * y, int * comp) {
     int channelCount, dummy, depth;
     if (!x)
         x = &dummy;
@@ -8697,33 +7774,28 @@ static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
         y = &dummy;
     if (!comp)
         comp = &dummy;
-    if (stbi__get32be(s) != 0x38425053)
-    {
+    if (stbi__get32be(s) != 0x38425053) {
         stbi__rewind(s);
         return 0;
     }
-    if (stbi__get16be(s) != 1)
-    {
+    if (stbi__get16be(s) != 1) {
         stbi__rewind(s);
         return 0;
     }
     stbi__skip(s, 6);
     channelCount = stbi__get16be(s);
-    if (channelCount < 0 || channelCount > 16)
-    {
+    if (channelCount < 0 || channelCount > 16) {
         stbi__rewind(s);
         return 0;
     }
     *y = stbi__get32be(s);
     *x = stbi__get32be(s);
     depth = stbi__get16be(s);
-    if (depth != 8 && depth != 16)
-    {
+    if (depth != 8 && depth != 16) {
         stbi__rewind(s);
         return 0;
     }
-    if (stbi__get16be(s) != 3)
-    {
+    if (stbi__get16be(s) != 3) {
         stbi__rewind(s);
         return 0;
     }
@@ -8731,31 +7803,26 @@ static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
     return 1;
 }
 
-static int stbi__psd_is16(stbi__context *s)
-{
+static int stbi__psd_is16(stbi__context * s) {
     int channelCount, depth;
-    if (stbi__get32be(s) != 0x38425053)
-    {
+    if (stbi__get32be(s) != 0x38425053) {
         stbi__rewind(s);
         return 0;
     }
-    if (stbi__get16be(s) != 1)
-    {
+    if (stbi__get16be(s) != 1) {
         stbi__rewind(s);
         return 0;
     }
     stbi__skip(s, 6);
     channelCount = stbi__get16be(s);
-    if (channelCount < 0 || channelCount > 16)
-    {
+    if (channelCount < 0 || channelCount > 16) {
         stbi__rewind(s);
         return 0;
     }
     STBI_NOTUSED(stbi__get32be(s));
     STBI_NOTUSED(stbi__get32be(s));
     depth = stbi__get16be(s);
-    if (depth != 16)
-    {
+    if (depth != 16) {
         stbi__rewind(s);
         return 0;
     }
@@ -8764,8 +7831,7 @@ static int stbi__psd_is16(stbi__context *s)
 #endif
 
 #ifndef STBI_NO_PIC
-static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
-{
+static int stbi__pic_info(stbi__context * s, int * x, int * y, int * comp) {
     int act_comp = 0, num_packets = 0, chained, dummy;
     stbi__pic_packet packets[10];
 
@@ -8776,8 +7842,7 @@ static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
     if (!comp)
         comp = &dummy;
 
-    if (!stbi__pic_is4(s, "\x53\x80\xF6\x34"))
-    {
+    if (!stbi__pic_is4(s, "\x53\x80\xF6\x34")) {
         stbi__rewind(s);
         return 0;
     }
@@ -8786,22 +7851,19 @@ static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
 
     *x = stbi__get16be(s);
     *y = stbi__get16be(s);
-    if (stbi__at_eof(s))
-    {
+    if (stbi__at_eof(s)) {
         stbi__rewind(s);
         return 0;
     }
-    if ((*x) != 0 && (1 << 28) / (*x) < (*y))
-    {
+    if ((*x) != 0 && (1 << 28) / (*x) < (*y)) {
         stbi__rewind(s);
         return 0;
     }
 
     stbi__skip(s, 8);
 
-    do
-    {
-        stbi__pic_packet *packet;
+    do {
+        stbi__pic_packet * packet;
 
         if (num_packets == sizeof(packets) / sizeof(packets[0]))
             return 0;
@@ -8813,13 +7875,11 @@ static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
         packet->channel = stbi__get8(s);
         act_comp |= packet->channel;
 
-        if (stbi__at_eof(s))
-        {
+        if (stbi__at_eof(s)) {
             stbi__rewind(s);
             return 0;
         }
-        if (packet->size != 8)
-        {
+        if (packet->size != 8) {
             stbi__rewind(s);
             return 0;
         }
@@ -8844,22 +7904,19 @@ static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
 
 #ifndef STBI_NO_PNM
 
-static int stbi__pnm_test(stbi__context *s)
-{
+static int stbi__pnm_test(stbi__context * s) {
     char p, t;
     p = (char)stbi__get8(s);
     t = (char)stbi__get8(s);
-    if (p != 'P' || (t != '5' && t != '6'))
-    {
+    if (p != 'P' || (t != '5' && t != '6')) {
         stbi__rewind(s);
         return 0;
     }
     return 1;
 }
 
-static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
-{
-    stbi_uc *out;
+static void * stbi__pnm_load(stbi__context * s, int * x, int * y, int * comp, int req_comp, stbi__result_info * ri) {
+    stbi_uc * out;
     STBI_NOTUSED(ri);
 
     ri->bits_per_channel = stbi__pnm_info(s, (int *)&s->img_x, (int *)&s->img_y, (int *)&s->img_n);
@@ -8882,20 +7939,15 @@ static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req
     out = (stbi_uc *)stbi__malloc_mad4(s->img_n, s->img_x, s->img_y, ri->bits_per_channel / 8, 0);
     if (!out)
         return stbi__errpuc("outofmem", "Out of memory");
-    if (!stbi__getn(s, out, s->img_n * s->img_x * s->img_y * (ri->bits_per_channel / 8)))
-    {
+    if (!stbi__getn(s, out, s->img_n * s->img_x * s->img_y * (ri->bits_per_channel / 8))) {
         STBI_FREE(out);
         return stbi__errpuc("bad PNM", "PNM file truncated");
     }
 
-    if (req_comp && req_comp != s->img_n)
-    {
-        if (ri->bits_per_channel == 16)
-        {
+    if (req_comp && req_comp != s->img_n) {
+        if (ri->bits_per_channel == 16) {
             out = (stbi_uc *)stbi__convert_format16((stbi__uint16 *)out, s->img_n, req_comp, s->img_x, s->img_y);
-        }
-        else
-        {
+        } else {
             out = stbi__convert_format(out, s->img_n, req_comp, s->img_x, s->img_y);
         }
         if (out == NULL)
@@ -8904,15 +7956,10 @@ static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req
     return out;
 }
 
-static int stbi__pnm_isspace(char c)
-{
-    return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
-}
+static int stbi__pnm_isspace(char c) { return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r'; }
 
-static void stbi__pnm_skip_whitespace(stbi__context *s, char *c)
-{
-    for (;;)
-    {
+static void stbi__pnm_skip_whitespace(stbi__context * s, char * c) {
+    for (;;) {
         while (!stbi__at_eof(s) && stbi__pnm_isspace(*c))
             *c = (char)stbi__get8(s);
 
@@ -8924,17 +7971,12 @@ static void stbi__pnm_skip_whitespace(stbi__context *s, char *c)
     }
 }
 
-static int stbi__pnm_isdigit(char c)
-{
-    return c >= '0' && c <= '9';
-}
+static int stbi__pnm_isdigit(char c) { return c >= '0' && c <= '9'; }
 
-static int stbi__pnm_getinteger(stbi__context *s, char *c)
-{
+static int stbi__pnm_getinteger(stbi__context * s, char * c) {
     int value = 0;
 
-    while (!stbi__at_eof(s) && stbi__pnm_isdigit(*c))
-    {
+    while (!stbi__at_eof(s) && stbi__pnm_isdigit(*c)) {
         value = value * 10 + (*c - '0');
         *c = (char)stbi__get8(s);
         if ((value > 214748364) || (value == 214748364 && *c > '7'))
@@ -8944,8 +7986,7 @@ static int stbi__pnm_getinteger(stbi__context *s, char *c)
     return value;
 }
 
-static int stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp)
-{
+static int stbi__pnm_info(stbi__context * s, int * x, int * y, int * comp) {
     int maxv, dummy;
     char c, p, t;
 
@@ -8961,8 +8002,7 @@ static int stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp)
     // Get identifier
     p = (char)stbi__get8(s);
     t = (char)stbi__get8(s);
-    if (p != 'P' || (t != '5' && t != '6'))
-    {
+    if (p != 'P' || (t != '5' && t != '6')) {
         stbi__rewind(s);
         return 0;
     }
@@ -8991,16 +8031,14 @@ static int stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp)
         return 8;
 }
 
-static int stbi__pnm_is16(stbi__context *s)
-{
+static int stbi__pnm_is16(stbi__context * s) {
     if (stbi__pnm_info(s, NULL, NULL, NULL) == 16)
         return 1;
     return 0;
 }
 #endif
 
-static int stbi__info_main(stbi__context *s, int *x, int *y, int *comp)
-{
+static int stbi__info_main(stbi__context * s, int * x, int * y, int * comp) {
 #ifndef STBI_NO_JPEG
     if (stbi__jpeg_info(s, x, y, comp))
         return 1;
@@ -9049,8 +8087,7 @@ static int stbi__info_main(stbi__context *s, int *x, int *y, int *comp)
     return stbi__err("unknown image type", "Image not of any known type, or corrupt");
 }
 
-static int stbi__is_16_main(stbi__context *s)
-{
+static int stbi__is_16_main(stbi__context * s) {
 #ifndef STBI_NO_PNG
     if (stbi__png_is16(s))
         return 1;
@@ -9069,9 +8106,8 @@ static int stbi__is_16_main(stbi__context *s)
 }
 
 #ifndef STBI_NO_STDIO
-STBIDEF int stbi_info(char const *filename, int *x, int *y, int *comp)
-{
-    FILE *f = stbi__fopen(filename, "rb");
+STBIDEF int stbi_info(char const * filename, int * x, int * y, int * comp) {
+    FILE * f = stbi__fopen(filename, "rb");
     int result;
     if (!f)
         return stbi__err("can't fopen", "Unable to open file");
@@ -9080,8 +8116,7 @@ STBIDEF int stbi_info(char const *filename, int *x, int *y, int *comp)
     return result;
 }
 
-STBIDEF int stbi_info_from_file(FILE *f, int *x, int *y, int *comp)
-{
+STBIDEF int stbi_info_from_file(FILE * f, int * x, int * y, int * comp) {
     int r;
     stbi__context s;
     long pos = ftell(f);
@@ -9091,9 +8126,8 @@ STBIDEF int stbi_info_from_file(FILE *f, int *x, int *y, int *comp)
     return r;
 }
 
-STBIDEF int stbi_is_16_bit(char const *filename)
-{
-    FILE *f = stbi__fopen(filename, "rb");
+STBIDEF int stbi_is_16_bit(char const * filename) {
+    FILE * f = stbi__fopen(filename, "rb");
     int result;
     if (!f)
         return stbi__err("can't fopen", "Unable to open file");
@@ -9102,8 +8136,7 @@ STBIDEF int stbi_is_16_bit(char const *filename)
     return result;
 }
 
-STBIDEF int stbi_is_16_bit_from_file(FILE *f)
-{
+STBIDEF int stbi_is_16_bit_from_file(FILE * f) {
     int r;
     stbi__context s;
     long pos = ftell(f);
@@ -9114,29 +8147,25 @@ STBIDEF int stbi_is_16_bit_from_file(FILE *f)
 }
 #endif // !STBI_NO_STDIO
 
-STBIDEF int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
-{
+STBIDEF int stbi_info_from_memory(stbi_uc const * buffer, int len, int * x, int * y, int * comp) {
     stbi__context s;
     stbi__start_mem(&s, buffer, len);
     return stbi__info_main(&s, x, y, comp);
 }
 
-STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const *c, void *user, int *x, int *y, int *comp)
-{
+STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const * c, void * user, int * x, int * y, int * comp) {
     stbi__context s;
     stbi__start_callbacks(&s, (stbi_io_callbacks *)c, user);
     return stbi__info_main(&s, x, y, comp);
 }
 
-STBIDEF int stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len)
-{
+STBIDEF int stbi_is_16_bit_from_memory(stbi_uc const * buffer, int len) {
     stbi__context s;
     stbi__start_mem(&s, buffer, len);
     return stbi__is_16_main(&s);
 }
 
-STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user)
-{
+STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const * c, void * user) {
     stbi__context s;
     stbi__start_callbacks(&s, (stbi_io_callbacks *)c, user);
     return stbi__is_16_main(&s);
@@ -9250,12 +8279,9 @@ STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user
       1.30  (2011-06-11)
               added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
               removed deprecated format-specific test/load functions
-              removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
-              error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)
-              fix inefficiency in decoding 32-bit BMP (David Woo)
-      1.29  (2010-08-16)
-              various warning fixes from Aurelien Pocheville
-      1.28  (2010-08-01)
+              removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks
+   anyway error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha) fix inefficiency in
+   decoding 32-bit BMP (David Woo) 1.29  (2010-08-16) various warning fixes from Aurelien Pocheville 1.28  (2010-08-01)
               fix bug in GIF palette transparency (SpartanJ)
       1.27  (2010-08-01)
               cast-to-stbi_uc to fix warnings

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -1,16 +1,14 @@
-#include "ggml/ggml.h"
 #include "clip.h"
 #include "common-clip.h"
+#include "ggml/ggml.h"
 
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
-int main(int argc, char **argv)
-{
-    if (argc != 4 && argc != 5)
-    {
+int main(int argc, char ** argv) {
+    if (argc != 4 && argc != 5) {
         printf("usage: %s <model_path> <images_dir> <num_images_per_dir> [output_file]\n\n", argv[0]);
         printf("model_path: path to CLIP model in GGML format\n");
         printf("images_dir: path to a directory of images where images are organized into subdirectories named classes\n");
@@ -22,12 +20,10 @@ int main(int argc, char **argv)
     std::string model_path = argv[1];
     std::string dir_path = argv[2];
     uint32_t max_files_per_dir = std::stoi(argv[3]); // Example: Limit to 100 files per directory
-    FILE *fout = stdout;
-    if (argc == 5)
-    {
+    FILE * fout = stdout;
+    if (argc == 5) {
         fout = fopen(argv[4], "w");
-        if (fout == NULL)
-        {
+        if (fout == NULL) {
             printf("%s: cannot open file %s\n", __func__, argv[4]);
             return 1;
         }
@@ -38,8 +34,7 @@ int main(int argc, char **argv)
     auto result = get_dir_keyed_files(dir_path, max_files_per_dir);
 
     size_t n_labels = result.size();
-    if (n_labels < 2)
-    {
+    if (n_labels < 2) {
         printf("%s There must be at least 2 directories of images, but %d found\n", __func__, n_labels);
         return 1;
     }
@@ -47,8 +42,7 @@ int main(int argc, char **argv)
     fprintf(fout, "%s: %zu directories found in %s\n\n", __func__, n_labels, dir_path.c_str());
 
     auto ctx = clip_model_load(model_path.c_str(), 2);
-    if (!ctx)
-    {
+    if (!ctx) {
         printf("%s: unable to load model from %s\n", __func__, model_path.c_str());
         return 1;
     }
@@ -68,11 +62,9 @@ int main(int argc, char **argv)
 
     const int64_t t_start_encode_texts = ggml_time_us();
 
-    for (const auto &entry : result)
-    {
+    for (const auto & entry : result) {
         auto tokens = clip_tokenize(ctx, entry.first);
-        if (!clip_text_encode(ctx, n_threads, tokens, txt_vecs + label_idx * vec_dim))
-        {
+        if (!clip_text_encode(ctx, n_threads, tokens, txt_vecs + label_idx * vec_dim)) {
             printf("%s: Could not encode the label at index %d: %s\n", __func__, label_idx, entry.first.c_str());
             return 1;
         }
@@ -100,22 +92,18 @@ int main(int argc, char **argv)
 
     int64_t t_start_encode_images = ggml_time_us();
 
-    for (auto &entry : result)
-    {
+    for (auto & entry : result) {
         int n_items = 0;
         int n_acc1 = 0;
         int n_acc5 = 0;
 
         size_t n_batched = (entry.second.size() / batch_size) * batch_size;
 
-        for (size_t i = 0; i < n_batched; i += batch_size)
-        {
-            for (size_t ib = i; ib < i + batch_size; ib++)
-            {
+        for (size_t i = 0; i < n_batched; i += batch_size) {
+            for (size_t ib = i; ib < i + batch_size; ib++) {
                 std::string file_path = entry.second[ib];
 
-                if (!clip_image_load_from_file(file_path, img_inputs[ib % batch_size]))
-                {
+                if (!clip_image_load_from_file(file_path, img_inputs[ib % batch_size])) {
                     printf("%s: cannot load file from %s\n", __func__, file_path.c_str());
                     return 1;
                 }
@@ -125,24 +113,18 @@ int main(int argc, char **argv)
 
             clip_image_batch_encode(ctx, n_threads, imgs_resized, img_vecs);
 
-            for (size_t b = 0; b < batch_size; b++)
-            {
-                for (size_t j = 0; j < n_labels; j++)
-                {
+            for (size_t b = 0; b < batch_size; b++) {
+                for (size_t j = 0; j < n_labels; j++) {
                     similarities[j] = clip_similarity_score(img_vecs + b * vec_dim, txt_vecs + j * vec_dim, vec_dim);
                 }
                 softmax_with_sorting(similarities, n_labels, sorted_scores, indices);
 
-                for (int k = 0; k < 5; k++)
-                {
-                    if (k == 0 && indices[k] == label_idx)
-                    {
+                for (int k = 0; k < 5; k++) {
+                    if (k == 0 && indices[k] == label_idx) {
                         n_acc1 += 1;
                         n_acc5 += 1;
                         break;
-                    }
-                    else if (indices[k] == label_idx)
-                    {
+                    } else if (indices[k] == label_idx) {
                         n_acc5 += 1;
                         break;
                     }
@@ -164,17 +146,19 @@ int main(int argc, char **argv)
 
     int64_t t_end_encode_images = ggml_time_us();
 
-    fprintf(fout, "| total                | %2.4f | %2.4f |\n\n", total_acc1_score / (float)n_labels, total_acc5_score / (float)n_labels);
+    fprintf(fout, "| total                | %2.4f | %2.4f |\n\n", total_acc1_score / (float)n_labels,
+            total_acc5_score / (float)n_labels);
 
     // print timings
     float total_text_duration = (t_end_encode_texts - t_start_encode_texts) / 1000.0f;
     float total_image_duration = (t_end_encode_images - t_start_encode_images) / 1000.0f;
     fprintf(fout, "# Timings\n");
-    fprintf(fout, "- %d texts encoded in %8.2f ms (%8.2f ms per text)\n", n_labels, total_text_duration, total_text_duration / (float)n_labels);
-    fprintf(fout, "- %d images encoded in %8.2f ms (%8.2f ms per image)\n", n_total_items, total_image_duration, total_image_duration / (float)n_total_items);
+    fprintf(fout, "- %d texts encoded in %8.2f ms (%8.2f ms per text)\n", n_labels, total_text_duration,
+            total_text_duration / (float)n_labels);
+    fprintf(fout, "- %d images encoded in %8.2f ms (%8.2f ms per image)\n", n_total_items, total_image_duration,
+            total_image_duration / (float)n_total_items);
 
-    if (fout != stdout)
-    {
+    if (fout != stdout) {
         fclose(fout);
     }
 


### PR DESCRIPTION

This is necessary to prevent formatting race between different contributions. The style is mainly based on the one used in ggml / llama.cpp projects:

- indentation = 4 spaces
- pointer alignment = middle
- brases on the same line = true
- column width = 128

`sh ./format.sh` does the job by excluding `ggml` and `build` directories.