### PR TITLE
Additions to PR #43 (WIP: Python bindings)

### DIFF
--- a/clip.cpp
+++ b/clip.cpp
@@ -139,11 +139,20 @@ std::vector<clip_vocab::id> clip_tokenize(const clip_ctx * ctx, const std::strin
 }
 
 struct clip_tokens clip_tokenize_c(const clip_ctx * ctx, const char * text) {
-    clip_tokens c_tokens;
-    auto tokens = clip_tokenize(ctx, text);
-    c_tokens.data = tokens.data();
+    std::vector<int> tokens = clip_tokenize(ctx, text);
+
+    clip_tokens c_tokens{};
     c_tokens.size = tokens.size();
+
+    c_tokens.data = new int[tokens.size()];
+    std::copy(tokens.begin(), tokens.end(), c_tokens.data);
+
     return c_tokens;
+}
+
+bool clip_image_load_from_file_c(const char * fname, clip_image_u8 & img) {
+    std::string _fname(fname);
+    return clip_image_load_from_file(_fname, img);
 }
 
 bool clip_image_load_from_file(const std::string & fname, clip_image_u8 & img) {
@@ -817,6 +826,11 @@ void clip_free(clip_ctx * ctx) {
     delete ctx;
 }
 
+bool clip_text_encode_c(const clip_ctx * ctx, int n_threads, const clip_tokens & tokens, float * vec) {
+    std::vector<int> _tokens(tokens.data, tokens.data + tokens.size);
+    return clip_text_encode(ctx, n_threads, _tokens, vec);
+}
+
 bool clip_text_encode(const clip_ctx * ctx, int n_threads, const std::vector<clip_vocab::id> & tokens, float * vec) {
     const auto & model = ctx->text_model;
     const auto & hparams = model.hparams;
@@ -1311,6 +1325,11 @@ float clip_similarity_score(float * vec1, float * vec2, int vec_dim) {
     float clamped_dot_product = fmin(fmax(dot_product, 0.0), 1.0);
 
     return clamped_dot_product;
+}
+
+bool clip_compare_text_and_image_c(clip_ctx * ctx, int n_threads, char * text, clip_image_u8 & image, float * score) {
+    std::string _text(text);
+    return clip_compare_text_and_image(ctx, n_threads, _text, image, score);
 }
 
 bool clip_compare_text_and_image(clip_ctx * ctx, int n_threads, std::string & text, clip_image_u8 & image, float * score) {

--- a/clip.h
+++ b/clip.h
@@ -173,27 +173,35 @@ struct clip_image_f32 {
 
 struct clip_tokens clip_tokenize_c(const clip_ctx * ctx, const char * text);
 
-bool clip_image_load_from_file(const std::string & fname, clip_image_u8 & img);
+bool clip_image_load_from_file_c(const char * fname, clip_image_u8 & img);
 bool clip_image_preprocess(const clip_ctx * ctx, const clip_image_u8 * img, clip_image_f32 * res);
-void clip_image_batch_preprocess(const clip_ctx * ctx, const int n_threads, const std::vector<clip_image_u8> & img_inputs,
-                                 std::vector<clip_image_f32> & img_resized);
 
-bool clip_text_encode(const clip_ctx * ctx, int n_threads, const std::vector<clip_vocab::id> & tokens, float * vec);
-
+bool clip_text_encode_c(const clip_ctx * ctx, int n_threads, const clip_tokens & tokens, float * vec);
 bool clip_image_encode(const clip_ctx * ctx, int n_threads, const clip_image_f32 & img, float * vec);
 
 // bool image_normalize(clip_image_u8 *img, clip_image_f32 *res);
 
-bool clip_compare_text_and_image(clip_ctx * ctx, int n_threads, std::string & text, clip_image_u8 & image, float * score);
+bool clip_compare_text_and_image_c(clip_ctx * ctx, int n_threads, char * text, clip_image_u8 & image, float * score);
 float clip_similarity_score(float * vec1, float * vec2, int vec_dim);
 bool softmax_with_sorting(float * arr, int length, float * sorted_scores, int * indices);
-
-bool clip_image_batch_encode(const clip_ctx * ctx, int n_threads, const std::vector<clip_image_f32> & imgs, float * vec);
 
 #ifdef __cplusplus
 }
 
 std::vector<clip_vocab::id> clip_tokenize(const clip_ctx * ctx, const std::string & text);
+
+bool clip_image_load_from_file(const std::string & fname, clip_image_u8 & img);
+
+bool clip_text_encode(const clip_ctx * ctx, int n_threads, const std::vector<clip_vocab::id> & tokens, float * vec);
+
+bool clip_compare_text_and_image(clip_ctx * ctx, int n_threads, std::string & text, clip_image_u8 & image, float * score);
+
+// TODO clip_image_batch_encode_c
+bool clip_image_batch_encode(const clip_ctx * ctx, int n_threads, const std::vector<clip_image_f32> & imgs, float * vec);
+
+// TODO clip_image_batch_preprocess_c
+void clip_image_batch_preprocess(const clip_ctx * ctx, const int n_threads, const std::vector<clip_image_u8> & img_inputs,
+                                 std::vector<clip_image_f32> & img_resized);
 
 #endif
 

--- a/examples/python_bindings/clip.py
+++ b/examples/python_bindings/clip.py
@@ -1,5 +1,8 @@
 import ctypes
 import os
+from typing import List, Dict, Any
+
+# Note: Pass -DBUILD_SHARED_LIBS=ON to cmake to create the shared library file
 
 # Load the shared library
 path_to_dll = os.environ.get("CLIP_DLL", "./libclip.so")
@@ -32,16 +35,9 @@ class ClipVisionHparams(ctypes.Structure):
     ]
 
 
-class ClipVocabId(ctypes.c_int32):
-    pass
-
-
-class ClipVocabToken(ctypes.c_char_p):
-    pass
-
-
-class ClipVocabSpecialTokens(ctypes.c_char_p):
-    pass
+ClipVocabId = ctypes.c_int32
+ClipVocabToken = ctypes.c_char_p
+ClipVocabSpecialTokens = ctypes.c_char_p
 
 
 class ClipVocab(ctypes.Structure):
@@ -49,6 +45,13 @@ class ClipVocab(ctypes.Structure):
         ("token_to_id", ctypes.POINTER(ctypes.c_void_p)),
         ("id_to_token", ctypes.POINTER(ctypes.c_void_p)),
         ("special_tokens", ctypes.POINTER(ClipVocabSpecialTokens)),
+    ]
+
+
+class ClipTokens(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.POINTER(ClipVocabId)),
+        ("size", ctypes.c_size_t),
     ]
 
 
@@ -125,51 +128,62 @@ class ClipImageF32(ctypes.Structure):
     ]
 
 
+class ClipContext(ctypes.Structure):
+    _fields_ = [
+        ("text_model", ClipTextModel),
+        ("vision_model", ClipVisionModel),
+        ("vocab", ClipVocab),
+        ("use_gelu", ctypes.c_int32),
+        ("ftype", ctypes.c_int32),
+        ("buf_compute", ClipBuffer),
+    ]
+
+
 # Load the functions from the shared library
 clip_model_load = clip_lib.clip_model_load
 clip_model_load.argtypes = [ctypes.c_char_p, ctypes.c_int]
-clip_model_load.restype = ctypes.POINTER(ctypes.c_void_p)
+clip_model_load.restype = ctypes.POINTER(ClipContext)
 
 clip_free = clip_lib.clip_free
-clip_free.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+clip_free.argtypes = [ctypes.POINTER(ClipContext)]
 
-clip_tokenize = clip_lib.clip_tokenize
-clip_tokenize.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
-clip_tokenize.restype = ctypes.POINTER(ClipVocabId)
+clip_tokenize = clip_lib.clip_tokenize_c
+clip_tokenize.argtypes = [ctypes.POINTER(ClipContext), ctypes.c_char_p]
+clip_tokenize.restype = ClipTokens
 
-clip_image_load_from_file = clip_lib.clip_image_load_from_file
+clip_image_load_from_file = clip_lib.clip_image_load_from_file_c
 clip_image_load_from_file.argtypes = [ctypes.c_char_p, ctypes.POINTER(ClipImageU8)]
 clip_image_load_from_file.restype = ctypes.c_bool
 
 clip_image_preprocess = clip_lib.clip_image_preprocess
 clip_image_preprocess.argtypes = [
-    ctypes.POINTER(ctypes.c_void_p),
+    ctypes.POINTER(ClipContext),
     ctypes.POINTER(ClipImageU8),
     ctypes.POINTER(ClipImageF32),
 ]
 clip_image_preprocess.restype = ctypes.c_bool
 
-clip_text_encode = clip_lib.clip_text_encode
+clip_text_encode = clip_lib.clip_text_encode_c
 clip_text_encode.argtypes = [
-    ctypes.POINTER(ctypes.c_void_p),
+    ctypes.POINTER(ClipContext),
     ctypes.c_int,
-    ctypes.POINTER(ClipVocabId),
+    ctypes.POINTER(ClipTokens),
     ctypes.POINTER(ctypes.c_float),
 ]
 clip_text_encode.restype = ctypes.c_bool
 
 clip_image_encode = clip_lib.clip_image_encode
 clip_image_encode.argtypes = [
-    ctypes.POINTER(ctypes.c_void_p),
+    ctypes.POINTER(ClipContext),
     ctypes.c_int,
     ctypes.POINTER(ClipImageF32),
     ctypes.POINTER(ctypes.c_float),
 ]
 clip_image_encode.restype = ctypes.c_bool
 
-clip_compare_text_and_image = clip_lib.clip_compare_text_and_image
+clip_compare_text_and_image = clip_lib.clip_compare_text_and_image_c
 clip_compare_text_and_image.argtypes = [
-    ctypes.POINTER(ctypes.c_void_p),
+    ctypes.POINTER(ClipContext),
     ctypes.c_int,
     ctypes.c_char_p,
     ctypes.POINTER(ClipImageU8),
@@ -204,9 +218,83 @@ clip_image_batch_encode.argtypes = [
 clip_image_batch_encode.restype = ctypes.c_bool
 
 
+def _struct_to_dict(struct):
+    return dict((field, getattr(struct, field)) for field, _ in struct._fields_)
+
+
 class Clip:
-    def __init__(self, model_file: str, verbose=0):
-        self.ctx = clip_model_load(model_file.encode("utf8"), verbose)
+    def __init__(self, model_file: str, verbosity: int = 0):
+        self.ctx = clip_model_load(model_file.encode("utf8"), verbosity)
+        # TODO vision_config has wrong values for some reason, hard-coding vec_dim temporarily
+        self.vec_dim = 512
+
+    @property
+    def vision_config(self) -> Dict[str, Any]:
+        return _struct_to_dict(self.ctx.contents.vision_model.hparams)
+
+    @property
+    def text_config(self) -> Dict[str, Any]:
+        return _struct_to_dict(self.ctx.contents.text_model.hparams)
+
+    def tokenize(self, text: str) -> List[int]:
+        tokens = clip_tokenize(self.ctx, text.encode("utf8"))
+        return [tokens.data[i] for i in range(tokens.size)]
+
+    def encode_text(self, tokens: List[int], n_threads: int = os.cpu_count()) -> List[float]:
+        tokens_array = (ClipVocabId * len(tokens))(*tokens)
+        clip_tokens = ClipTokens(data=tokens_array, size=len(tokens))
+
+        txt_vec = (ctypes.c_float * self.vec_dim)()
+
+        if not clip_text_encode(self.ctx, n_threads, ctypes.pointer(clip_tokens), txt_vec):
+            raise RuntimeError("Could not encode text")
+
+        return [txt_vec[i] for i in range(self.vec_dim)]
+
+    def load_preprocess_encode_image(
+            self,
+            image_path: str,
+            n_threads: int = os.cpu_count(),
+            # Initializing here as a temporary workaround for SIGSEGV when done inside the function scope
+            image: ClipImageU8 = ClipImageU8(),
+            processed_image: ClipImageF32 = ClipImageF32(),
+    ) -> List[float]:
+        if not clip_image_load_from_file(image_path.encode("utf8"), ctypes.pointer(image)):
+            raise RuntimeError(f"Could not load image {image_path}")
+
+        if not clip_image_preprocess(self.ctx, ctypes.pointer(image), ctypes.pointer(processed_image)):
+            raise RuntimeError("Could not preprocess image")
+
+        img_vec = (ctypes.c_float * self.vec_dim)()
+        if not clip_image_encode(self.ctx, n_threads, ctypes.pointer(processed_image), img_vec):
+            raise RuntimeError("Could not encode image")
+
+        return [img_vec[i] for i in range(self.vec_dim)]
+
+    def calculate_similarity(self, text_embedding: List[float], image_embedding: List[float]) -> float:
+        img_vec = (ctypes.c_float * self.vec_dim)(*image_embedding)
+        txt_vec = (ctypes.c_float * self.vec_dim)(*text_embedding)
+
+        return clip_similarity_score(txt_vec, img_vec, self.vec_dim)
+
+    def compare_text_and_image(
+            self,
+            text: str,
+            image_path: str,
+            n_threads: int = os.cpu_count(),
+            # Initializing here as a temporary workaround for SIGSEGV when done inside the function scope
+            image: ClipImageU8 = ClipImageU8(),
+    ) -> float:
+        if not clip_image_load_from_file(image_path.encode("utf8"), ctypes.pointer(image)):
+            raise RuntimeError(f"Could not load image {image_path}")
+
+        score = ctypes.c_float()
+        if not clip_compare_text_and_image(
+                self.ctx, n_threads, text.encode("utf8"), ctypes.pointer(image), ctypes.pointer(score)
+        ):
+            raise RuntimeError("Could not compare text and image")
+
+        return score.value
 
     def __del__(self):
         clip_free(self.ctx)
@@ -217,6 +305,22 @@ if __name__ == "__main__":
 
     ap = argparse.ArgumentParser(prog="clip")
     ap.add_argument("-m", "--model", help="path to GGML file")
+    ap.add_argument("-v", "--verbosity", type=int, help="Level of verbosity. 0 = minimum, 2 = maximum", default=0)
     args = ap.parse_args()
 
-    clip = Clip(args.model, 2)
+    clip = Clip(args.model, args.verbosity)
+
+    text = "an apple"
+    image_path = "../../tests/red_apple.jpg"
+
+    tokens = clip.tokenize(text)
+    text_embed = clip.encode_text(tokens)
+
+    image_embed = clip.load_preprocess_encode_image(image_path)
+
+    score = clip.calculate_similarity(text_embed, image_embed)
+
+    # Alternatively, you can just do:
+    # score = clip.compare_text_and_image(text, image_path)
+
+    print(f"Similarity score: {score}")


### PR DESCRIPTION
Almost all the functions in `clip.h` are now C-compatible.

The `Clip` Python class has wrapper methods for all the C-compatible functions, and property getters for the model configs.
Example usage is shown in `clip.py` as well.

There are some remaining TODOs:
- `self.ctx.contents.vision_model.hparams` gets random values, not sure if it gets `free`d somewhere accidentally or if there's another issue (`self.ctx.contents.text_model.hparams` works though)
- Getting some `SIGSEGV`s for `ClipImageU8` and `ClipImageF32`
- `clip_image_batch_encode` and `clip_image_batch_preprocess` do not have C-compatible wrappers yet
- I combined loading, preprocessing, and encoding images into one method in the Python class because it didn't seem useful to me to keep the intermediary C values. You may or may not want to keep this design decision.
- I am currently returning Python lists, it could be worth returning numpy arrays instead, but that would add a dependency.

Relevant issue: #41