### PR TITLE
docs✨: Add colab notebook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # clip.cpp
+
 CLIP inference in plain C/C++ with no extra dependencies
 
 ## Description
+
 This is a dependency free implementation of well known [CLIP](https://github.com/openai/clip) by OpenAI,
 thanks to the great work in [GGML](https://github.com/ggerganov/ggml).
 You can use it to work with CLIP models from both OpenAI and LAION
 in Transformers format.
 
 ## Motivation
+
 CLIP is deployed for several task from semantic image search to zero-shot image labeling.
 It's also a part of Stable Diffusion and and the recently emerging field of large multimodal models (LMM).
 This repo is aimed at powering useful applications based on such models on computation- or memory-constraint devices.
@@ -16,21 +19,24 @@ This repo is aimed at powering useful applications based on such models on compu
 clip.cpp also has a short startup time compared to large ML frameworks, which makes it suitable for serverless deployments where the cold start is an issue.
 
 ## Hot topics
-- 09/14/2023: All functions are C-compatible now. `zsl` example is updated to match Huggingface's zero-shot behavior in the zero-shot pipeline.
-- 09/11/2023: Introduce Python bindings.
-- 07/12/2023: Batch inference support for image encoding.
-- 07/11/2023: Semantic image search [example](examples/image-search/README.md) directly in C++.
+
+-   09/14/2023: All functions are C-compatible now. `zsl` example is updated to match Huggingface's zero-shot behavior in the zero-shot pipeline.
+-   09/11/2023: Introduce Python bindings.
+-   07/12/2023: Batch inference support for image encoding.
+-   07/11/2023: Semantic image search [example](examples/image-search/README.md) directly in C++.
 
 ## Note about image preprocessing
+
 PIL uses a two-pass convolutions-based bicubic interpolation in resizing with antialiasing applied. In Pytorch, antialiasing is optional. It needs some extra attention to implement this preprocessing logic that matches their results numerically. However, I found that linear interpolation is also good enough for both comparison of different embeddings from this implementation and also comparison of an embedding from this implementation and another one from Transformers. So let's use it until we craft a proper bicubic interpolation.
 
-
 ## Preconverted Models
+
 Preconverted Models can be found in [HuggingFace Repositories tagged with `clip.cpp`](https://huggingface.co/models?other=clip.cpp).
 If you want to do conversion yourself for some reason, see below for how.
 Otherwise, download a model of your choice from the link above and then feel free to jump to the building section.
 
 ## Model conversion
+
 You can convert CLIP models from OpenAI and LAION in Transformers format. Apparently, LAION's models outperform OpenAI models in several benchmarks, so they are recommended.
 
 1. Clone the model repo from HF Hub:
@@ -64,6 +70,7 @@ python convert_hf_to_ggml.py ../../CLIP-ViT-B-32-laion2B-s34B-b79K 1
 The output `ggml-model-f16.bin` file is in the model directory specified in the command above.
 
 ## Building
+
 ```shell
 git clone --recurse-submodules https://github.com/monatis/clip.cpp.git
 
@@ -84,13 +91,14 @@ And the binaries are in the `./bin` directory.
 I couldn't reproduce it on my Macbook M2 pro so cannot help further. If you know a solution that I can include in `CMakeLists.txt` please ping me [here](https://github.com/monatis/clip.cpp/issues/24).
 
 ## Quantization
+
 `clip.cpp` currently supports q4_0 and q4_1 quantization types.
 You can quantize a model in F16 to one of these types by using the `./bin/quantize` binary.
 
 ```
-usage: ./bin/quantize /path/to/ggml-model-f16.bin /path/to/ggml-model-quantized.bin type                                 
-  type = 2 - q4_0                                                                                                       
-  type = 3 - q4_1                                                                                                       
+usage: ./bin/quantize /path/to/ggml-model-f16.bin /path/to/ggml-model-quantized.bin type
+  type = 2 - q4_0
+  type = 3 - q4_1
 ```
 
 For example, you can run the following to convert the model to q4_0:
@@ -102,27 +110,28 @@ For example, you can run the following to convert the model to q4_0:
 Now you can use `ggml-model-q4_0.bin` just like the model in F16.
 
 ## Usage
+
 Currently we have three examples: `main`, `zsl` and `image-search`.
 
 1. `main` is just for demonstrating the usage of API and optionally print out some verbose timings. It simply calculates the similarity between one image and one text passed as CLI args.
 
 ```
-Usage: ./bin/main [options]                                                                                             
-                                                                                                                        
-Options:  -h, --help: Show this message and exit                                                                        
-  -m <path>, --model <path>: path to model. Default: models/ggml-model-f16.bin                                          
-  -t N, --threads N: Number of threads to use for inference. Default: 4                                                 
-  --text <text>: Text to encode. At least one text should be specified                                                  
-  --image <path>: Path to an image file. At least one image path should be specified                                    
-  -v <level>, --verbose <level>: Control the level of verbosity. 0 = minimum, 2 = maximum. Default: 1                    
+Usage: ./bin/main [options]
+
+Options:  -h, --help: Show this message and exit
+  -m <path>, --model <path>: path to model. Default: models/ggml-model-f16.bin
+  -t N, --threads N: Number of threads to use for inference. Default: 4
+  --text <text>: Text to encode. At least one text should be specified
+  --image <path>: Path to an image file. At least one image path should be specified
+  -v <level>, --verbose <level>: Control the level of verbosity. 0 = minimum, 2 = maximum. Default: 1
 ```
 
 2. `zsl` is a zero-shot image labeling example. It labels an image with one of the labels.
-The CLI args are the same as in `main`,
-but you must specify multiple `--text` arguments to specify the labels.
+   The CLI args are the same as in `main`,
+   but you must specify multiple `--text` arguments to specify the labels.
 
 3. `image-search` is an example for semantic image search with [USearch](https://github.com/unum-cloud/usearch/).
-You must enable `CLIP_BUILD_IMAGE_SEARCH` option to compile it, and the dependency will be automatically fetched by cmake:
+   You must enable `CLIP_BUILD_IMAGE_SEARCH` option to compile it, and the dependency will be automatically fetched by cmake:
 
 ```sh
 mkdir build
@@ -137,6 +146,7 @@ make
 See [examples/image-search/README.md](examples/image-search/README.md) for more info and usage.
 
 ## Python bindings
+
 You can use clip.cpp in Python with no third-party libraries (no dependencies other than standard Python libraries).
 It uses `ctypes` to load a dynamically linked library (DLL) to interface the implementation in C/C++.
 
@@ -145,6 +155,10 @@ If you are on an X64 Linux distribution, you can simply Pip-install it with AVX2
 ```sh
 pip install clip_cpp
 ```
+
+> Colab Notebook available for quick experiment :
+>
+> <a href="https://colab.research.google.com/github/Yossef-Dawoad/clip.cpp/blob/add_colab_notebook_example/examples/python_bindings/notebooks/clipcpp_demo.ipynb" target="_blank"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
 If you are on another operating system or architecture,
 or if you want to make use of support for instruction sets other than AVX2 (e.g., AVX512),
@@ -165,23 +179,23 @@ make
 And find the `libclip.so` binary in the `build` directory.
 See [examples/python_bindings/README.md](examples/python_bindings/README.md) for more info and usage.
 
-
 ## Benchmarking
+
 You can use the benchmarking utility to compare the performances of different checkpoints and quantization types.
 
 ```
-usage: ./bin/benchmark <model_path> <images_dir> <num_images_per_dir> [output_file]                                     
-                                                                                                                        
-model_path: path to CLIP model in GGML format                                                                           
-images_dir: path to a directory of images where images are organized into subdirectories named classes                  
-num_images_per_dir: maximum number of images to read from each one of subdirectories. if 0, read all files              
-output_file: optional. if specified, dump the output to this file instead of stdout                                     
-```
+usage: ./bin/benchmark <model_path> <images_dir> <num_images_per_dir> [output_file]
 
+model_path: path to CLIP model in GGML format
+images_dir: path to a directory of images where images are organized into subdirectories named classes
+num_images_per_dir: maximum number of images to read from each one of subdirectories. if 0, read all files
+output_file: optional. if specified, dump the output to this file instead of stdout
+```
 
 TODO: share benchmarking results for a common dataset later on.
 
 ## Future Work
-- [ ] Support `text-only`, `image-only` and `both` (current) options when exporting, and modify model loading logic accordingly. It might be relevant to use a single modality in certain cases, as in large multimodal models, or building and/or searching for semantic image search.
-- [ ] Seperate memory buffers for text and image models, as their memory requirements are different.
-- [ ] Implement proper bicubic interpolation (PIL uses a convolutions-based algorithm, and it's more stable than affine transformations).
+
+-   [ ] Support `text-only`, `image-only` and `both` (current) options when exporting, and modify model loading logic accordingly. It might be relevant to use a single modality in certain cases, as in large multimodal models, or building and/or searching for semantic image search.
+-   [ ] Seperate memory buffers for text and image models, as their memory requirements are different.
+-   [ ] Implement proper bicubic interpolation (PIL uses a convolutions-based algorithm, and it's more stable than affine transformations).

--- a/examples/python_bindings/notebooks/clipcpp_demo.ipynb
+++ b/examples/python_bindings/notebooks/clipcpp_demo.ipynb
@@ -1,0 +1,3370 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "collapsed_sections": [
+        "D3MQHKeixw4b"
+      ],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "4ae67bba152f4240adbe501402f70e8e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_7c5d5c25159343e2ad0756ec6346bc6d",
+              "IPY_MODEL_7525713bf9434a8e83ccdd1bc94792a8",
+              "IPY_MODEL_746a421cfd89487585007264cc316536"
+            ],
+            "layout": "IPY_MODEL_8d4f2cea3f02404ea5aed908d6e7ac38"
+          }
+        },
+        "7c5d5c25159343e2ad0756ec6346bc6d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_b1d89c5c59ab4c169ba53e5b01602590",
+            "placeholder": "​",
+            "style": "IPY_MODEL_ef1c0a8257434468bb70636ac049035a",
+            "value": "Downloading readme: 100%"
+          }
+        },
+        "7525713bf9434a8e83ccdd1bc94792a8": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_023c6c4ed3b446188eeaaa8151649fd2",
+            "max": 867,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_6e9e8d05043a4b1cb30af96f34ab2d97",
+            "value": 867
+          }
+        },
+        "746a421cfd89487585007264cc316536": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_1b763c56ae2d46829e53e18cbd6ae7ef",
+            "placeholder": "​",
+            "style": "IPY_MODEL_5abc9e4f2eb6438e86dd127f9f96d08a",
+            "value": " 867/867 [00:00&lt;00:00, 22.6kB/s]"
+          }
+        },
+        "8d4f2cea3f02404ea5aed908d6e7ac38": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "b1d89c5c59ab4c169ba53e5b01602590": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "ef1c0a8257434468bb70636ac049035a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "023c6c4ed3b446188eeaaa8151649fd2": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "6e9e8d05043a4b1cb30af96f34ab2d97": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "1b763c56ae2d46829e53e18cbd6ae7ef": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "5abc9e4f2eb6438e86dd127f9f96d08a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "eca90f32fc9248769e710913f60b9b7c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_6d1630037e604e83b8b37b13221c0113",
+              "IPY_MODEL_2701f0097b2e40f58d3d2933c40f5ad1",
+              "IPY_MODEL_fc6e9db41ffa469d8c968afe968f8333"
+            ],
+            "layout": "IPY_MODEL_68711a15d3454c6da258d61210b6fff5"
+          }
+        },
+        "6d1630037e604e83b8b37b13221c0113": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_f5f4d0cc28d64341b290eef632dfd6c6",
+            "placeholder": "​",
+            "style": "IPY_MODEL_4a81afcd4c2e4b9e9973600c21a6a03f",
+            "value": "Downloading data files: 100%"
+          }
+        },
+        "2701f0097b2e40f58d3d2933c40f5ad1": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_fcd94e1dc1bb41e2a9e26e9eff76c540",
+            "max": 1,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_d0596dc4deb247a8b3af85c619adec7d",
+            "value": 1
+          }
+        },
+        "fc6e9db41ffa469d8c968afe968f8333": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_6857472d8e4b4dd68278597963525e1a",
+            "placeholder": "​",
+            "style": "IPY_MODEL_61e755addc4c4fe6920be4081155c766",
+            "value": " 1/1 [00:11&lt;00:00, 11.52s/it]"
+          }
+        },
+        "68711a15d3454c6da258d61210b6fff5": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "f5f4d0cc28d64341b290eef632dfd6c6": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "4a81afcd4c2e4b9e9973600c21a6a03f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "fcd94e1dc1bb41e2a9e26e9eff76c540": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "d0596dc4deb247a8b3af85c619adec7d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "6857472d8e4b4dd68278597963525e1a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "61e755addc4c4fe6920be4081155c766": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "6632fa54917a4a66949ac64be2405eae": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_252bc9f78759418c91bcc7a162fed88f",
+              "IPY_MODEL_74e10b36274d45adb9ddf63f10824b86",
+              "IPY_MODEL_974691f61e5846efaa42e118cd87ff72"
+            ],
+            "layout": "IPY_MODEL_989e22e99798474089ed8c55d9adf74f"
+          }
+        },
+        "252bc9f78759418c91bcc7a162fed88f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_020b30456ac04d02b0d511a9780e0169",
+            "placeholder": "​",
+            "style": "IPY_MODEL_9b88d8521b964d829c0ff02e53983197",
+            "value": "Downloading data: 100%"
+          }
+        },
+        "74e10b36274d45adb9ddf63f10824b86": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_3088b25b28d843888b3ed4443a43cd4a",
+            "max": 136091680,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_2b76a7691c33466a908d23d8c5698867",
+            "value": 136091680
+          }
+        },
+        "974691f61e5846efaa42e118cd87ff72": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_f9e253e85ff942b4b7025fa80bcd43c9",
+            "placeholder": "​",
+            "style": "IPY_MODEL_109cf29003f8412ba5d9ea731f95ec3f",
+            "value": " 136M/136M [00:05&lt;00:00, 24.3MB/s]"
+          }
+        },
+        "989e22e99798474089ed8c55d9adf74f": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "020b30456ac04d02b0d511a9780e0169": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "9b88d8521b964d829c0ff02e53983197": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "3088b25b28d843888b3ed4443a43cd4a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "2b76a7691c33466a908d23d8c5698867": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "f9e253e85ff942b4b7025fa80bcd43c9": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "109cf29003f8412ba5d9ea731f95ec3f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "a58c4bf3ff87443bb130154914fd6d30": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_d59eb2b6f7a34c828cb732a8ac86febf",
+              "IPY_MODEL_8233eea0e1404d59960253f136c7c098",
+              "IPY_MODEL_f8a61b8bab194518a303bd620c244186"
+            ],
+            "layout": "IPY_MODEL_f598bcca46204914b14767473fefd867"
+          }
+        },
+        "d59eb2b6f7a34c828cb732a8ac86febf": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_412e57470bae42609ff839adf0e2f802",
+            "placeholder": "​",
+            "style": "IPY_MODEL_41ad3ca4daa74aa494de4d4b56d166fb",
+            "value": "Downloading data: 100%"
+          }
+        },
+        "8233eea0e1404d59960253f136c7c098": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_2242e5ca5f5943efb9d6cc6158954c8e",
+            "max": 135404761,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_f27f0685c73944b794af96df74fd36bc",
+            "value": 135404761
+          }
+        },
+        "f8a61b8bab194518a303bd620c244186": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_13e4be26528b4d1dbb5f3a8be1458635",
+            "placeholder": "​",
+            "style": "IPY_MODEL_7486b22826a74aae85071f33f0fc3a17",
+            "value": " 135M/135M [00:06&lt;00:00, 31.3MB/s]"
+          }
+        },
+        "f598bcca46204914b14767473fefd867": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "412e57470bae42609ff839adf0e2f802": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "41ad3ca4daa74aa494de4d4b56d166fb": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "2242e5ca5f5943efb9d6cc6158954c8e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "f27f0685c73944b794af96df74fd36bc": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "13e4be26528b4d1dbb5f3a8be1458635": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "7486b22826a74aae85071f33f0fc3a17": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "1a4295168897427eb269166acf54b014": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_165cd045e8f144ecb7d0c3901964259e",
+              "IPY_MODEL_1f5e7e234d544e5e8637b67f876d7397",
+              "IPY_MODEL_be7fceea155642f5b983df24bdd7ca3f"
+            ],
+            "layout": "IPY_MODEL_c892d6a91ccd41b9b2a34831dd566555"
+          }
+        },
+        "165cd045e8f144ecb7d0c3901964259e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_6997b6fb2bac419d85adc36f415587ea",
+            "placeholder": "​",
+            "style": "IPY_MODEL_648fc8fc6c804aae9faf02f09a64e2b4",
+            "value": "Extracting data files: 100%"
+          }
+        },
+        "1f5e7e234d544e5e8637b67f876d7397": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_a1670f5b5fc3434985acbe1f5cb61f0e",
+            "max": 1,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_8739d5ebc54a41529741cc43b91ade67",
+            "value": 1
+          }
+        },
+        "be7fceea155642f5b983df24bdd7ca3f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_7607d0df712a45499051e8ab1e7a1cc3",
+            "placeholder": "​",
+            "style": "IPY_MODEL_c50b5960a4614bdd9ce3c940e3207a35",
+            "value": " 1/1 [00:00&lt;00:00, 11.84it/s]"
+          }
+        },
+        "c892d6a91ccd41b9b2a34831dd566555": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "6997b6fb2bac419d85adc36f415587ea": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "648fc8fc6c804aae9faf02f09a64e2b4": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "a1670f5b5fc3434985acbe1f5cb61f0e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "8739d5ebc54a41529741cc43b91ade67": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "7607d0df712a45499051e8ab1e7a1cc3": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "c50b5960a4614bdd9ce3c940e3207a35": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "dfc716ebacef49e1aeb4de6a22303aa2": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_d0e7e6ae228e4eca92d1c29bd51e281d",
+              "IPY_MODEL_00618ab3c8064ead9c5e36c36f15b9f5",
+              "IPY_MODEL_4482e1cbf57c4a64886843cf0945ceac"
+            ],
+            "layout": "IPY_MODEL_9e8b1fba499b4333b460022371ec51cd"
+          }
+        },
+        "d0e7e6ae228e4eca92d1c29bd51e281d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_da665853f8144b7caa80a54034499bc9",
+            "placeholder": "​",
+            "style": "IPY_MODEL_58a9d43ad9654e39aa3a022b6c7bcfcf",
+            "value": "Generating train split: 100%"
+          }
+        },
+        "00618ab3c8064ead9c5e36c36f15b9f5": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_ba3cab9e1105440299aaecf75b533468",
+            "max": 44072,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_1a8d331fc5944af788491ae42cc2631d",
+            "value": 44072
+          }
+        },
+        "4482e1cbf57c4a64886843cf0945ceac": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_31dcc7dd63af4947a793f9adc4a43846",
+            "placeholder": "​",
+            "style": "IPY_MODEL_40bbfc78bd494552ba6f9a17ea1aa9bf",
+            "value": " 44072/44072 [00:04&lt;00:00, 8122.41 examples/s]"
+          }
+        },
+        "9e8b1fba499b4333b460022371ec51cd": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "da665853f8144b7caa80a54034499bc9": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "58a9d43ad9654e39aa3a022b6c7bcfcf": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "ba3cab9e1105440299aaecf75b533468": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "1a8d331fc5944af788491ae42cc2631d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "31dcc7dd63af4947a793f9adc4a43846": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "40bbfc78bd494552ba6f9a17ea1aa9bf": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/Yossef-Dawoad/clip.cpp/blob/add_colab_notebook_example/examples/python_bindings/notebooks/clipcpp_demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Downloading an image from internet"
+      ],
+      "metadata": {
+        "id": "tqrOHxcPxfyj"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!wget https://i.imgur.com/8H7XCH0.jpg -O cat.jpg"
+      ],
+      "metadata": {
+        "id": "oOaE1AmDyth_",
+        "outputId": "e32b635b-af09-4aa0-ca86-654a7e731d56",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--2023-09-13 19:58:43--  https://i.imgur.com/8H7XCH0.jpg\n",
+            "Resolving i.imgur.com (i.imgur.com)... 146.75.92.193\n",
+            "Connecting to i.imgur.com (i.imgur.com)|146.75.92.193|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 44544 (44K) [image/jpeg]\n",
+            "Saving to: ‘cat.jpg’\n",
+            "\n",
+            "\rcat.jpg               0%[                    ]       0  --.-KB/s               \rcat.jpg             100%[===================>]  43.50K  --.-KB/s    in 0.006s  \n",
+            "\n",
+            "2023-09-13 19:58:43 (7.65 MB/s) - ‘cat.jpg’ saved [44544/44544]\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from IPython.display import Image\n",
+        "Image('cat.jpg')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 407
+        },
+        "id": "Y9Q6bhVA2L01",
+        "outputId": "abfccda4-eca6-4be3-d88c-f66823849bab"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "image/jpeg": "/9j/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAGGAiADASIAAhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAABAUCAwYBAAf/xABHEAACAQMCAwUFBwIFAgUDBAMBAgMABBESIQUxQRMiUWHwcYGRodEGFDKxweHxI0IHFVJi0jOiFiRygpJDssIXNERTJWNz/8QAGgEAAwEBAQEAAAAAAAAAAAAAAQIDAAQFBv/EACgRAAICAgICAwADAQADAQAAAAABAhEDIRIxBEETIlEUMmFxBTNCUv/aAAwDAQACEQMRAD8A+ocW40kaHvDlXzXj3GjMXVW29tD8Q4vPdFhrYDOcH9frSaWJ5Gy3M/H+fKvIX6z0+SiqQHLMzserZ9eutUkHTzxz2A9fCjRb45bn2VE25GOR36+vnT2D5ELtw3MEgZ39cqKjyB3ix9et6mLVmfrkeNXfdmGMZxjp6+VZyD8hFXIxzz6+dTMmRhj7ue30qz7q6gbGuizkOefvpLQflQLK4weh8+vrxqh3JbcmmDWTMPZmq/uRG59CnTQryWLJGBFDO+pueenjTeSyIzz9/r50NJw/G4z5U6mhbFpLDn+dQZvAn2YpkbBj0qL2BycZPmeVMsiBYqBO4ztipBiDsfZTIcNY+Rz0FEQ8I1MccwcUfkQOQoycGpByDjl7KcDhR5FcV7/KySDvnkD4+vGj8oLFBZsE8ia5k5HMY+dPF4Sc7Bs56VenBCRnSTny9bUPlRuVGdBbGMHbbP51fFGxG25I61o4/s+7EnR76Ptfs42QNPlSPOjc0ZiOF8jAJolbVxjPwFbKH7PADB3oyL7PKWxpz86R54g+RGANsx20+yuixkOe4c4r6rafZGI96Rd6MP2Wt9Oy77nlU35cfQ6Xs+NvZSrgaTz6c6Ga3ZeYORX2G4+zKdU7o8qU3n2XhYbJvTLykzPR8raI68j51S8bliBua+gS/ZkK4YjOPGqB9mVeTlnOTt0FP/IQFK3Rh1hdm1MMUYkWCNuVa9fs6hXU+ABuSak3DLO1t+2OWbIVR1ZqV50Xjjk/RlRE5OdsGpLBNKe5G7GtcnD4lTW6LgdMUVbRYmlTs1jiVRkkcqT+QvRVYH7MbHwq5Zc6GA5AY3+FSl4TNCQrRlm6gb+6ta3dZhE++dyOZ8s12OMKT2smJW/sU7j96C8lmfjL9MU3DZgdJRi/kK4nDrhjkxn219Bfh7mIRKW1vzwvL14VTHw6KA4lJLcmJO1N/KaAvGT9mSteBz3A2TCjxFGf5G6g9ptp/wBW3xrYQSK7Na2aZI/Ew/t/eg7yze4kP9Xs4VP4s95vGpvyZDrx4mXk4Yqg6CD51S9n0Ix7PXyrTpw5FVSkLyEjujwGeZNQvrW2tk/8w6l2/EqEbn2/rRj5L9iywfhknsPAd318qqa1KYwKezzRuF0DC9AKGEBfoQAeZ5VaOdMhLDJCtYsbYx0xUzEpG4z7qYtahD5daisSatI5Z5inWREuMlugB4uVQaMgY59d6ZtbkrlRt7Kpa35j9NqPJA5itoznGABzqHZE7nFMTCRzFUtFpfFDkCUwNY21AdPOutETt6zRPZYBOnA57CrFjwNwK3Mn8gIEwNxtVgjXOPLrRKxYBIQee9SCciBv5UOYyyIhCTEwI5frWp4PxHs2Xw5cqzfZ4OQMHriiYXMfPao5KYedn1Gw4oCow3TpT624kGX8Q233NfKLTiZix3ts+NNoONsoB1493r4VxTgzfIn2fU47tG61aJlI5181j+0bL/ePw+Prar//ABSwX8Xxpakhfqz6H26eNRa5jA5ivnrfatwMZ6+vfVf/AIpbHecY8qP3DUD6C17GOoqv/MI8Z1Dlmvnz/aRXGdfz2/jzqiX7QZOA/nud/wCanwkG4I38vF41JGoUDNxxFYLq8ueN/wBKwEvGDj8fw+f8UE/FWbfWffv/ACKb4WxPkXo+jHjSn8JGT5+vhUP80VtwRjGTvnb6V8+XibFzlvLHr86Ng4hlgNWd9vb9fzofEMswrW3GfHw29fCovbLpA6DbyolCp659/r41xsHxz88/Wr/IyDyME+7DV4kH51H7tkgHl0AHr4UXpAHlz91dRVOQ2NvP18aPyMX5GDi0UDkDt691SW23GTjrv8qIAOdPPfl5+vjVkajnkc8+vpQ+Rm+QrW1Axn1+9Wi1BUch7vXwq5cDbpjr4fSrM7c8Y8/h/NJ8jB8gIbYDI0jHr1mqpbYeG/X20cfDr5evlUHUN4fD1tTLKwrILHt11d0ezb18Koa3TV3Rv126frTVotWSfePyqhosOf19bUyy2N8tC0wAcga4LXXtzPKmRgyMDn5evlUlh3ycYrfKD5gFbNdPIHb3YoqG1XJyPj6+dEhPjn176IRR7/XrFH5RflBRZam9/hvn61bHw9dth4Db18KNQDT6O3r4VaPM+3Pr50/yGWQGWxQb7ev0omK0TOdPrpVoB67n9frV6d316+FSlMPM7HaoeQ+Xr4UZFbKF5AfT9ajF0zy8T6+dFxnbcb5+f1qTmI5nEgXOw9dP5prYWajc748qBjIDdKd2pAXH5VOci2J2y8RgDGBXdIqYIqqSVUI3pFI6VbIyImk6thSi9EEIOph7qpv+NArphPNse4UiurlpphHIxLsRtnfflVIpnXj8dy3ItvLmLTlRzXI9eFKppy0ngq+XM0dFbm6cu/diUYXzFVXNqzMixIQreWcb/wA1TZ048WOL6FLF7mZk16IhzP50TFbJcSxTKp7JF0RA79Satv7YWwWNsHxHLboKb2cMEdpGHI1EagBthdtvjTIeX6CW1sdDh8E7M2F7q+AH1oOaAoxghiIfGok9CeuPGtCEM6kQxqoB758PAeZ8qpu4wkbtCwLtzZt9Rx+WPhWehU7ZmprUmPs0ZhjZmHj66VZacJMVs7rH3jvrY/rV9rZ/e7hRLK628f4wv93jv+taSZYJIE0DEX9oHh4iilqwyluhPHDJBCDLIDIwzt09dKT8SleVvu1vkaSVL45t63NF8cu3kxDaJJrZsal3J8h1oyw4bClqsCRNJdacs+dlz4mtV7BdAPCoHt4TDEgJbdzjn7a9MpVi8zMFB9g8h+9PYrNY42iEikse+x29frXOIRJBEHbSiqM6sb5P5Vq9s3JdIzst7MVEcMTDcaRnr5+dVxWYlw1++uTGNER50UljJcKDChCj8WroPOrTZtAhU4JPXGB686HKjcUDrZ8ND5KDtMAED61RMtnFIWZQZcZCl/0/Wuy2dw0p7Z+zjH9ifjb39KJslitoz2MCIx/E77lvXhWX+sP/AATyWtzdMuVEEf8A/Y3M+QHjVYto0Vvu6rIBzcnZaZXEvbSBXk7QD/SuBj6V6USOgSKBIVxpyRk1uT9BcV7EghYyHMiqPHVtU3ijYfjBbyom5tERdtOcbud2J8PKl8jrC2dWTzOBk4q0cno483j89xOSQjlihmi72f3q+GcTA6gMHxq8xAtjBP1rObPIyqUHTAGhAPWvCHcDn0o1o8dflXhFsTj9dqHMhzBVi93uqXZ0YI9jt7ia8It+XWsph5gmjA5beZqJXVzyPX50YUwo8/L18KiUwdhtW5jLIwYKc5G46VLU42DZ9tXsu29V6duW/rNDkNzOCRwy9ff1qSynYZPuqI2GknmK8Rt9T8P5ohUyRZjg5yPPlj6VMZdTk7jb19arQdORzirFGACDt69YrDLIRbKsCDv69Yqsk8uY8qIIGCT69eNQIAbf0aFm5A2p98+/Pr514k7DfPQZxv8AWrynl8PXyqpl0jVjbnyyMfSjYlnFYnA9evKrUdvHHr8vyqjAyc8uoqTnQxA5eJ8fXxrV7NyGy58fgPj/ABXcg8qgGGk4Px39e2u6upbJ9evOuYjZYCMYI610c+vr1yqCtnb9PXwroxjmBTUCyQIzsfp/FXIfEn3+vnVI9p5+vfUw2D093r5UGYvB8T1+f1rofzz7PXyqkNt69YqWefhkdfXxpTF2Vxz/AI9dagTk5BOevtqsscdf3+tc1ZH0FCjEidtufs9fCoZB2z7/AC/UV4tsQfLn6+deB235536b/oaKNZ3pn459fOug6agGydj69dK6TjbbYevXSiZkwQSB+Xh191Wq2NqGLYbwJ9ejUw+c0UKGK4A6gjf151NJMHb168KCEmFz0+Ix9KksoI3I9/r501jJjFZNs7cvl9KuR/Xr86WCbBHt9e+pifB+X1/ikY3IcJLgjx9nx/irluBgYO2Pbt6+FJFuTnPT2+vjVn3vHM9c+vP86nTFch4twAdz4ev3ptb3yhFBO/KsetyS2N/XOmFtKxGdW2PXurVZfApSlo1R4iqg77eVZ+fjEsplZDyGAa9E/bSLnONG4/T96rjtU7CQ9Gf600Y0e5gwqP8AYVJMSodgQvr51C1c3fEFOTqkcKMeGRn/ALQabzcODxyRIg7649xpVwwPDxKeZsBQMR+QG35DnTx09na2nH6jm4Jj4jHbxYIxkDwXkKvltAmCDiNANx18fpQ9gHuL2WViQ34RmnjWyyoi6tlxnbnVKvo5pS49mQ4lC0t6rsHMY7zAD8R6L7T+VWWZkup2VHXbmRyz9PKnc9h2haQMeoXbOkevW1Drbx2NuQmzyc89OlJ0yikmg63AS0OkM6xju/7z+9AujqGll0tI4wuDsmf1NGcPZnlwR+Ad3pz6nzpj90iYlTgjctjrjp7KrVo53Pg9mahtMsAWwm7Njwou4m14ggbs4Ih/WkP9o8B62q7iS9kpKEITgr9aWW8hjykAzpOpnY7Bvf1/OlT9Mr/ZciC2kbzbHSnh5e31mnraYYWjijOfZtn61zh9iiIsgfvDcEjGTUb+XsI2VVDYQgk7D4+sU1UiblylQrjkxcuhQHfZmHXrgUR/lEEshmca5M5Jc6gM+Xj50O6CIE6grHn3snPtoqxllXcPsT72P6eyhBjzTq0SlaKBirlwVGyqaTy31vAzSMFQ8v8AU30pveoiRlHZUdhnYdPZ6xWflt4knR+xBI/ubvY/fzoOxo7JK095GXhtlVCMdozHlS1rW7jkK/eBjqI05e/9adzXsyDTHEx0nBYsq4PvqtJJo2DNAMtsveZ/bgn8qCoNvoWpZiOQu7SKSeg1Mf0FFSvbdisUdtI+RuXBY+/n8K81xFPMziKR237xwEbf8qi7f7RHkZYBsH+fOhtDUmJbyxF1qXsJcY2AkCigU4UqS6Wgu/aV17+HlWvtkAXU0cu2/IZPx/Khbq80jWySRKNizRbfvTJ0IzKtGsDYMZj322xRkeGTIO2Kt4lcwyRa7URy5G/+qk0M1wkpzCUPSitnH5PirJG0NSB1rmCDjfn78/WuoxkX/psD19fpXeQ9Y/ilPCnFwlTOjOPpUQOeeWPlXc+XxPrfzrmdTbePMevlWAe2Od6ixA/P317I5nn69Yrx5Egjl7sfSiayl138jUdhtkVbo2xj4+ufnUW+eenr5URkys522PP2b/WokA+fmB6+FSBHjt+n0rh659u/1ohs6o7o9nt9fpV2MqDn4n18aqXG3P8AX+fzruvG+w68s+vZWCXEYHXPz/muFFwO8PL14VDXtp6Yweu3rrXi+SMZ+PX60DWcbOo5GPb6+dUse97+ecejVjP1xvn1/FUMw0n+aKNZ1snbkfZ8f4qvO/IE/p9PyrxYnO/tzUSx1AY3J9/80xhumoYz7PX0qWcevW1VKSF8fXrepBjj31zindRDADHPfPh9fOrQxBHXrtVAbkD69eFeDYGevnTGLwxBxsfdUix/n186o1e31+v511c7bjw/j6UGAIyduv6n18a8G8CMeQ9fCqi2Rz6e7+K7k4/f18aUJcDqG5GP0rp2wevt3/mqlYkdf3+tSzkfljwoGOlsE+vXsrsfeA3ztjb1uKgBz6+3186mgwN9yT19bH86YCLGAHs5+XrzrhTBxv6/WvYywO+fL18q8eY5Yx8qwzKyvgfh6+VcwBzqxgSB4+fr51HGCTWEOFuuf0NdBG3j5evlUCMetv4qQyV5ke3186JiYbPhj410nc+vXtrqjHx9e+ub/L1/FAx0H4nw8a9r89uY9eFRwTv0/SppGWfHPesZK2XwszrgjZfXOm8ULQ6ixymPmfyoG0Tsm3B/FjHr8qYxyPI3ZsNOSM0JHv8Ag+PwjyZOCbsGCopY4JyN9h0plbRg2UaE5OsjPiOf60ohniguOxcjWVYrvvkZyPhTPhkms95STrbblvyox2dk1Wwt1bJKk5Zdj4Uo7JTxVozsFVS2fZsB7+lP2j1MkYwMjAPr2UsnQNxSR9GrszhR54wD86ZxJwnugcR/dp8KdGofhPMCnVnG7w4kbY/iPmayt2lyLprhs9nqOkewfnmtbw/As41YbkchWx9hzpqKZCVNL61OIo1OPM9aR3VxJ95UuqpltgeYH8fnWjkXSwXA7NQGJPLb9KzPE0lv5gyDEAYksRgtjl+tDIqF8d2x9w6JTDrXrv7+lNFCgkEABR3vIeFJOETvJGFK6COlPHwkG4znfA3zV4P6nPnTU6EfEZEmZiV/pLuznbHlj9KDs4kup1cxnQozGp5DzPjRF86RxJbpDqIOTq/CPaev1qy2kU4CtqbmTy/ipf8A0XjqGhnojgTSBqY9796CuikMJkmRh4JjejIpMNkj5c6EuohcTBjuw5D9TVpdEYXexRcrrn0JbAMBq05/CD1x+lVSySpIlvGVMhxluZHrxpr92+5wtIArXDHctk7/AFoS2tGMjuRpnl5lV3Udf4qXHejojPROOyhjjV5y8jodR697z8/lUbsCK0ZuwYzMAcjb3ftRixFEIRNCjYuRgt5DyqqKFHnR7lstnKJzCnpnxNHvQvL2ILXhs9xM0t0MJzCYzhfPoB86ZXM1rCrRxhZCAMxxjOfaf1o+9WQkJGj9mpyXIyfd50luYLjt9cIKL/b3ggx12559taq0h1LkL7uW+Gf/ACEiL+Adnsc0NFC0jFpZJGOebdPYBRtykzIcW88rsukkS9OgU9fb0r1rFHFAwkt2HLU0hLEe2g0UUidtG8aB0uZjEfxdpgj60NfyWzRv2jh1U45fn5+dUJHJFKTDPmLJ0aV5e7xqt+F3FzP3XCyHlltIPuP5UKs2uxV93tJpsW34z/amxzVN2kkOAihseA5e0VoT9nhbIryjsph/er6gfaPCgRb9tdCGWaPA5PnBzTAdMUw3zv3Xi8sj186KDFl1cj8Dn60fd28VuVVNLPz2PP3fpQTSBz+DT5c/Q/Kg9nleX4sa5RRHHl7hUGOOu2PXurzHAxke/wBfOqi2+/PPvz+hrHl0Tzt69e+vat/H3VSWxgjz5evlUkYEHbp691MaiwHby9esVW24wa9kb9K4Cc7eNYCIELnPQV4Hbbn5evlXTjyxjn66VWTj3+Pr50QnS3T1/FQ1b7nBHj6+deLFt8c6gz4IPuomLu02543qsydNhtVLtkDfAI38KiSfj5+t61GstaXPX1661Evk46Z6+udUB9+ePZ6+VeJ7uPLHryo0ay3UM8xnz9fKo6sDIH8VUSB5+ZNc1efI+vfRoI+Vs/6gelTGM77ioAbeyrANzuefj63rkETOHffr69ZqWnLZ393rnXdOVGOXl6+Vdx3emPPlj6UbGsioBGAdvIdKmAQOuPXrNd04O+fX614DPTfy9fKg2JZw/i6/lXc+Xy9fCp4x66V7A8NvM+vjS2ayHMeVSFSIO/Pn7N/rXCNvL2evhWs1nUz5+757fpVq7j9B65VWOW/z9fOpg8zjfPz/AENFGslkeWPXy866Nz1z4+uv51AH2+6pFuYznb166UyGs43L1691R8yf4r2okk4Pr1zroG+d/X60QFbKfA868p2+nr5VYV26cseX8VDHvPn9f1oMBNT7h5V4nJ9evfXOQ8fb6/mvDn69e6hYESB39evrRljF2s2CRpAz7vpQ0cZbpt6xTmKzNta632ZgV9vrxopnZ4mGU8iKZZDLb612ZCFY+PnVltdiR0KYzgZzt3vrS8TlO2hGWXmCPb62qdraM/fXUM94eG3OpN7Pqo40kMLi1y8Fwq4IkxnT+HpRfDpXW9IKkBlGx6ePuq8qZETlp2O/UeutWy2ub2ExgEoSTjz/AGJpkmuiMpJqmM4p9UqY8CaDgy/E7oAfgYAE9MjNd+8RRzuq94xrvj5VdbqqOwCglt2bxx41dM5araFssQmuZJMMIIVKqDtnzHl+1N7RzpXVkEbYqTQgqGCgsTsPGl8d4BxAwA5wDlhsAfCh/VjXzjQ2lPaDQdlPPzpTewu0mtABFp04A5DpgUxjPaYB/Dy5865doexLgADOQW+VNJWicHxlQNwmDsGKknUTk55486Zzsxzgnljfp4n20vtX7MBnJZvZiiMuVPaOApOwzufGtF6oXIrlbFU6Ga4VWzoH9ijz6+HsqNm5WdgwOfIfAez50XxCdbSJVjQiRwcKvP25/WgbJJyC8i9mM59p/U0lVItF3EbpJoGtyMk7D2dfZ51baplDJuNW+W6f7qCDu0ywRRd0jMsp5ewUVc4Nqy6gEx15H9qtfshJXorllW5kAV8Ivh19eFS3jRuyYKMbuaEso9TkkaRzGKPngyozqP8AtFJF3seSUXxFUJkeV9DPLvjLt+E+HlTABlcHC8t25b+X0qqLAkCdkEjA2A5VOaVFYDLbn8QXUPL+aKRpMrRca2BVgf7jn9fyqhLJHkYupZiNye8asliYOuQ7BB+J2ycjr5GurKQjA6gB1Lafbj6VvYy6ISQW0al3LAfhAc7A/EChJJoLSFpezSFRnBI5+wD8q9LJMX7tizqf7tQbHwzQl4s9xIu9xBg7qGwPy+dBsaKFd5cxXcgYPy5AMMn3eFRi4Va30eqWWRcYYZOkg+Jptc2MrWf9krA9O6w8d+vspa8NxHZF5rbTz/C2+nrt+lBaZW7WgG7N5aM0ELzSJj+9Q2Pf4/nQMMEMsrfe2eNhuEKAg+zNPLeJRbMEjyeYIbO3TO9IuJrMkxfSZEUguo2I9eNMa9HJIFTU0cutRvpJ9fGrQ0EsOdR1fixnB/mupbW15AslrMNZ2aKTbB8vpUl4YAmmdGVSM6huP4pf+ksitC58asA593x/iqGfPl89v1H5UXc27W5Ckg5/uDZoI8/P4b/X86KPn8sXGVNESxGcZ8fX1qavjbr19tVk4Pt6gevhUA2Bjb1+lMSsI305Jx7vXwqOvC8tuo9fnUVkOSD+fw/mvczsfZt6+FAB4sud84z699RJ8/LaoEb9D51BlwfrWRrJlgBt18vW1VOc56e/9a6Sff7d6g34fl6+lOjWQBJPM1HPt5VPGF5fL1tUGTDZojI9nI2Hr11rhLZ/evDIO3wFebfp0rGoizH35qIkwu+nFeIznu/T+POoFTnYtz9e+igGmB22Bzn2ejUl5eXh5VEfhyQK6OfT4+vjXEhS4c99z459fGugY/Dmq1znw9nr5VJT5A+3l/FExYBnAx7/AC9dKmN+p95z69tQHdOfjk+vjUl2ION87Y29GkYp056+vXjXQM/t8/4r2M49evZUwu3IH3+vjSmPDkeWMe7+PyrhTb96mFJz45+dSCbDbxO3r5VrDoqEZ5DOfXrFcCHAPTy8PL6USFwMEfHw+le0tvnn5+P186awA+Nj4dfD+POvY38fb41cYz68fXxqOjHnRTNZALnl8vXyqQGB5fpXcfH16Bruknx9frT8hkyJXHtzz5H151HR6G3r2VesDE7D9fXsptacI+8RZO2ocufr20rdlceGWToTR2rscKCdvlTKHgkzt+Hpjf186e2drBZoupcup3J+X81OTiUSuY0/FjbA+NZJez0sH/j9XIHjsLe0iXtO8VOc49b/AJ0PNcRyqQ5xpBwB+XsrvELh3jCDAZhnl68aW8LtjedsJMgjfBPwoOXo9fFgjCNonw6yjm4n2OCf6e7dOf7/ACrUJZxW0KkbBht5nes1wiZjx2aJS2oQZH/uPP8A7a1UmPu6/wC0bDpyqkUuNsXNKXKjPJMDfQxQaljjwmB4DnTlJFjZjgKSME0saAwydtnOOePOpzRtJpXWccyRzz4VLkx3BMMtAqhnKgtI2SfLpRelD3VBHUnxoBZFj2YA7bAcjRmpXjyTg45U6eiU47sruL9bbnJg4wM9PrSl4QLqOVGXURuz81HTSo/OuvwWK4neQ3UhY/8Ab5+2iYrCMR9j2rghdORzFFW9BSjEOt7lGQCNtYXbOavuT2sSqSvPcgcvZ9KTWiRWs4tw5KgHG2RTZyFjBBA6Z9fnVFdE5RSlaKoXQ3GAQxHhv/NMlVAdR7zAbEjlSUzLDKJHKhm/CBtn2CmsDs4GCBnqfzo436Fyx9gt86RR9rMhLE4VEGon2/ShVf8ApmSc6WI/DjZR4Dxo+8bEbMmlT/cxOAPf09tJe0TtFy3aSEHHgW9o5e2mlRobQ2ttJEgDAoAN85J8vZXLuAzyKXUsF2UBvnXeG5EYJVC3XSMfKiboqhHTVsRj5+daStC3UjlpCAMgY28MVdcL/TwoPmPEeZoOMsrZaQ+X71c8ihf+py6k0INJAknysF0Kk7uGPg2cEZoC6l1SqxhaRs43bA9w8asnEb5xI7P/ALfniq4QkcZLKiEDcKdZPt+tG/wol7K5Zo8qHkZlXmFQbDyHh5VcLuNYwgmcKNtP4vXt6VGO4EoISJdWQNTsNXs25VSbMNKSxJUHkxBGeuwx+9azUEpOMuBlH8VYZ9/garMrAZR1bqAyn3jI/KgruG7JDdlpjU93sdy3kBvt+VVz3EscJJjMYJ21nDL4DBH/AHUvQaD24hM0RA0tvsyvnHt8vOll9dztausyhAvQDI8jj9aoteHpdP3rfJO/aIQj/I4z+dHzcLkaNVjc3CLyQ7Hz2P5VthVICivjJGEikhMi+I7N/bg9aDt5kkmZ7mPUgbSTpzjPQ+VXcT4cGiDRJ2UnNkc5B8x62oWwhuHEvbIrFRuy7Hy1fWsOmRaGO1u5Ee3HZOe667hais72Mja5v6ernn6143PZTaXV1cZABHx99Qjt7a7Ur2gQnkp5fxQ/6BnplS5h7SLdSDuv0/Sk0qMjaTt9P1FNJLJrfWquo0nffn68aVyai52/u556/X86yPK86Frl7KSCCTUBz2+no/nUzqxsMez18q5z8CP0pjyURJ37vr14V3lvt5+H8VIrg4PXn6/WvAYGRnn78/WsEjjO56VHp1znG3r5VPA/t5cvd66VwplTk+eDvWMVYxj6dK9p272+POrCDkk+jXmHe5593remCinGGA5EV5hhtvy9fCrjHleQx8v4qJTxPnz69K1oogfSCTtt511hy2BI8fXOrSu+1QljJA3Pu3o2YHIxVZI5fxir9OdyB7PXSvMp3HP20bFZoFB6g5+efrXtP7eyrQvXbH6fSvAbnb5+t64hWiIXIOfXv/WrEBBzvnPzqSrvy9euldC4HTTj5UQHiVJ5KPZ8/wCK90/fNc055gevXOpadxyzn176VgOgb58/H18auUbAdeXn/PlVSry9evZVwXA6evXOkMTUAjpjHu/irFUnp8T6+NdjX4/A/wA0THDn2es/xWoKi2UqmOm/r51LTsMfL18qL7HI93Xw+lQeLxHtz+v1rBcWgUrjOcaf0qDR9Mb+vWaK0EDGOXxz9agY874HhitZOnYKE3GBvv6/aiobbUwyMD5Y+lFQWZK62Hd26/D+aJ7QRZQIWIGoDrmmVno+N4M8m2St7JCy5OlhjY8/XnTX/wDbwkxDOMkgczQuteyYt+NdwQOXrwq5HzFqyCp04PkelOtHrY8EcfQt4rcNAYmXJV2WP4mgeKK1ncpJHh9snPLFE8RBub2GAtlRKrfA+t6jek3VzdIFJWNNOw5tilatHdB01ZLhlwb+FmbkAASef80wNoLRSsS4Dx8wOXLalPB4fuFncd0hQof2g09tLlL+1TS+ogc+pqiRObaeuhBYwdhxSWcZPaKFznwPL2b09upTHa6mO472PDfaqZ7TsdZQddj4Hwoe/kJ4Y2M9o4XBFJuthdSaZTdX8hg1JozjOfz2r1hxFZlC6DgjbAOKHLQzWZQOAVXBfmT68at4Wn3aQkHC5zuN8/Wh7KUuL0FmZozj7qxUtjcbUclwpjAaMjPVahcduyh49BbGMAb/AAq1Yn0KxDbfixT0yMpJrYC7GO5yDpU8yen7VXPxGAXQhMZ1sMqwOM1bcqJ42k15VT3vP140FKLCa37GZoyxOVzzPs8K0dSM6asou7ia0lEvaFmdsaV5DzPn8qd2MsdwiOcFiPn+lAzcNs7i2CyK7YXukNg491WcNEETGGMNpXbBfV69tVVpitpx0EXUiq+VEYJIwSM5Hh7KKilYYDNjlVU0JZlPZsQDnvNj0a7JgoCCpGOimlapg01QXJJGU3JyeuP08aCMpbZAq42OjvHHn9KMQgw5KqRjrvQwyshVYwif7e5v51VE0iPD5Jo7h0f/AKDAENrOR5cqYzSRLt3dQxsTjf11oGJmS5UFgEz1xz8vOiZoYLiEpMNSDlgfLzFOJJbspZ3eTvMcDfA2qOBKQcDA6Zz6FUTuIFYJAzIvgcHyr0UpZDkE77ZGk/LrUlHZT0eaFPvXeTl4Ntn9D51ZmMqO4VBO2MLv+fuoN724sEJ1MxbJwQNqjBeGdNcyYbbKjOGHj+9UVIDtjN4VjjxCqsCPwl/W2/KqVfsY2WZotv7Qv9vn5edDqjKSy9pqH4SD++9WG6knl7KR1wvUd0g+/wDLlTUmLs4IlCM0UWA3exqK/wAGqFijMJIXub7nvevZVN7f3NmgERMbDfUwDI3t25UAOKXSyB5m0h/7wDp97Db30jpDKxpJpjgDRPo8QjbMPz+lKf8AO5reQwvIG35sc48iRjbwNMTZRXCa45QpbY4Hdz+WaUX/AAeZGLxwylWG/ZEEjxIHh5VtsKobfeLW8hHbSgs39hYbnxHgaTyR3EVzojV1P4hjfI8R/wAaDtriSymCTQpKNypIK/n0pgbuCR0ZX0tsTHL136NS8aDdC+4aRptF1bkauT42YeBrj2zfdysY1b9TgqfrTjiMy9mJNJ0DbOORpdlJI3bvLIv4SpzkeylGbtUAySSdloKHtFz2bkb+YpcmmRWOkow5jn/IrQ2Z7RSk0YLg/iHhQXEbYJOxMekk8+W/1rWcHktqFS2hSU72wGOeT6+dc074wRj18aJ0csfL6fpXDHtjxrWeJ70UaRt8vb66VwrnrRAgY+vh/NdaBgM7+VazAuCNsfHr68a4QSNuZ8NjV+jbHP2evlXAupc8h57j150Uwg+nbyx09fKuqvw8/Xzq4xfp69vnXewOnJ50bMlfRSFJHr1mokDoMDflV7RlRyO/OqCM5PWsN0VPsMdPHntUWwR+eatcZbz8Bt6NQ053A6bYFFGsq097ODv09daiwwR0B8PD6VeELHJHT5V3sTqIOdzpprQLHwTK+fX21YiLttt7KmIx4jHTw/irdGP3+v61wWAq0d3mK9pOdwefv/mrtI59fZ19dK4EGOYx8Rj6VrBZTpxgYHw+P8V4DJ9esVcV33Pz9fGoac+32dfXxomJY2+Hr966BjY+v3rg5j169lSA1EDbHny/itQ1F8IBO3LHhRqkY8ff8P5rlvwy8lAdIWK+Zx7Pf50YnCr7mbZj/wCkavkPyp/in+HRDG12VAYPUtn2HP1/OvDvHugeWP0H6VNoZV7rRsu39y+tvyoyysWlIJHXOG/X60nxtuiixOboCjs3Y/hGMZ35Y9fCi4eF4JD4BOPb686drarGpz4bVOJI9bM7DOnAFVjh3s6oeLCO3sVSQjRp048seFAyJ2cqyKo1cl8Nv0p1JFoiLjDyHOPAeFIuJLNDGmBkB8+ZozjR6eF+kUmbTP2L/hbxNXffQuq2j5h+nPfl76Q3d4UuI3PMSac429v57VfwwO/ELiXYplSu/LH6VJb0dMoJbGHaCO+Rzjblt1zv/FTuphauXQbTNlttqjctFJM6NthQVaqrdHuoyWLFUYLjH4vGmX4I/wBHE0GpGUA4KYP6Up+zrlb+aInTpOw8fGnZmjZR+EDbbyG3wrOTSrw7iYuHyqsx3Pt6/XzqjjTTJxdxaNTfd2MkDI8BWes7z79dSW5U6V/EDTQ3aX9qWibOrIyOY2/Okn2ZxbyXUkmnOSQR4VmrYceoO+wmXhgtEZ1PfxnB8etE8MgmNqXZAWblXm4rbPcrEWEjNgaBv8/CmgnRI+8wjHiTjTSqKvRpZJcaYrhtrsXiM6voUnukZx4b06bWCGTJ23WgZ+L21tqLznT0xv8AKom7ilj1R3BUhc4PPHs8POqxUSU3KXaIB9ZkGXhlBwcjHt/ikvFUtp40nEidqhyRnZseudMpZFubVmV28iDv7Njz86TTuq3DoTrJYb5xvvnYim4oCdDS2uhNCjQaJEbZg0o94PMZ86lYFVvZGJZWboR+R5e6k1r2kKmTQj7E6lcagvX/ANQptb6mCtJlkYZD6cEHpQdaG/R6VDjIwdti3LFTA/pld+fPJ/Ol1vfBZuxckFTjB54p0ume31JgnHQfHanSUiUm4g0JbJyRkNtjxquYAtqVtwNgF/cVegeNsuikEZyN/QrpUM5KkZHMH186yWgctgE8CSJ+KQFQCQRtj217712M4XGpDjOeQNHOwUBNQLHltjB8aElkaSEAlHVdmKjl40/H8NdknuBIM4RRnTtjn4ftVJlcxiJ1Rh/qHh9KrliInzswHP2dPdvzrz9np7MoWLNg6Rnf6/nSpWwvSK+80470ak8ldh7Oo+YrpMJbRNFCUJyjxE5/auG1XVG6yFWx3QV9ZHlVNyFMn/mQixscCVRjs2/3DqD8qtw0JyPBJEZXGkREaQxDKfZzwffVilh/TmbKPtqbvAj2/rQ0aSWUzB3Ywt0DZGB62aiZLuK0QOSSjEKW/DhvAjkG+RqdNjXRZY2pjZsq65Oz/iB8Dn61644fb3ClWRIpRt2kZ0/Ll7qU3d/lf/Iyskn4hp7yEean+32bihxxK6nhKSoHX+2SJt9vHPOi4xQqcj01vccHkBz2kbHOQ2CR+tEw3UV5HoupV1asxSo2k58M+NVW3Fw8YhkRpYydO43Vh4jofzqNxbwpJqijAV+eg/3eG9THL7odujxlkkddiuAHU9G9c6AWCCQ4fvOMjtEGx9q/pVUkFyJFy+E5JKp3U+zw8q8ksgmeHiSR61wO3Xu6gf8AV9aKWgWHgqYRpljPd0nO4K1nL6DspS8DbdVB+Hvpw4e1mLSASRA8xscUr4nCsTia3fMbbgDkR+3UUtew2D23E5UOmQZYdeR/nyo08Tju172dh7fQpUV1L2mMIT3vLyP1ppaWEMkbOjd7+5ScGknRPLfB+yoqOnLGfd9POoquW3559e/86JKacDGceHj9fKrLeHLDljHPy6+6pWfPS/tolbWpcju/D18qN+4hk/D092Pp+VM7K2DLy39egaZ/ccLspz5c/wCfzpGy0IaMPd8PaNs+HPf18aCEZzy3/Wtnf2gC4x8Pn+4rPS22JDsAPPl/FFTElGmDRW2r2ezPr2UYlmGXkCuPb69tWW6adj8zg+W/600hi1KPHPh19nj5UHkL4oIUyWowcjfO/Tf60tuLJU7y/IevhWmkgXTyzt7Rj6UDPCpU7befy/Y0FkDkiqM8LYN5j9KmtqOo9uT6+NMktsuR+3o/nRAthtp3PkM/L9Kf5DkYp+64/tP65+tRez1AYHy6eulOmgXG2MY+X6ipC2G3PmNuvx8fA0PkCkdEOD79x1z9amIfH17v0o1YMdO7y23GPp+VeMe2Ovn6+dcvM1C8oB+/r51zSR4/l6NFOnxz6/iqSAOXr18qaxSrSDgeXQevhUNO/l8fQqwnr69edQ/uHt8MejTJjR7L/uyKgMkqJnox39edH2FnbPfRAz5OoHSF60o4lCfvTkA8gwx4Y9bUZwkvE6u51EY5+Fd8ccYtWe1Dw8fHl7HtxFNK7d/CjljkB5eXlQws5RJqV3HTn+v605RAz5DZVu9jOPRqbW+OnTHL416qSaEWtCr79e2v/wBZ3xzDb7+vjR1nxaC7j0jEUvQqu3woHia4iJHLzG3l7vyrI3M01nN20TlSDnc7e/60rxp+h1RteKG8t7cspJyMqw3UjqazU1/fBlYMcf3Dw9eNM/s99rYbhhZ3rDEhC6ugY+PhR3GOCwGN54AVLpsByrzvJ8dw2jqwZ6fGSF9tfz6Rlj4AePrwqV7dExl3jMiKCSBvkVVaKJIOyfusuF3Hr400WF2tWGO9yx69GuPZ0uSTujGcQdSrEg4Dl9J9v786JiuhYy2Y7Mr2j77/AC9tM5ODpeyGXDDK4AA2x5/Sks5eSaHu/wBKN5EbPXB/KjFFXNNUMr2RFjZ0YaW7vs8f4oq0U2n2cgkkfLHv5I6N+lA3cYThrYDDWwLBv7T7ffzpzEEm4UiOABpwp5dMfHyqkY9k5PSFXE57i3WJkfZhhiT13/b21OADi1u/bZVR+Hbnlef7VZLbNccORWKlwMKPEDn7vyrnBR/Uuojk4xgfl/NGKt0Z/wBbO8FjFraPbvIO7nbfl9KV/fEccTFt3CrBFY9DyFEyxva8fdFYnVFqbfl5e2g+BKpW9dth2urV0OPzGaavQqfbJ2dr/lkP3lh2l03/ANRj+A+AHjRVnHc8SZTLN3M52PralfFb2QBtbIi8o8Np1HHvyKbcFilXh6EIhZh3tROSfPalcG5UNzqN+x5HY2cI15B8STnNWvHbIraIwjdFGFrO8RvVgZIO9IJTnATYez6UJLgqig3KtjkGJ+JJqsYrqjnk33Y+ttEbd1NIJI0shOPKlHGQIblJXdexdhjJyOXQ9Kt4fN93YRPJKNX/ANOV9Xsx4Hzqy8aK5DRNCW/uaMbFvZ5+VdGLHd2SnOgJLFY07a3f+p46tmHn9accOL6VDjQCN0I2z5Y/Kk9rbG3DGzlk0IcvBJ+JR4jPMeVN0a3A1JGVXOxztWeL8CshffwacS470Z3OCe79KacNmDIAmdtsZzj3/rQ5idoCdWo5xt651y3zBcbHunyqHHjMdvlGhzKGkTAcK3MZ29goNHEjMrqquux33opizR6iRyzkeH0paC0lwe0CN/uXun34/OruNkYMuLOswV1GByJOf5FRJEb6mUjU+x5YO2Afr4VKQ60aLvCTGVPLJ+teiKznTpOplLBehI9cqZRM5FMmpYQWGTg9z8J2zy+lQhNwIMPkherf6fpTRrIyWtu+klUPePUbbfnXOIpFbWZdGOV30j/d0qscTqyTyp6FlxMkS9gT2oxrGsgkD1yPlS+WZIWeLJMcg3BPI9PYfKld5dSxTPI8qgRvpBK8snmPAeIomeBEhjeSUYP4HHeGnwPXHnWataGjrsgb6V9aRxktGW0gfMeYNByzz3EKSwSRujIP6LnfzHny58xUJeNw20rJINgo3zvz5g/rQU/F4XbuaS+rUAV0gnx8j+dScb7KWddZ3BkhQaT3lORnPurkM87BwkmqQd7KD+4c/l0pZNxYCZlCCMP0zgD3eFBz32tzMhIkxltJ/FScfwJoEuY7hHnZ1inDY1ae6w/3URFduIGKMCpGZIn73wPT218+PErz73qJIj1aSRt8asi4rxK1u8J3W5hlG2fHHUeVbi2E333lJEcLIS67hc7nw99eGniJ0A5cR5DLyby/asl/mE00zyx9wqMMo5D2eVO+ATM8hdeeoMd6WjDWC7QpLbTgALGOe4xy+H5Utvomt7N5yusRODIB1U7aq5xRtHEGdVY6CEdeRxRPDo0khmR2JAhZfHVGRv8ADwpTCW3nEd2FchoJP7hTQQC2mUpqCsMr7P1FZbW1jdyWsoDwk5B56fBh5VquHx6oV7+uPwJ/D5eRqWTSJ5Z8Y7DhAHOrx/L6edFw2+ls43zXYVAIH5eufl1o6KMZAwPX6eXSuY8VxuVh3Dhgr8dh6+FPQiiPpjHy+n5UntmCd7bxyfl/NMRcBF5n9f5pZHRjVIC4jHscqc7dfXxrL3UY1ZH4s9Nt/XStFfT6vXr3is/db55H27j+POgSyFEexGPl9PzFHQTaRzHLx29efSl4JBPj7fXxqYkI5bH55+vlWYsZ0MZZc79SfYc/X86EmYaTt8B6+FUdqxXbGMZ8v4/Kou5O36/r+tKkF5OROMqT0xj2+h+VW7e7zP69PbQAkKN1zn2b/X86vSbO429m/oeVPRIL2yPHPIj1v+ddJUAAfL5/uKCaU6huP2+n5VMzd3fPnn1z861GQ9k7pwc8/f8Az+dUO3n7MfT8xV8yHAyMD9Pp+VCSKQSSCfLPw3/WueJRxK5G7pJ5c/XlQrvzG+f1+tTlYj49OfryoQt3T+vL+KokTaJF99vbsPXwrmvOOfxz6FV6seJ9/wAP5rhPT1/P50aFQVIXlte0U96LAbHMj11qdjPhgxyy599U2s7QSq4GehXx9eFF3Ft2SfebZc20m4B5L5Z8K7sb5x/09nwfIUo8Jdo0ljdxXS9ih/qRjUD4j10pvC6TJpfHLr6+dY3gmtZGud+fU/n9a08jF2EsewYZAHn65V6GDJqmNmh9tF9xwqSeJgFfPkPW9fOftDY3fD7pYpItcThjkLjl0H0r6HBfSxrpZDp8NWQB5eVA8dsBxq0aJ3Ck9c/n9a7ouL6Ixck9mJ+x11a2vGGiubIGF9h2g1ACvp11bqbAmNiYz3kzzHl9KwNxwCSCNpYmdbhSMjlr9nn8jWu4HxE3/BtIVxp2XWmn5fpSeRjTxtBUvumjP9m6MVAywJz5+PvplbSkxquPKrBw8KzF21HG9G21qoBOnvE5x6618/wbZ6UpxoqGWhygzz5+vnWKmaSz4pLDMiFWIcDV/u5+2voEduoBxyxt5ViPtpbIJYpFUkx5ZiNsnG3up+H6DHNXR7i8oLvHjJlj1JgeHOrre87Th1ujYEqx97NILjihveHxOrES6+ydCwyDjrVTSzQRxMRIkisGYePLpQ4tWXtUkaCxu2ls0jcEuh0n+fZ8aYWESw3Uj8tttufrwpBbTi34miqf6Td04HPb8qeLeQkSnUO01bhunl7POjC+wTfpCu5V7r7QdmFHZLGSX/1Z8fEflRHDbVbSxkjZCNbkkkcqDjutPFC+sBCMszDbn0+FOJNJspCjAxhe8wP6daKt7A2loyfGgl1xS2Ts5GOrGAuAvnT651RcNXsZo4wdiV7x+A3FC8JslnuZbp5mCt3UkfcKPp59Kq4myNeqDZSLdxt/SlVvxDwbHo1eEHVsjKfpEbS6kZu7EzDkSy438cneqGN5LO8iPpkDBVBT8Pj76eRzSxQBpURScsTjb15UDaTKxIWSLVICxK75HT3VsScpCzaSLrCwKl7h2Ltjun1+VNXtGwJUPt2zjyPlV/DEQwPGwweu+/l/NXynseY7vVl2Oevv/OvTjCkcEp29CGVJI5GYjOnbfYjPLBoi3Oq0w+W1DmBnceXQ+XWinMU8bZALb4IG5Hs/MUohlltWZZCDH/r5jH0/KlcKHUrGXD7xrd5lWPKI2GGdmBHMetqNmmh0E5xg5ydiB0P70uSN5gLiLKyqNEi52bwb8t6NaNJbcTIxBXwG6dNx+lTlitjrJ7CrS9CSNHqxv12qFxcMsbd7LL3sxjcjrt+lZxLqe3unt7lQVH4G6Y8iOY/Kj24ijtGJdR//ANi8/wD3fWhCNqmaTp2hn96SWEvG4zzUn9c9PPpVcN2JrqAK5XUA2/MNy3+GxpWIZ7Z3eGZHjPeUgaW88j9etR4bdB75Sv40cFlI/tzg48R5U6jsVvR9EspEkVk25aW264399ZTi1xNHxFon30jTpG4ZTyPs/KmXB7vLyxs/fCjTnw6fLrSL7SXizNJKh0zx90527x/Wryj9SEX9gNtMspZlDps6+JHh+9cm4bBKrwxTaEl7ykNgZ6/+k56UiF9dWnG1y2LV2Lqf9rADH/yB2o7tZYr54JnUpoZgFOe7jc+zOK5nE60xXe8JmY74LrqSQdD7vPqK5bcIDW+k6Sy472d1PgfEflT1bkTlZEXSJOzVw/XVyJ+W9QkhmFyy4BRvwuOef7c+edqhKLRRSTFg4NHOoFyrKQcbjHxPj59aWcS+zscIUDqe6R0PrpWzjhka37R0IIG6+A6j9qS8UlaEO9xsgHdAOfj5edJv0FmF4tamGJUAyzHSMb7VfZ2JjjQykP3SRr5ir5I/vU5nmyAD3FHj4+udNLaJJLJJRtqc4I/tVev5/CqdIXspHDxHrY8tOomrODTmzuUddxq0+vpTC/mhit2VSMyKpz7vW1JLeRkkKnGpipUZ8/W9Ssfsc/aAluJpLDjE0XLzX9KG4bfFlkeIDVv3S3LxHwqNwZJOKxgn8MmBQ0SDh/2iVv8A+PLkMANvd5VN7D0Tlt4r4BwNMitgY8PD209s4VgjRUGwG22dv1oO2tkiZzjIVu6ehHSjEk0HB8epx6PnXNJ2eV5ee5cUMEbHMD3+uXn0oyNyTnr88+utK45s9d8+/P1ohJsKeXL17qlRypjWOUjGD7/2/SrDc4TGRy39n0/KlIn8/bn1866ZyepHn1z9fzoMflQTNLkkePn6+NAuM8858tj7qkJQ3L5evlUsA+Xz2+lKTk7B1h6fkPXvFRMBIwMYPw/jzozSAfPlz9fGrYk1N4+71v5ULEBEtiyjnnPr30bHw/CA48uXx/iiYYF1+Xyx9Pypk0C9ln1686RzovghZmLqyBJwoHlz9D8qBaFowc7jzPr41pp4Bucb8/Df6/nSqdRrOAceQ/IfpTxmDNChYqsXA8/n9fzqx4u6N8evW1XBFDDwx7sfT8q5qy243z1+X7GnshRqpF1L1z588/Wls64O3Ly8PZ+Yph2i6NgCMZ8sfT8qW3MnfPt6/X9a5oHoOuIBOBncZ6evLzoJ9+Wf1z6+NFTvk7AA/r66UI+2+2Me3arI5MhWBuMDln1+1e0kHrjbrn1+lWY6HHx9e41wkHfrz5Y3+tMSPAf6hn3+vjT7gt4FSS0mGYpdsN62NIV88eWPXyplwyNXnGQu3v8Ad7PPpVMM3GaorgTc1Q2jtFt7CVVJAxzHrl5UyspBJZIpyZY+63t6b/rQbSNojGfxS4IPX186tgkSOEiMZDMW8/h+ldnPiz3uNoYpGpzseeM9f5qp7Uzg6dSnoV/T6Vfbvq7zHAPQ0wRVMfT39fXjXp+PNezkzJgcPDWa1VnGQBtnvD+Kvs+FpbXEki7B/wAQ8/P60YshVMLkCvNN/T06RnkP1q8ssXaOdRkugWSDLHGPp+/lUI0CbjkPyqbyhF35c6GNzvgD215WTipaOqCk0XMuhyvQ1jPtlJDDZt2kX4s4J23PhWwaQSEHntjlWR+2lkl1w2bJIOnJxyA8/KpSL4u9nzvhcjCaW1ihDZUSRNnbV158xT27uVaG3XJLKN10bKuPy8KwiTvBexGORZlXcEMenSt9eyJcWNvcW3emiwzHbvA/k3PbrRlBpHQpbRFl1d4P/wBXHPmPlzqM9y8N12nYhUc7uhY6Tyol41iMKSZYFe0LYz3fAeX5VXcWzRRCVFzHjePp7zU0gtgE16GR5BcaJ4X2jP4cfStGslxcR2iHstMx/qtH3TjoD58qyXE7Sd3EowG1BiucasbmtEFukgsezc9qsfa7/wCpjj5DPwroxw9kZy9BfE5RZwwdk5MTHS+eeMZ+ODWbuL4Wt5apE/apjUngFAXPnzz8KLvLe5vLe4BJVh/0ieRC8vdgfKkcv2fnedT99ymrtNGBkat8fOtKV6NCNdjziXFZb22FqqIRKdLKW2x5+XnVvC7KbSr6VjRf/wCtdINLbSKGxxh5JpWyuAAD68qfGdra3iRolQYDaAc7efj+lW8XHbtkfInSpDm1ZrZck6kbkw+f8UUk6MNJbb40mt77tEA5jVuT6+Br0t12eEU8ySpz638q9Gkzz9pht/JGo7mz6txnY+uhpZNhl1a27TJDHk2etLJ7u4LuVB1R7FejDxH0rpu2dY+2yo6MTypVG3RW6RYt9LYFZFYlB1GSMeB8qKi+0EMyLLGwLPswJ6+39aS3fELa0kzJKdZ2WVOvt86xnFJzaTPLbOpR21MNGkZpmqAvsfSb2dnjS5t5O6eY6Z65/wBLfKhEv+zUS74UZ1jfHrrXzQ/a25AIE2Jf7gx2b31bw7jl5dy/dhM7NN3QDudVKlGxvtVH0ZPtTENL6FKIcP1GD+lVtxqNJDNDuFOWCnfHj+9MeHf4d2Y4eHv+0aaTmVPZncbjAOKPs/8ADvhduweKScjBXDNkacYI8xSyy44vYyxya0W8B4okvFP6cgKlSxx08/2pVxyGbiV9OY37KBt8g8x9KfW32bt+FxabQnUw0sztuaieFKQAwJYbc8E+ftqWTyYV9RseB3szcliwkjjHfKY0sTsAOp+OxpnEkUgiAALr3S2MFv8AV9MURcQJFGVw409cZPrxFDw8QifvawuARnG2Onu868+XkNs7ViVFsVvCVMci5jfSVzzXH774qwSTMXjQAIpCZK6vQ5e+idK3CnZSCR1652P716e7hsoXdyqgE7nY5+v500W5CS0VXUz2VnKZpDIy7sThSf3rB8S4h97lMzlVhGw6aqj9o/thFMzKNiF3AfY+vlWDPFpuJcTUf2puF6Z9v61aON9kuRsrm8ieFU5PJz0/2LV33kx24gVVCEBdznujp+9ZqzlYk5DPv33HIEnx9c6cRzf+UNwMhhlVAG/P1tSy0OmNJSJG1E50nffmcVTIqNfwOvdWMgbf92PpVUYLW6nA72/u+lX2MPa7tsVbJ3+Gak2EZIomuyRthtXiMc6qjU3NyySryOfZRUQMFzG24cDSQPPnUxCEmaXbJHT18q55sjnzKMS4Ds4wi9Kqzv65euldaQnbbbzyP4qovzzzz18frUTxsjt2XBvZ6/Tzq9JcePP30vMmCD8MVIS/l8qFCJ0HdqduufD5/wAVwzZJxjHr5flQolzn559fOuGTz9fWtQ3IOSTvDfHt9fOiY5eWCSc9Nj/NKVkAI9evZU/vGBufjuKXiaxuZAV6Y8h6+FXQygEcse3by93n0pJ97IU8/XrnXY70qRzpXA1mnjm73jv1238/P86M++ppxnHrfb9KyycQyOeBjpvt9PyqMt+dR73xb4fzSPGXxzof3F3HpOCDt7dv1H5Uqlk1ZzjOcbnG/t/WlzXe25P5H+fzquS7AXY4z4evlTRxME58guWfHm36/ofzqgS8j6x9PKgGus756fLp7qgbrB9/r+ausZFmsmv9IOM8/n6+NBSXGfXr4UI8obljGM+WPpVTP4+Wc+vnXKo0O8jLnkzz9ftXUk3wd6o6jx+Bz9a6WAzvt8sfSqJUTbsv0oTsce0fH+Kg6OuM9RzByMfqKq1HHwzn186msmBswBJ/C3In9DR0wWRDYb5/T+ae8DTXK7f6dj0P80mZBJ+AaXH9v5kfStB9nTELWTUwIJC4I2H7VbDj+50+N/7EXXz/AHcwFcnLZyPXyogKpmDocK34s/hOPOh76IuyKV3RwWGfDl/NW2UxlYgpIhz+Fl288VecLlR7sZUrGkA7wAGBnx3/AJpmmyjGfdQEYCgAgDarjLp5EkVeEuKIzXJhDzomQT3RQ1xxGNcDUOYHOl17O65G/r9az91cyvMhAB0nofH1vUZZ3eikcC7ZpJ78NqVWAOfH18K9FKCuQdudYq4vGt43ftFeQd4gvsF6e6mn2ckmunMs0uonGB4fvUm3JlOCjG0aNJ9MelyAccs+vjQl9ax3NrL2qqdYI3O58vbRbDTlwgbbAwPXwqqd0WEvLsdPLnt4eyrxi+mR5e0fB+J2z2fFiJnKRoxXAXz/ACra/ZhUfhcqMv8AUB0jwxjII8Rjr0oj7VcItb+NmcldtmJ5evGs99m5pra4jsw/aRxE9mEfI9eVdKhaA8tG2SMyoiuE7SDYezw9tSkiImaFlysinQp/tPUfUUEb8zjXbjJRmVwdu6MZ2+FXx8QjazNwW1iNQWOc4IHX60kcO6A8vtC+64WsN5DCqg9oO8dzkeB8qdCBUkRrmTs4xHhQDy7vreg4Lw3nFQxRTFoDq45g9R5H86nfTxT3JVYdbL3i5OACDy9mDVZw4KgQlzFfGOIyyxRWvDWysYX+o4I7wyGz54oa1g4jM/dtmeMMxwSVABPOndrZieRDJH2bINQ0nYj2++ncXDEZtbSSICNwR19tc1cmWb4oz1pwuG2LSurO+AWRRnvdN/1oTiAmvJDgaFPdxpwf5rY3NssFkRC79R3+Z9n0rPvJHEBpwcbeO30rtjKGGOzzM+f7ANlbPFAIs7fp66U3SCEQKHGXVgwNBrcJpGB3iMb+vnUnus4GOuffWl5sIx+pxzzWFSww97IwcjJPr51hvtFxcW/EGtohy/FjkK1xnZ1ZV3bSQPX6V8s4je9je3P3lTqfYE74rYckp7TL+P8Aa2wW9uWWFhFMcsMkA8vH3Uj++8RdGTvOhGnBGdvCn9h/l9x/VnmjwM93OneozXsCz9nw61Mq9GUbVZW2d3FJWZOSCYZLIV/Svpf+DX2Uk4tx8cVuAPulkchdiZHxsMeVZeeDiTRsZeHELjmcAY9tbr/D77R/5Lwa/tZdMFxrDqGbn5eVUjGic5a0fYOJM1zeW3DbEgM3fmbpHGPrTkW0UCaQQdsEnmaw/wBk+NQr9oJ5LqQF7mJSGPL2e2tncXEMikK67rnbzqGTFrSE5O6YvseGyTTPd3IKgsRGh9vP9qJubSMR6kA5ULa8etJh91mcRzR5BBOxHIH2VDifGbHhNuJLq7jjQnALsBk/WueXjNaSKrK27bFPFMJbuZBjA6evnXzLiV2lrNIVmILE+RPl+1G/af8AxIiuVeHhULzTNkBtGAPPz9lfNpIeMcZyWk7Uhe8qEDR7c0IeG7tl/wCUq0fRLP7aQ2kRi7VWHhq3Hu8PKlX2p+0t9cwRtbIoVx3XDYBrK2PDIeESxXd7xC1hkDZ0Oe0cj/0j861F5xnhdzbi3jhWdpBqSRF3Xr/djcV0wwRiQnm5GGTh17ezB7ojDN1cc6c2ViLIktDpUZDSDcn14U9ThEUlgt4H7NMd4HbfyHu5VCfhxEEZt3aSR86kcaQB0OeRqzhFqiam0K7q/UzQ21tCBDq3PQ/tTGRmKoqrqwe8T19eNJJbe6iP9e30MmcZGk+3ar4bq4iMelnKr+HB5Hrt41CXjf8A5GWb9NnEqMulOaxqN/8AVRdppiuVBG2xO3r4VmuHccTOieFwORcLyrRoyvGJEIZSBvnp66152aE4S2iebO1tBk8oaUsoG3w/iqWlJz+p9fGqsnV1z88/Wurk+WPL18K5WedLI5dky59bVAtk/QV44wBiqy3PfrQ9inSwGakoJ51HTlsD9/5q9E7nlQAuyA9Y9fKuZ1bjw938VKQY/f186ki9fWaIaorJ2GdsevRqppCPbnptV7ppG3rx/igJcnpz99FGLVlzyz5YHr4V5pCqjbP0+lQjGnGfHx9fGuSZz9Kxi5Z25ajnz55+tekuNwRvnw9fKg1fDEDlUpXzkj166UyiFFhu+mdv09fCqJbhgSCR4c/Xxod2wx73WqGYvgLnPl6+VUjEpEK+8kHn8fH61BrjGPAeXr4VAQhl1eA9e6hpg6NsTTJCs1wbJx1zvn1zru+AQfl6+FUhu9jp+lXLv5cufr4GuABINt5efr51LPPx5VHODXjjl7vGmoU5gHG++/r9qkUJHdBIx032+lVhvX5fzUtWMYzz8PW/50AnhrjIDBvHfbHv6e2n/ApmeVo9WnWOR/1ezx/OkUbuT3dz7Pjt+lHWb9nOr6GUjfI5Y9fCujBPjJFIS4ysbcQaUcXtl1gxzxMOWdRHrlTOxkPZZ0atK6WJ6+vGlN5exz8Rs1kR8JKAWHnyPtrSPAI3mi7+pxqH64/WvTWNSdo9VZKSsLidHjBCnAGdxyqEkkcSatseNejnituHkySjSo3LcsdPd+VZGfikvGYHjsZD2Oor2hBI28/1pZ4uMbKY2pSqwP7Rfam3tFeCLvy46bishFc8dvpWMEMipJ/c21a/h32QRbjtbti8mrrz/mtUlrbwwMoTCY2x65eVcsMV7Z1zyxx6Wz51YfZa9EgkvGZ0U7LjOfdTnhYe04osZbShPLpj6Vfx/wC1NtwqVrOLBlYYPl76R8JFxcyyX7ya3JGMdKEo09dg5uSt9H0ogtHpXIOxwfl/NLuIrIYG0EM46ZwT7POrba+V4cbZxzHr5UvmnV2IRiAu/iMfSu9Y7pnmyy8bFxj7dFLr3F/sYb+76UvFtBDN2sMUannsPW1G302Z20uSD4n9f1oUMdQ5nfp41weRnblxj6POyZpSZN2ihtnmkTvb78jn2+P51iLnjjpxD7vYo39Ugdzrnnt7+XlWu4tC01iiKcEnb14flVHB/sQkc33m8dGfIZQOS+0/rXfhlLiuTO3Arhs7YWYsrMIz74AkI5sx6AeHKmUFs8cauzZdsLIG/uOf0086fQ8Ct5Ih/UZEzqOB63oqLg8UWNALAnOSfKo5Zpvs74JJAq26QFGRHRlAYBTy23GPHy61Ke6it4Uka4VUJPfIK7Gi57WUBGLKNIJ8QayvE4m+9s7DKIO8T/b1qKe9FKTQyv7wPbjuKw6lX6e39aQTy93c4APXx+tZTif2yuI5CLK2XslPdfHP14Vnrril9xByZ3ZkJ/DnZR7KvLxsmV3J0jxsuGUpt+jb3HH+F2WO2vIs77KdR+VAv9tLEZENvPLg4BIC5+NZO3tVdnyjf7yBv8auHDj2mIkk05OosM74q8PAxpb2BePH2OJ/tlfA/wDl7MIT+Evkk+HKs/dpd8Xlae7xqfwAU59nSmyRJAcpL2ZICZDbnx/ijVs8qXMagju5ZhXVjxwhpIrGCh/UztvwG1xq7BWfP4mbI+FN7K1NuO8F7NenLI8c00PD0jhM0kyKi45HJH716MrEqvbQhmZMLJOdh7jVUrGcqL7UxyppdSRq2096l11Y8KNw5ELdqVJ7MLqAP+rGflXla9uJJF+8OkkY0ILXugnpnxqq+t7pbmf74jvcLjRKmT3vPodulNx/ROb9FMdggVTDdXSdkcqgfKr7geVTS6+0MIkSG/umiH9zk5Hxqt+G3CFMw3KupLMew0nz5/lUWtkkdofvMihEy/bEoCoO/nRUEujOd9l/bcUaZbqS/kE2CilHAz7R+lUcT4dfXsST3dz26YLAlu0Kp1OKfWkVtZ2uUhR0XK5J5r5E8/HalJLtaJKuywSypzxg/iHxANaUAKZnI7S0juewHayyagoDMEGSfjTC/wCC/aHszLCrJZ6gnZwjBLe3rv8AnVvEb7h0t8tzHbqzKgcOd9Rx58/2qEn2lub1oUxPCsS6pNDltajnkD86lOMr+o0ZL2I7b7PMbyS1E1vHdA40u+Svjyzyp3wvhfDuFzubgteTQt/Ty6iFumWHMgUH2Ul1xm5uTiKEzbDtNwG3UePvo+OzeUIkf3kiUHVINtRPNeeOQ99UUbQjkMYuMRxKsQSJgrtr7KFUA8MY5+2m/wDmSNbxysFIjckRxFcHxGnx5VhbmzltlRggS3c4VpG2yRyNcUYV2fsomBOlV3z4Y8R+9JLG+0Mp/o7vOKzixdrazCWeoFe23Ynkds7D6UtWaK8imcIdh3g+/wD3e6uWdzD95WN7NpGdSpxLurdCPA1yNks7lgiyKNXe/X5GlqX4No9bQwxFh98jRjglGzzPLfoa0HDJ5raLKsXjzuUGpfh+lZy+hfSJInjR410kMcZI2OPpQ0M8z3itMdJA/Gqcx4kj86V4+XYbPpdk8F43Z9pGkjcgTgHyxz+lXyQPHKYpI2Vv9w5++sKOJSiZEllGo8wT6wfzptb3Rkj0QzSiInvIrZA8wK4cniRf+CSwwl0P3Ax1zn35qAUFtvX7UEL9LaJRO7Swj/8AkacaR01fWmUCJP3oJBKCc91vhXBk8acDlnhlE8EAxjlRcaYU55+vnUFi36nzoqOPKkfOudiJbATEXfAB57Y9fKiktMJt4fL6VbbQ6pN+nj8v5pssAVcEHn7/AOfzoMek0Z6aEjZhv69ZoBocSbA+zkf5p/dQZOAPh8/4pTMMZ3+NaJJqgJhj2D16FDyMSpxy/SiphhSfz+v60KTnbfmenX61ZIIMc6tvj51aOW3yHr4VIRasYAx489vpU2j07HoPX80xkgKQePh7v4qmNQWOaOkTOfb86pCFSuNvYM+vZTxYyCYINQG23z/n86HurfGV2Hn6+YoyGXG3l08PXwqNw4ZTq559fzWbMwpfxnc/H1+9FRuCeW/rP8UtViG57eXrlRMMh9p9es1yUKFscezFe1bdfjv/AD51UC3UHnn151FdmA6evWKxqLSMtz+Xr4VwMNtidvHb+K8R3c+vL+aqJxgnx8PW9YwSsgzjJPv29edXLMVORz5+efrQK5Jz19esVeFJXy8en8VkEcWF1bG5jMx0knGQNj68K091c6oMxyAyRoFyT09da+fk48c+vn51pfs+U4k/ZPIUlXwP4h7P0r1fDz39GXhkvUj5F9s+Mfaa4vWgMkqJETiOPYOvifGtD/hv9onj4JcJctgwyh8HmoI3x8OVfQ/tL9l4ZI43a3LKp05xy/b8qyV/9mjwmzmmhMjdsNJDHIA9v6125FUWjvhTpoZQfaKe6mKq7MucAD1/FMuK31xHYhbYN2p6cyPXjWF4JL9xuB2jEvjSuWx3q2PCrAzwyPK+tpCSW5kD10rixY7dF8s1HZjU4bcXdw88glkd3wcn8JrWfcYrax7FXyQuCUzj+KZ/dILJI4UUBTsAevv/AF6URc8NRINR2LfGuuPjJI5J+U3Qrs73s7UYRlcDnqz8frV014qx9zSGO+3j4e2lxeK2DLGWYHw29eyh+2G+hAB/8tq48/kcVwicWbJylotMjO42+Hr5UTmKztzPNpJxsPXT8qA7Uhhq9evGh/tFcdnHGozh19e+ufxoKTcmDx8fOVMpt+NrxDjkMLjI16VB8fr519EtOFTNE2l0Cht8c/Z7a+G29/8A5fxqC4K6gjhsDkQP0r7HY/aSzura3vYZsxyKNQ1cm8DXqRx84nfKXxvQ/gs5CixJ3dR3PgKYmAR4XpyzSa540jWZmt5UVsAjvdaydx/ieLX+jNaNJcLlSsJGKn/FQXmcjfXRjVW19zbGc18u+1n2khdJuG2cXaJJlJZBnHsU0tv/ALX8V+0KlQPuVuc95jtj9RSZsWkAeJiyt3QzuAzHnsPCqY8Kjth5N6AouHcP7MmaaNHH/wBOSfJz7Fo+KysY1WfTBJEraSBqwT4DwPspceIYZRa2kQYd5pHOTn4/KpT3IEAH3iCCRt+42fjg8vZV+uhNhzizmeXTKyIpzpRwoGeQGd6ClaDVFEEOk82eRmb3fxQk9/NHGkcUxaIPuM88/wB3z5nepyhC1wqbGORJFBPg3eGffyprBRdGklsjsEwEbOt99QHn76Z28hvGFw6IHkIYBnGfDagLW0RpHDM2hkZu63LDZ9CvTzdio+7SLuxCDTq5Md6yWhW9j2Ne0tprlERZIzpYlenXAx8qB4jGkKJIJnBcBnjWXbB8ev50t/8AOSKyPedlCQWaJH06jzxz86pzFPcNLcq41Dsyw6Y8B7qEL/TSoJk1hsRxnTqOkBsPnwPnjrihJLy8tlPYzSBI17uk4APgSRud6ta20WqG5kWNWUlVL6s59h8vdVMbwK/cOtezLsGwBqyQDVifZXHxq9ZQ88ZcS6ge07yDwPU9DQtnbtNdNM6ErsoHaZxn/VVcVtDLFOG7RyG7qsce331WySW+tw4aMgBtPMew1lI3Gh9DxmSCdUMS3UyIcEqW07b4GfbRtleuq39qQjaityyD/T1/7cUrMMSWtvcrMCrKx7ME6gCBkeXTFd4dL2d72zupC5V1Y5Mi8jv7/lTMDBuMQR2l2k8JysYEffOokaR7htVUVqJrhHDL3X15kbdgcZwFPPzrQ8ftEl4W0eCfu8mlmOB3cZDYA8M7VmrB2kkMblWKr3HVcnl7tvyoAHMtrLGZjGixQySaUVu80gHMk9fcab8M4VNLwcXkpeTQrdqsbb6QRpPe6Zxy5c6De5t+IcNiS4MNvNDpSMy/3bk8xzHmfGo2vCeJXqyLDJgEd4a9CgdORphAW9MJ7JZV0qy9xGbIVyd9QpfPw95IYUiUS6dQBVQvkCu2eXQ1aZZRfiCSGEtr0JIVbutn8Q+lHcT+/wAEK3MbIVQai0MeOzP4cZ99Bq0MnTFycLe1ukacf0HBRSTnDaevrpUmspG1yPHIECDMmTpJPgRtg9KohtGvAsz3Ou474CFiWUgjHxyaahL37msLPM9uUKrGSQAd9O3tyaEbrYZd6Kbiw+9cNR270gOXVRuHXY59o0t50onjSS4SNYZI0VcEM5+PPatJbydvaQyrKGkz2bLozhlGQfYV2NANotiwVFMMxYr3cnTzOTnbH1pNDKwJLRlKrcTdpERiNi+oDHzxRljFfW0rTiVXUsu2oMGX11pj/lSR23aTKjOFOlZPE+fjUk4jYWcjgxzMjpo7PZlz4g9KjNr0USoc2CWfEYmXX2E4OnBOx8VNC3nAL3hR+8WWp4/7olP4d98fSlqXPDzGGtO1AJGAf+XXlTqy4xKV7Ny0ihdOH7vuz4+dc7TRZNPTO2fHx+G5Ut01Y3Ht8RT6GZJEDxtqVuvrr51kL4QAm7tlAbV34yPxHxFesr9rZi8chEecPGelc2bxYz3HTI5MKfRtY3CyagR4+/10pgZwIwPL5VnbS8S5UyxPqC/iGd18M/WimvNLA6vr/NeZPG4umc1cexjMcpn2ev3pHdtpckb+zajnvlMXMe718qSXdzqJ5H5ijGIkqK5ZN+hA329fKqlAYHbp18PXWqHl1Ng9etWwtsd9886rWhCYJGy88+vfUnbfcn163FDyOAuFxnyqPaZ5n1661kgolKAdvEevd+VBlssent+X80WQzee/r30M40tqHPy+n6UyGLtWnuknP6/Wq5GLKoJwM9PXyqsZaTSBjb5V2ZGUnJI6b+vnRoR7GbR4yevntVls4DEY39esV2TSF2+QoeI5cgevXjXMZ6GTTp5Y+X8flVWvD7586pdSB150OzH5UezDJ3XQOnr1tVCnPn7+n0qlX1d07e/18aKgVWb39fWxrNDJWdVcj4Z39fGrwe5nkefh6NeCY5c849fSqu0IyvT5fxS0aUaJldS7A+vXKieFzS2d/BOoxoYZ35g1B8diBjp4+vjQ4LZwn4vHrVccuMk0L2faruCO6sGimQhGXfPSswOHferRoZBHPEv4GG2oeulMeFcegu+BQySyASaAr43GeRrPv9obX/xAeDf/AFWi7RdZ2YZ9b17soLI0z0MMpKFoEtPsrYfe1ZI4xIDnvZbAzv7vKtMlpbW0QVAORPfbTgch+xpK9/FbQtFhsFssdRGT4A/rQs3G8KRnn+E56+FVhiUULkm5MNii+9cWL6gUiPd0Z/F9fzrnF7nEJQREkbeXr8qosuIR2NiR/c4zgtn0PypPe3ySuwIyTse9jPv/AFpPIyLHj7ObI9gU80gJ7gTO/wCH9f1qvtXC/iPxwf5qTOAuVZx7D+n6VAYIycMPXyrwZO32TVA8k75HfPjsfXwobjNzHLw9WlkAkjGlV55Hr4VbeFIVBXdvA+vnSiQFpNUoJboPCvS8HxZv7votjXF2jPJw6+v5DrPZJzL538vfTizsxZ2D21s8ioc5Od/PHhRLzBUDSYAA7o5fAfpXreK8v3MUUZSML3i2fhXqVGC0XtyFKpIpKNNO5bGELk/t9KYW/DkTvSDtpQR/RQ7KOXeNMJ+GrZo0Ikj1N/uAI9vPH60Je8RtrC1aC1SOR/xSF1xnfGfH3eVQ5WUpLoIjhLu3by9oiDXpUbJ+9KeJcVhMEkSLEzb6cNk/THkK5acV+9zOrOQpU4VVwF6bCihwL7yzzpoMA3yV1OD4bZ33oOl2HvoSzKohSa3SZpioLK6gjxpfcqHbUswXvZxyKnzrXzfd7e2SxtJJXOS0sgJ68yT+lYvi0moqIgpZRpDeG/kK0XYJHYri4E7Sav8A4kg0/mtklMyq/wDWmRWB354yaSWtkSSsiB3de6VGynxpxeRTROlwiMcoAMEjJAxmqULYwUGCaeNk1SqjAeH4QefxpTc3dtF2bxIzyMjagdsNt9ad2faXUsc5DDtNnA/3Jg1nme4tSY1twhjYrk7nBGnnWiK2Dw3DSz41Y3yeXLHjWqg4XYPZLFc3Lx7Blkzp7vv2NZ5OGyoFlMQOFJKA7jwyKNm4fxOFLdVeSTbeMZZV9g5e6jszGd/DZWto8UMbXBl70JlJLqw5geRzWbZ5o7mN+xVE05xj8WdsU0tDcx3UciI4khXdwc46dfbVs/F3tdSG9a4f+/K6wM+GRj303QuwaC7uryzi4dbWQd1ctiNWGsEdT1r1/YXSX/3e9thbIAP6Zk07YzqOeZNG8O+1M0CSnhURVirBgF3Xf8WkdaOtp+HcRle6v7KRJ3GDL+FWI5nf8h40jlTMuhVZcOuZEuo4YtcMaEs/Lp0r1vA1vP2N5BHqjXtFRiPw+3wxWw4SsVrYyGCZTbykkhDup9tLPtBbJeSO0VoVYae0cg5YdB7fOjDJboElonNbpLbpFPLh5Iuyc7bsn4SfaM7+VZ7hfCI57h4O1CrGR32XdtW3xOxp8/dtra5Tfswr6QuxxsRj2Z2q+0aFGuH/AOjo2yeZH4l9o50/KhaYqu+AvBA/ZTRzNGT+NNOPIfSucPt7myXJzpxp0DGDnmD5Uzk4hOFaExRXBfG8j7N8/gaFmF9NG6fdoVQv1G//AMiTvRU0jOLei+3sbO6m17RSFml0l9WpsfpXb65mkiuo2UktltLLp1NjGfy2pfbJf2dypjCoh/04Pt6/KjrviyS5kvHhjOw0Lgkj3UssjXRo477FHZK8Kytbv2yqevIZ2x4imSzzQwzI9oHMiYYPIWOnz2+fSkM18/3h5IZZVPQh2FQjZdS3RuZQwbs2Qam38q3LkhnGmOG4Ybf+payB7e5ULIHJ1QSf2H2ct6XN/UuVR1CtjGccmHNf260Tw+7SwaTR2sxkITEqY1e7yr3F3juFluYnRtXMD/UMD0ak7seJY11qUlmYrgZUb/Dy/KqAsBZpChOpSp7RWX17aEZka1XWoC6sEg9a5GGMwSOecRrnu74I9dKTiU5HOzt0lPeZVH4SG04PjRcckkSLlgVbk2qgLlFwv9WVSP8ASpwce+r4ImeFnjYyAfiTSAeft50HGzXQxLxT6ezGqQD8I3z9aXszxSa4l1J/cP0/evRTOFbvAnpty+hrscxSNtaFhj30FEzl+l1jczRMLhNSqHxqUcj4Gn0lz20QnjyE5Nnp5+ysbNJLZ3Jy+uCTfSeR8j9aOs75TIXjkIHIoWqOfApqxJxUtD43JK4br4n18aHdmznln3VGNlkQY31eHr5VZIFCdSK83jxdM4WqbTBmOG22GcY/OrlYhRg/Squ63h69c6kn4geuaYU5KxJO9VpJjBzvmrGxqGBtjpVEhOTyxWRrCBPq5ez15VAtqbl570PHsxJ2PKrx3e/8MVqNbCrZVEnj6/P86rvsEYHI8qjAdUmzbY6eH0rt2QV6c8bn18aKQ/oYzyYYjOPfXraP+qD4+vQqb2jSrqVdvXrFSjXszhgARz9frXItI3xuuRfLHqXbGPlj6UPNb4TI55ojUfD16+NTYK0Xt9H+KFiCwL1xiiYm0gdPfmvIo3zivBADy69acybQTr1eBOPX81x1z7efvqKLhht5bevlUmAU52x8sfSlGuy0tpiAOwx6/igJ5yFOMBRzwfX7VbeT6V9nn6+NJ4VmeL7yjCSKVtXf27M+ePy611+Lg+Vux8UObGaXdz91Zba5CkMpAPLV5/Wk95dcQi4xHxFzai9hJAxq/Djly29lXFbeTUexjddegsNSr7aJazZJykkds5xghZCwwPFvDzr0seLh7OyHKMeN6Iv9pZJ43M85RgOSR5AHj+1W8Nngl/qLxJZSeaHZvZg/nS24tI7eYF9KKN9YOR8aFnSAQrJFJGdzkbbef7VeXNrToVx/DaC5zlY1yg6nn/NcHZqu/wCE9OlYWDjVzZN2speSJxpKauQztjY5/Smo+0YkujarCTIzYjx/d1/LFefk8bLklTdkZYZGjaUBCdh45+X80uub5kUiLSD/AKn2Gfr+dCNNI4JZ8Y8N8fvUQvaEBFcv1cjPwz0q2LwI49z2NjxfpUbm+lw8MJcsThj3aHll4wsZ0RW6vjmG3+dNTanPfzhRlsnOB9KF4gEljCQTOOYwyYPLx8a61OlSOjghbwpZH4h2vEE7WRSx0yMTk42394qxb6+1yp2rRrHLumy4X9K5EWt7yBGBUhdwN+efWKsv3Th84uCrGOQMsvmfOg5W9mootnle6e1ebTFMh0yHnknIPnuaJPB3u45XbDzLs68sttz8vA0LEsU4jAkPYqR2Uq8hn+1vDem0U0lsoEx1Sjk4ONvL6UG6MZ08MuBO2VYYOTjclfPFMba+ubUzHW8JVRjAyx8/P2U7iaGQqXCTltv9Jx7OtVFLdVKYiRAfwvINz7qWcwxiKYr664k8izNI0ajf8K6vAE+HnS42bvdGQyQrjuqcfpTriOTZF4kCqTj+kmN/ClCWyCNi8WCRt2j4A93hVcTTjaEyWmNLSS1SNUS77aQZ7iIdI9woq5le5jS1R1Wf8KxBhyxuTis1HcdnK4MuVxjs4Nlz5tVY4lcR3Sm3RFdX1FY8HV7Wpmrd2LZroQ3DIokYZ0ldm3HMD9edLbq0mn4hM0ICRByuZDtq1ZFMJL6Ge1tnbOpkLHruOePpXJLwm7MMKRhXw6hj3JCeYNC6B2LuIKLYxfeuEiRwN5Y2P6VASW2pxHaXxUKM6pdgaON+WmMTw3dvIMZ0kDl51ZJfFFKxXNyWwchdOa3YQW2ZIrzEkKRw6O8TufjXJ7uzW3zJewaZNRjVIsBd/Kld1O8wJ+7TSlhgmViAKUtFJJ/RKomCe8u4FbjbMFw3dpZcQd4LuRlbdiM97y9lMkt7HiMY7Nbhm/Fp8/f+dZtbO4W4ZFfUqn8WnrWjsrS7jQu16VUdO6c+7PypuIORd/mD8Mia3WOKAMSdcx1EH2DrSxvtFdG5LPObhlXShI7q+weFVvwea6uMvMZHYFmCJ8KZQ/ZhUhUyzxqv+nVljjyXlRjBLYrdhXA+NGe2aKU4aLPeP9+fOvcclkVbXs7j+mqkZB7y8vngVdBwiGKM6DoODiRgMj2Dxol+EpcRjVJqI6Fc4/XFC1YeOuxAeIXlzKND286LurzR6Cf/AG0YvE76CJEbh0bd3H9OXZv2okWKWRYIGyB0Jwa62tHy8UhA5g4NFpPoG0J5bq4lkDNYMuCCxZydNDXdw5LaAfvB5KseBWnku7ZowiRaW6f0wfXsqiW6bR/T1nu8lXGKXQdmcS2v5I1ZI+z1ZBdyAPgaMi4ZxRCxllDoV7xzkAY50bJC0uzwtjn3iOfrrXZI5ShREdM9e00/KsmGrEU1hxEzdkxC6TnXq239c6YLGllAiNcKURWAQd7UTVz2Mksh72APB87ezNQ+6QRHU8sZOOTNz+FI3YyQCrt2eh9S5zv0rqTQREDtBgtnLE86LnhtmhBWAsM7sSQxNDtZgvnsJI/cG9eytVhOSzxSxljNoOTy3J+VetOJR2NxHIXkuIxnUh7o+X5VXBbIiiSWbGDuNGAT9KsltLObvJMipjOZBg59oBoLRmHXM9s8zy2mtcYcKyqcgjPjvQF3xeKcK0dpJHMow5DHTJ54/tPs2qUV0YYJonniZZVCBw0jFcHYry3oSTsJJcmTPTZfxefP5U0hUv0EmluLl9blNhpCKKDjuHguCpCHfdWGfhTcvFAMRqzn/SQAPlzpZI0zuks8BjhY6Q2nA+VIOhxwfimqVYmCqpOnblWoKlxlc1homhS57roBj+3OMj21ruF3na2S69iFx3t8+Hurh8nFX2Rz54f/AESd9EuMYrqSZHSgLmRxdZPL20Rbt2qrp2OfnXLXs5AwkEZO58DUSmpqnIUCgjf2UHPN3dIPSlQU7ZcE3x08q5cy6Y9B5+BriXBUgb5+efrQ8/8AWLHfY9OlMlsNBMEgjbLAnHP140NeX43Gdh0qMJznO/j7KVX0bLKcg8+VWjG3RTifSbSYLH3vxZyc+vnUJdDzll2znl4+ulCiRBGjqd9O/r9Klbyhw2QPj8K803ytqi5hhT4fEY+lQBwpDfM+vjVrAiPYdff/ADXBF/T9u3r6UUrJ+ypAe0AHL2et/Kozns325Y6VajHXpOPHPlVd4urB2OKahXpFKysQasWRsnV41UikY3wf1+tRJIbS+w/T6UtCpl3dlVs4wB6/ilFhxVIJIuwkQLG3dDjUCg6Hyo69m0W7pFhVAGST+Z/WsGP6KHs5DENerffPiK9XwI0m2dvjrVm44j9pre5nEV4rSGMnSsRjRWB8SFG4xSG24xNNp7NJGPeYhensHSsvI00zSSBVQL4Hb50fZ3d0bgxEx24eJhnG0nVd/dXclR0jbiHFBFw8feX3J1acd8ny8qRcJ4tJdcSVDHlXPcB5E+BoC84fxJple5QszDI/qAYFHcMiNjcDDo0zLpjCZITbnnx91M6rYqWxrNAHeWXSXR3z2RfG/MnHSq7WZIuLwaSwUqUXbOk486ulmt0soxO6nAJJ1DvY6E+GPfWW4pfSm6M0PdjYjspP7u7yNCD2GdUfQpdaR7JrQDvADOOXX9aJtLmQvqtUjyjYfUO8fPflj21z7OXfDftHwJ7uTiX3fiNqn9azEGsuRydTnkeWMGibeXB7kXZhtmLfSrTdonB2y5i/d1O2dR2J288D9KBvY2LYjww0nrTAW8hY6HyG5ltgB661c9nohLGTILfgT/V9ahpdlrszl5JNE1vMw1vgZz8Nz+RqkcTzIwuo8/27cwfGmssSTNy3XdT19eVASWiuwV0AUYAfcj4/rW0wbK44o4pGuLW4SLWO8h3V/d0ohJpn7nZKq89jqQ/SgpuHo87rr0gDaq7O1uo5CySHsxy6UaYtoZTXaQRFECM55AsVOazyXV2Jz2ojHlWg7LtYxriDbfiIFQ7JVypQqD11frTKH6Dl+Ab3V3ewrbQwyFcZJB0fCiV4Be3YQJDbQjq8hLn50bbxsrnsou94t3jRiWUs0ZaRy3lv+VNGKiB3IEf7P2awql9xVpiD3UjUBfgKHHC0DsLSEleuNqbfdVgTOkAHx51cOzt0aUy9wb4O2/1puQFH9FcHC7nOXcBOqgfKq5OCuJNIlwM5VQ2MH2HaiZuIG4JA7TSrbae769lWQh5gJpICdtjnO1amtswF9wu0ZFMzgA4AKd0/CmH+XkOXRYstz7NCB8zV0U7SQ3EmAIUAXGOtVXnEZbbs0hkSIacs5GWPj/FMlboRvVlc/CNb63kfK7kHG9UHhlmMkPk/7Rg+7lUUe6vsYa40/wCpzpBFcWw7RwOzB3HekY0eC/QqTJRNw7Vjsu6o7ylQQfzq2Oez1YSbQGPMDGPKj04W0bZ1RBRzxHv8aEulxIMyzaNWciIbH10qdJuh91Z4RIpWaOVpFbu51daoju4V1pFC8rjIJAwPiedXX+mOGziTCqFLsSOefGhgO0VWzI4Yj+mpxk+f1rR/0EiTrIluTJL2XLbOo+vPFU2oeFZLm1jumKtl3Z8avdTYQOluAIooh10jU3ryoVL60tneH7sWA5u3M+6s3eomquyT37PGpQSqG3/6eceP8VVHerPMuREVHM6WUiipJ4GgTsXmjBGcFdSioQSnHelVz1LLpP8ANBN0akyFzJZs+6prbbIkHr30FKmm/eLA7mAccw31oqUQyXUTv93eNO8ehPjt+lLY3Z3YnnIxZse2hfoPsZxG3hGMxhsY55x+1XiRA5SfGAue6c58Pd+VKo0KOSsQB5nJzRLjTC2EGo8sbfwa2g0wfinFeHq4tlV9RGnLDYe0igwsUQ1aBhur9KXx4ub1Yuy0NqzqPSj5pJJC2hQ7HG+fnS6Dui0cQtkkaPBd16Iny9lWpfI8ZElrIWG55n3fvQoVYZFWNkt8HMZ063Yjmfb4UTalWl3a4LEnvMQvX/Tj40eNAUmyDy2ExaJoZkZhkd0jzoRY4i2l8nz57eulOhIh2WQKfw6CQwYUvubXRLr3AbmTyz4VN/4N/wBBmtoVD97IB5auVVm0tpo2jR8Odlyc7+utNY7YOo14CncHlmrDZQIF0FdXUKo2+NKEyyQwa17QOzasMpp3xAQX3C3uLF/6NvgOsqgFcA/9v1qV7ZRt/VhQq394G+R+tCJZ/ewyRntAD+DGPYaZS0ZoRyxoYyrIveG++2fGiOF3pgZFdtSgaRvRkllCgeD/AOrjbpShomUPnY9M+NK0pKmaStUzRtpuP+n06gVyJ+xfRgfpVXD50EfZnGoY1E9fCrLnMJRxvvzrz5Q4viebOFOg5XYxsTueefX50vkPeOo435Yq+K7VFAyN+XQ1RKQ86JnAPWppbBBUEW7BpGd+XTHKrWl/r6tKFQckdPKqkgRxoMxi0oW2XJZvD96oFwYEVkYhwcg+dFDF4dWkOPGqbyJ3jLIB5H1+VWXEtvHEjR/9Rhv+vurzSv2GX225H5fzTJu7C3uzSXFpIVRUw7YGCDz6+jXuHxmRmJU5FFWkzSd4pqbvN3fngeHlVJuEht5VjbSXwefhXGxNBcjquMDu4x4jHr4VTNJlMjY+fr51TbGSSRde4bfzyf1qy4iQ63VgNAJIPh66UEElbzxs3fXujqNjn61abeJbXtFly2dlP+n10pXZYDOHxy938VN7kXMnYM+zHJPI5+vnTL8F7PGVu22GnbNEGfXbsJB/VB7pxv8AHxqq2gcDv76DzqyKJJCchu6GxpGdgMk+ylfYBbcQyXlnPGP6ZZCM451hpBiHfGc6cE7ivodzN2PD7q5eMns4yRvj17a+YPPbyyPJKm+Sw3PeB5V6Xh3TO7xemda6EDL2ve1Nlmxmr1u7W4UHS0DJ3lP+oeXgaCmhgli7XtWQsdWDy09cZqqO2dssk6pGBzbmfhXejoZqrTjl2Q0V1etLEqFUDjUP4qp5Y7cdonZ4VSuAN5PDl59az0d9ELfRPE+oNvIH7p+HWom+UFimCB3lRiWGrxH0NCtmv8JXtwtzK6SSFXyWYL+H2Y8aVNK0kq6jnBotLO8unLwW8r6tydPxopvszxQRGRbbWVGp1RgzKPHFUUWJIr+zl6vD+P2tzJGsiqSNLtgElSBv7629x9pOIbJDax25/udm1ezHn5181kB7ZlxuNq1nBb8XdgYr4HMAxFOfD/S3srNWLF0ba3d7uNWcdoeZJOnPuppHPC0aoo3XPeByGPL4VjY+IMsZhhwFb/qa+ZpinEYtMcURe3K4zq5Mf0pHBjqQ9ltx2uEyHyN+vv8ArVM0Lr3T3jnptv7Ksimdo11OASue5hh8KHknknKxqADjn1AqWyhWYSszKuh2xk+AFERqezGlYyfMbVSkZTK52H438TRWgsAypINsDAx8KtHRN7KpI8sMogXwFea3iUf/AE1IO3t9lSMDPpBD4x41VdjDLGNXjhzmi5MPEIheHsu3de4B3gDjlU04g8uTGhVOgbbNDssYsYU5n8RBHOh5RMi6lUO/9ur6Uy6F7DGmSTaSXfOVES5NA3Fw1vcMIkVcDPfOon3VYnbSRq0mNSjl5UVcQCW1UhooXJGS/P4VrRuiiETS2+p441bOSzjn7qvK/wDlzgqQP9Bxg1TP2VrFpGqVuhYYz7BVEU7Mv/TKhzttWezdBUKdjapGoY9q2s53qIkSaZ1VgHbYORyxRMmuFYCXwdOTilsdxIsmpFV85IwKrBctkpOtFYfsrpT2Us7eMjcq1VqrPEskxjjB/CqjcfvSiIhSjy7x4wAu1MoriF5F7FVwB3iwz69tGSBZC9dNLaJSSR7hSdl/qkfeW38ScevOmV9ApkLdoTnp4UNbWrmcBQG3zypIyiO06B+Igvca2IzGgWu8PKaTGPwt18qnxLa8kdoxjPIeFdsVMuhiuFXn8a2uIPYWHFuNKJkHmelLr6BHuE7ZWbVv3TpGfrWigtu3kGrI222x6PlVb2sTHIUMV2yevu8KklY8pJCbQkUUaLIe6PX8VZHhl1ZRsePhRUlqvbZ0rhQds8/XjVQTsWwVwPbzogKJ44hb3DsneCYUjpnb+KVRRTC7EaDWeerz8KeXaaeHOCrDVIuPZQtlIq3Urbee+wrN6CuwQWkobvf01GxOnNEqpaTecgDbJGoYplGyyTFHKjbIz6+dRmjJU9mofvdNt6VSG4gEsEbzqEbtBkB3Mek4pSbYpI4XcEEDHl1pzbt20miQYXOwG3trlugkulSRtOQ2Pd+lb3s3oUyQJcQ5XKyqmVI+ZqFtDDDG0l1chtuRJx8K0C8NchsYJPXPKlFxwG2hneYzFTzIzTpWI2WKpYJJFChRt1ceudXNiSJkfCjIbB6ezy8qutmgtrZA1yrPp2wuot7vCg7viNmWyrK+TpPdwB68aSSp6GjK+yuJ0UPEw2Db55/xRCYVhq5ePWlUvHOFibE15FrGQRkLyohftFwOFdL3ynH4QOlBq9hUktDBrR5F1xvqTPTn+1L7nh0gPaxJy545GhD9tOHxvoSaJc7FsE7e6hLv7f28CqlmrT4PNl0+z30KByDQiuNBXDk7nO/rzqmTgk98x7CJRMDsrOEJPv2zWXuvtrxC4lDrDbId/wCzNUf+L+L69RmT2aNqagfIh+yvbSskyvFKh0yI2xA9ntox5P6DCTDKqDH/AMhWaj+013f3CDily8gUaUZgDp8ieeKcx3tulvLHOpkBibTvjvf2n3Zrmz472SyJSVkLm5DSAxjlR8EimATNsMkDzpLbmLT/AFfwn50awWT7uA+nUGKjocHauaUfRBpDTh9w331WYgE5ULjI3GPhS+5dBMyA8m60XArLeQAqF3xucZNKQGZxI+devkK0YmSDmzJKMf2kZz40u4vxScoWAx3/AI0Q081veHVA4PVdPIDmfZQ3ExNPeaHQLDpBTHKqQitWPBb2fT4MwPFJH/auo49nWhZ7XtbtIon7rfhOMZyPD9KkLlI5iUHcK6duWeuPpUmUy6GjU93G5P615pC0W2adgqvJp1ju4O4x4+yhyvaJeidCY8rEJQfwb6viQvOroWUQmJiA4bKnfVk9Krv5HMzCN9UaxjOnlnJ3x408GltoKkl2LomIxHz1HA23/mprZiO8Z8AoATsedA3ErRQq0g/qlwEUdBuSfyoiC7aRmDHB86V2tg6GtgheLTJJo1ZxnfYeNXaz93YJIIm7JmJwMtuBj50Ddy9n93SMd7Tgkdarlupre57PYmSJkwV8Rj6UsFbATWTtERT3k0nUvj5ftWP41wEtIbjhsUbQ570GcYP+3yrV3JSAxw68XBG8a749p8eVC3Ek8EYdSGUupYKdy1dOKUsbtD45OLPnt1DxG3gMslpPFCp0sxibA9/LNQS5t2tdErtNpGEQ7ac/nX0i+4iP8kd4oRpL9+Nt1O/h4VgeKWnD5YLdoEMUrbMw/Cw8cfSvRw5fk7R1wzcuwOOKXilwIrK3dtC5fI2Xx91OeGcDtpkU3U6IVkI1JnHjvtUPs28FvJ2SEYmJ1uScgDl8aeQNci+WFtKwEnSDGAQMfh2q7f4VQ9splgjRERC67NlcaR9fzzV7NayWbp2SgN+F0bBG/P8AalsNm6q4lkRy/wDu0kr9KlLbPDAndaJBtr5n4j86ZMDMtx/g6QSZcwlmHdlUbSD9DS3hCrF21tImtSMgNkDmM4rUXq9rHJHnXGSNeQBk+I86y85aGfto0cuo3AGzehRsNDOQfdlFwkepQclGGR5Uy4NxbhszhJ3NuHbuq4JVh4ZqFhfxXlrrZQruPwOv9vtqm74dbSE6E0qrY7m2k1jNWbcdlKgjs11Ajd+lUJE5YpkquctkYJrCcP4xxXg11I9s/bQA4KldmrQxfa+C+YtJK1u2MMh3HxpHE3Q3+8RTv2EGAq7Y8fE+yjoziMbqANhqPP140utDahAyTB5GXO/j5mj44pAO3kCNjlnl68qSSaMmjusHvFowQcbUHdEG5U6s+VHSXCppULGA3+nBoKXIeRyO8RgE9KC7HOyf/tLcEc/3qyKETQsHJ0pjl18s1RHk2iZO4OathaTsnXYcsbV0LaI9AUstwSyaezijOBnb4Vdw9bZ5VkuZTqTbvbg/tVdzbySEHUNZ2wedQ+7FAdTAtnbzrohBNEpSaG81xDdXOjQHUciKjIoRxEVKb5OaAt4pYgr6dDA5q6WeWWWJiAw8xyqTx7pDqf1LL4jIWNtQSLGw5VXZwRzaF1d47YqV6c3EythcYAxRHCCmojTqI8OdZajoz7C5IYljCAbdSedV2VqMEudIz3QOvrwoibQsR0LnNLo5ZhKQFOPDntWim4sEnsvlKQvpbw5AdK5byGN3ZFKjnvUp76GS7RXjkY7b/hod5RqBXIUvtmoqLbHc1VMp4udbSFPx5FWcMfs4BnHPPKqb3Mkkwj0kDqK8qTJCikFR4mrNNxFVWOY+JRpIB/aOZPr51y64iJ/+muATz8/rWYu7p2JUNnSedVRTS6Q+TkDGPKisNqwOS5GhlkVXAcFfbVU7Q4XDEdMYzSmScyadRyeec12SRzpwc5I2/T20nxsfkNLpnkgiQbHXqGfDFL7CNC8rd7WXbugdc1fd3WmWOF8BljDZHMN66VPh5Tsy5Xs2Ud45zmlr6mUvsVvcpDC52DKNQoSDjq3LqgKIORU1y9jM9zJpI0BRz26VnBE8PE8xxl0Vt9PLND4qVglkNrbxSHVqxgsNJ8arGmK/GRqYOdudA2ImuuIo79wKpOj1+VR4jxKysT94eZEbGnSTRUd7Cpa0aJpkS3eaJVU+3as5eXJvAyOwC4xz/EM53P61nL/7awdiY4Q0jZzk8qzd59pL66wNQXAxkCjDjEWTbNXxS/tuGxdozguv/TQHfNY6Tjl65bRJoQ/2jwoCSWW5l1SMWY+Jr3ZYY55Kd6VuxURCvKzNnJ5kmuFGHMUxtrdkLSFVOldhnzxR6Whv7osQA57x22oXQ/AQ6OgOT4VM2sijJRgMZzpphcWKxSFXOXz+FaLsrMhmVU7q/jkkbuZ/0+dE1L2LZ7AQwrISQSmobUvrc8Ys4F+ziS2oLyu+g7cx/t/WsebG4CBjC+DyOmhF8toD30DZpraXTi3CSZcttHnoBVUcbJGYpIS4xqyF5VcTFFJCoXaNcsR1NLJ3oXYQrOY3Dv8AhPTqaeWsZY2U2RojY689OXrFZzUyzxMBq1LqwK1dlaveRxoZDCpjZnPgvU1y5VVE5jBuzWaa8IDrkrCg5NnmfMDNDm1hWEO1zEsysNUZJywqjid6jW8U1rlIhEYVTqMcj7fOl5LzFXlfCRKD3djmpJUiauhldt2k80kUbsI7dw+OSilsdybhULDTDqwrMOu2f4r0jzRuLh4miTtNMiHO4GNWfiKsay0cIuY1B1Ws6ugB/FqH7CmSrTCnRvrNkELGTGliAcn18amxdYXAyFXvAjpQUjxLOLWKQs7rqxjb15UUs7NblRjRKMac88HHwzyrzkmTSIorMV73eYA4/OqHDSZkWQB86VOfzqxGzdxaCcnPl09e2hzpiV2znUhbOOW/QePlWQK2cnjLWrPIoZ2fSpA/SqIDrkQgAE+HWi5Gf7iYwxB06lpNDMYeILqBZe0GoDwp+NjUM2kkbsSHGkHmT0oiW4ktrZ5P6RnD5iLc0LfxQ4lhjkRVGpS2IwDguSenuqPEFNvfzduNOyqQ/wD6QRisotdAS9oos5WFxNFKmmRMuxPj+vjVfFLoHsrS2zhY1PiSxNU3UDniA0TaSQrajy/06T470PkLemNnVZZO5IjH8PvqyjseKCbqTtfs1MscqmZWOoj21i4L10ncOQI4jgBl/DmtdZ9gn2auY45BKdZ/qLy3xWOvMhGd/wCl2j9/AzkDrXXgqLKY3VjjhMSSSy/1BiKUOuB3cEdfhTe74hJJavKjIexdUIC7HzzWf4TfyT3DWtvCxhaMs6puxVf7jTp7o2PEJZhAtxalAWRuQb/UfOuxK1ZdSCZrsT21v2PeukGXKrjf3VUOJth445ZNMvdKEagKUTOZ+JLdxkRK3ewOQo+3e2lheSMzB/7gcYPs8KC12UYOt4YWkVmRA22GYFW9lRZop1Z2Kqy457Zzy5be+qBw43cmIe1VFyDtnFEGR+GpCsVsX0A/1mP4s9PZ7adIWweC4+5yaNeIi/dPh5e+n8U6I7iRFKMvPOTn9RSy7t47+1a5gQ5yAU1br7vChre8W00bKzL3WV1I736UW6COJuG9nrEbMRpVtB8fbSm+sI9COqkZbSTitB20dzCZrVymV1OhOrA8jXfuXb2bqsgbJDA+O35UqlyDdmMN1d8JucQzNobofwtWg4b9tpEZY5kJTqvMUNc2SSpFr2I5+/nSe64bHbWTyu3e1/0x5VpSSVMFLs+l2nHuH3h1ZZW6g7Uwmms5E7RZEPd2xXy7h0yQQhrzWQfwaT+LFaPhHFoYJRElkAD3l7R871O4vpAuSdGhtowttl5MKx5mrknj7R4zuByaujjbz2p7OOEMF8OVIeIcTlkK6CFlI5jlVFKPsH3foZ3VzJHOGKEgn+0VyO7EtwFEUmo7asVn4uPTJOsc7MDyLeFN4OMLc2MsfaxiZDqTB7zCulNJWRk2NOIm6V00qSv4jQaXKx3ALvuNylehu04zbGIOwlj/AN/4vZSaWRIbx4Zsq5OnHWk+RJP9NDemOTcPdXDzMNSt3gPKmXDImNy4B0n8ODS2+Cr2C2ksYMKKsuf7mO5oCTiHErU9pbo+puRxSRzQUabHlFt2jTXME9qzSFiynrQ8NwYJGdydXIUBa3HG7m1P3iZYUb/UKAveIvbBoJJ9b+QqyywcaRJwkNJpWcE76l/DUJWBshMWOqM9/ek9peXKlpJHLLjlmkfEuLyT6lTWiO/ex4VGc4xdIMU2zUwcXhSQ9rq0sefnTm84laparGSV1r8Kwl/wya2s4LxLhnhkGQCeVFY7exXtnJbbBJ2FD5Yqiyjy2grt7ZptTXGFJ/1c6IF3AxZFbVjr661kLmJ7W4ABDedetrxjPjk75wuKu/IVaJvG12au5vIFi1xtqK9MgGhbPjlvJcPG4K4BCljjBpLHYdoXkuZCBH15E+FCRIkCsNn1HZn5iuaWe9IrGNuzZWE0M1q8UrZmDanYncn20wTilrErxgb6BsfhWDgunM3bAEFRp7vWo397JHKhTdZB3Rmo/JJNBlFctmpk4xbJHMXXBHhS171Z9cdsMMNwTyNDLfW0KJavZr2khGuVzqPjgeHtqp3nd5Etz/Xjbu93GR0NU/kt9kXjV6PXHGeJWUYtkfDONOMb1mbsSPCZpyxlMpXJPlR3E3kXjizOdJbS/s8aq4tP22kKumMysVXHIaVH1oKblTGvSSFKLqO5A9tFWsKm7gMwzC0gDeYGMijEsnFmJo4WZdILMeQya5KGThVs7BFPbF9hvjl+lZy/DOqB7mf7zxR5OzWMau7GoAAA5CpJFm9VY8ay2wPI1GW2K3mSSA5LAnYEZpnwu2j/AMwjkZ8sjgop/uUEZPwoOSWwXWw7i5Fv20COB20iiTu/hA8PLNV2MTTZa01ySRsFwOtG8St4Lm/SeZn1zkPHAm2fb4UBc8XSzZLeGJVVDgx6sp5sccz5UkZ2qRlO+hjPYxwxKz6DeEd2NeWaFlWW5hiEkgIUaEVBjTjy99ekvbbiEXdEkc6rqjkQ6lY55EcxVxtDLFFdBGZs6XjU7+t6aLrTDdaYZxWN4eBWCqmI8sdR6mgeGyTQzRSQvodSd26jr8qMlupLvhIsw+Vjk7RVx+GlyTJE2IQH/tyPA8/l86CacWkGLuLDp8skV7A5+5TKfasnVWoizu0LRpHFGzMdIXRmoWzRRs0PdW2uF7wc7K3Rvj+dXWMfZXCs6YKSBM8t/Kt8vBOzKSUdh9rbW0UclzLbRLpTAZ1GxIwKtlXEEcVtbRKkyZZ3AXI6L767fxxy9jHJIvZibU6j+49F/Laggs1zeukQXLKSrEHC/X9KlCXNXInBqbtkI7K2ignSU6VfOnByAfLyqjhkFlFa8T/zEh9VnIlsVTVpkxs3l7fOp3Eum3keRwUD6V/1E9WoZ7gOsobsVYxlFRE+ZPWlTu6BJrdFb/8AmBZz3hY25te8itglvb0J7tHfZyNZb+3u3X+kCEYMudSg8/Pag2iiuLL7v2gEzuJu5y0ciPXhRXDbjt7vdNFtFGRGHHQjGfbvzpJfVO/RCXWhw9hcrcpczH7ugJBZufLpjn5VfHM0TJxQPMsEZKrpXS7MOYA/CM9fDNdvrR7mxh4jDcOwC6lR8KGByG26EMAMVTFbSSG3tpJUaSIFoTGQUZWwWUkes1zVxHa/CcXEre8jjuNEaZleKWNNWx2KsDnfIO/splxC0e14bF2eCdRDN13XK0k/y+Gy4gR2pVEkXuZwckePjT3jF0IoeGWr9ti6iOMLt2nQfEcvOg0m3oRqzOGee0WOZ2eRTgpp5ksPDxop7T+tHc47MOCoRhghvZ5Cg5ke64WrW8jt2T6CEjbBU/7hy38auitntODywuSCi68kc8nfzPuoNNJP2F7VnIrNf8yBOQioDEwyVRtQ5+XM+2ruKzrccTH3iEzZCOVzjJGw3FEW8hg4C8pVZBKRGi5wQwAPx5bVRFIbi2juXgQuuzMRhI+o5eO/nTrVMwFxe8SO+iVIShjAZ9B2Ax3sD34PtpHLruuJShiVWO6wukbIu5PurSSWkF3MXmeOEyz6e0Ybsu5OkDkM4+FBcUsYllVLTtMtcdnMQeTZx8/M1SDDFoA4MyPwLiMSorhMtu34jppVx61iez4YlrDL2zKzyNrLd1mwi46bD50/4IEW9vYHha2ctqWIxnlvzBqg30C3sqnZ7d0TlzRef61fG6yUNF/ZgHAuEcStONW/EUEcSq3/AE2OSyjmMUxk/pT3iy6izsT2RGMDNUX3G4ZpmWBXUfh2X9aFurx+IXiPKJDOqnEgP4iMbsPHau9uKVIulZyB/us7Q3MOFYlWJ5+6mFyq8OMbo+EZcqwX+2h7hjerqiXWdAc4Oce2uW1795uo7a+lnAiXSuQO6KWSspFjWBriRB92nUK/Mnu5/iibmSOSQWc0ZZwd9OMH3/rU+FyRLKyK6tERgnAB/Y0yhNnCjO0PZlTntBuW+NKpeg+xVd8LaHh6okSFNWeePf7aQNaSTTDEZMj/AIhWrm4sJmIhhklc76SNj5k1Lh8FtdxzSTIsU0MioAGyMt51nJIz0ZDhzywcSMbEK6bEZ/EtaGwl0zlGcIDurAczSS9tE/zWZ1kxNFIRgLs3szVlnfDW0Uir2kLaXDr0z+VBPdoyYzu7VlmdC0bZw6uu450qvreS8mRQMRrsB0AoqXiS9powVf8AC2eRqNjJkltLFF7uhtsedJftgMxxhHS6WNNo41xHjr41fw+9fVHqK5XxptxrhzvbmSNArLlkx1pNBbw30faRMI51/EOntqla0OujSW112YkkYZwvLlmiPvYWyYtHl3XSinmKFvFFtFELl1EYTcryzilpux2Mc25Ukrhv7QKlJ8qFU7K4o2lndZz/AF+lXrFdQ30c/ZAaDtkc6uWVCRcFAM7gipLcyXQyO8qjl4U3yMdwi0NWjhsrkXUbBUm/qKq7aWqriU8ZH+ZSHBC6YRj+7HP3b1TGsU1npk0syHKqD0NFXNrZ8Uhht9YiEYyozzrn5tzJaugLg8rNAYpnY6t8+Vdm4rcQzBIpn0rt5VKJILO7eF5cKqABkqubhbyL2ttKsiMc5bun4U8mn2UtXTG3+fXzWUMjqrDV0GaEmeC81ySxvlsEYXTvVSXclnbxxvBpAHPFFXE/aWFtBrR3kbUzqN0G56e6k58Y6INUrQui1xfeNeBGsZUKT40K1ubxkQ4jGwDE7c6fJGI7efWqOWGktjc0HacJ7K7Wec6bZe+pZgT7l+tIsnJuTNGatsaSyQPGlirAgR4A6aqy/wB6ngdojHgBtPOnr3AjuH+72ile62tzkCh+MJDd2js0ECOzZeYc1psbSVNjQaixTDGLoh2wwB77E8hRP3WFbppER1XOUzgny3pCbvsx2duwaFf9XMnxNERcQa5kSIpuDzHLFVafbKtjDidrchIzHrZpm74zkADpUIbCCKP+vJqmYjnyUe6i2vvvdk0QkGIyP7vA70D98WKy7UthllIDAbkfnSwdLYkZUtld0gGhAHGdgTsPYB+tBcXYCK3tIAXkU6WYbnPUD41fdcTNnMjmDE4G5lOSvu8aL4ebm4VJVIxksxRQMjnRba2yWSfsCvYynDreaR9Dxr2bjmc9OXlV/DbqFpVvEaTRHtPkY1UPGb6JpPvkjRx3Kkxg4ySORx09pq+3kMM1vYSxq0TnVOSNix3Ce7881pL6tE5SdUT+19lre0urePPapkgUu4rGlkllrCSyFMuh5DvE7/GtdxFlubHsLdUR4XESqw2Y4zt4Uu4naWEssTTrI6xuIJQnRtO3uqeHI6SfonCb0mUy8MNzPrDCSLsda+EZxnSaU3luiX0Nu/e0xAlc89yQPftW0tODqb24mtrkGB4SujrkDHx2pEvDSL4sjsL0dlHEunOBjvN7qMcqboaOS9AFzbfeJgkcZmkikPbzAc2wO4vkKK4RcIl6gRoGn7Nlk9urYD4j4U2ks4eHq1nAXIYs0kmMEt5Uu4fwPsJHnEervZTPXn8OdD5U00wOSqji2rLJDEVKXDayCTns1/0il0/DEjsJpjs1uACTvqJP71puE28892jXcLa0lwz8vR5CocStFuOH3MRiWOd5cFQM6iv8VOOVxlQI5HFme0SWq2qzyv2FxGGBHIePvo62BS6Yv/UVh03z4OPyIoninDlh+zUAucCN5NEZJ7ybZBPzBqvgds8Fui3Ualw+mPDA5XFWeS1yC52rBogsFx93l5yZAB3DCruGWN2I7t0VWitVD3AZsE55Y/OhftBFNZ8UEv4YkwwIPL2edPYpWueC3HY93tzlyD+IheVbnX2/R+db/QSykhvXlhlGkHGgDnmmFpdQfcNTgSrauS+eZKjApBw2VVvYta8z2eodSPXOjA8UPDUVc6Lucyu3XT4e0mhP7Ohcm3RoLm5t/wDyzRDJuB2oV+YPOqo1hhuu2jzqdtH/AKR19nsoK+iSTi9tMxKJbx7Y2Hn/ABU7qaW04lC6KDbv+M567YNRi6mqZKIHx2F3swXGHSYg45adX7UuS1nmh4msWWYIhP8AtywH61qeJSRlZEGALgDnj2+jQVsFt4LzLRoLm2b+o3Rlw36U0Z7aHjKxEVZeKC4iZY4beHTl84yowBtR9tK8P3mSV+0HZgxsf9J5D9qAszLccTEelewQFjt06+2vX90zWQSI6g7frRkuVRGkr0OLa5ee3VfvvY20hwIymrP92k789udS4VcXEgurlZon4dGjEK0ZQyMOQGR48/fUhFCUXV+KaRXXK50nkdqB4vLFYr/l1uuoa9ZcHfpuOvOpwny+oyk3of8ADbhry0g7QwrDFmWVFUvpHjnlgbDGelM7m4tZF4fqdmCsXiZx16YyfPnWetrhUsIYbWR2muO7r0aS2nmf3ppG7Hg8BcYXDJLhc4bP4hn8q58jalZJ3dlYVbS9+7iQHEwul0EYBI35eX5VdxHiDr2OEWSOQOC+nZABuFPP65pfYNHNxAwAvapbg6yu8cozt/8AcfjTp+31xwz5ls9u0iOMeRBxsdgM/GqWuWwlVjeQtYCOaaO0iVWdkPebHXC/3CgDxCYcKuhapmBbiGQAMCxXS4b379KLn4bLc20vdSAAgQPKAMkHO/hXrWzjS1MkK2uqXvdxtQVupAB8+XnQU4rZq0K+ITvFIERVdNo9CDBydyfLrTC4cP2bTuUgkhZTq/AW6a/lvzG9HWtgkNrNcSIVKrnKjUfHfy86W/aC3aTXbrrZpY0lQu2QGI+XOjB8qa6Al7JWcF5/mhhulhZViAUBc6McgGG3zrOcWtr43M1wE7RQwVzHHiQryJPiPZWp4DHMkEHbW6RFFZBpG+kY5+PXahOO3MUv2hht0R9SrowPA5zv1G+fbVMc18jQE/toS/ZKacy/dpbW2uNOdUkq5K5/D7eRqjiv2ib7lNngltaSSNiOSInVs3Ly5U5SE2FnM0+000mElXZ2UHY+ftqHFuGdpxaO8lhWTh4BeQJ//d5gbk8qvDyXza9FFP7CPgyPBYQ3dsCXmR1lydjv8jULnh97IzIVX+l30CsO0x10jr7KjNa3tpZmGFXhBlZVWQbuN9xTninCb+54bw+6+8LI0MYJmTukdPlVvmr2WUyrhfE5HtHhmRZQB/1NGCMeNaLh5iueHSSXTK8EaYC/7vXWl3DoI7RWszL2t52TO8vLH70sj4k/DbFZYiGZpDpIGoHFS5vloLm/QbccVtkkRlmmOgkDtE3Ippw6+sm+zfEdY7JWukClcsWBArPxC34veIXuEaVjyRce6rb6f7vJ9ysbYW5ifL4OrWw6mqyauvY72ih57S1k7EO7NI+vPIkZ6eJptxHhVrawveWCtdrMmlldcGLI399LLSCGTiLJfAXEusmIdEB/ubH5UxbiIsOJNaLbkI/OQn8TY6eVQcnaUSLk70Ibq2uLe0DSaRnupnYkeyjLSf71w4ap0D2eBJnmUPL4HaldjiXjgu+0Z7Ryzydr/Z5Vbw8RyfaGa2t1GiQHO34hjmPH9qo5NafoPP8AR1Z8SF9ILPtNR16QARt0zSHiPA57PioNuMKGwcHFE3Q4fwqZGs1kaZnaJ+9+FvZ4Vbh4rayExd7m4lLRuOi+JovLSoPyV0D/AGk4gr3K2TDQscY3HjRs8EEXDeFwTIO1kjJLKMHypfxzgSw3wldmlLEMxDfiGOXtoz7TXS21xw+2+9PGqRqSg/DU001FREclpI5czR29nYwyRaUkZtR6geNU2cM8HEZ9EqGBVOXDAhh0qvj5mLW0qJr7OLUdIyu/Ko23apFbx3UJiM0mo5IXbwxzoxlcLGWR8RnwSG8W7ugYo2g7FwTjr0rkllNBwXVNKI7hn/GTtj1ij7S4nt450UhcZRQu+9WcS4fcX9siOY0mxnDtgedc3zfbZP5Xy2ZSw4n2E80McAllY4Wd8t8KX393ePcgTNI3gCeVa7g3Bks5JrmaTVpGVUL1pLdQXTXjRWtupuJCSSzDOPfXVHLFypFflVhNte8QEEUfad1sHS++aN4dcLe8R0SJGCo3YHFW8PtzHw+ITaVmZu9nqBRPDODyzQ3i6Y4FbZZGbORXM5Rdoi8ieihb1FvpYluEmZzjSn4V9leiuHa4lJmZiCVIY/AUjmhtrDjMUVjHczSROO2mcYHuHStA0f8A/kGcqvZlC2fMUMkVBiZFT0Lb69uZWudQOlMAe2hIXkkjltX3SX+8eOPjR6t9+tZy6aLcgjIPXNI7XhT/AHuKWG3bsklVe0Rs5361fHKPGmi8ZXGgngvAY+Iy3NjLI8VypBjlHIgcxj2UdafZ+OC8u55WZLeFWC6juPbTz7lLZXr3qxyO7sNESALy8fDereOWt5fcIZYrZ0kuGUTCPp4+6pvM26T7JvK+jIcBtFaW4uVbFrGwXU39wLc/hvVF42iW8uWZmh1BoAfHOw9lOrngUx4XPDa4RJJUyXOkaVB2HjREHAJ+IXFnbQpGyQZEhZ1I5f3dBnaqc03ZuduzBlLq6k7Vss8hy0kh5n31q7G4fh1hIcO7/wDSDOcqx/2iuW/BnWS7jvHBks01pGD+J2pjY8Ljn4ZGjwtJ2MgIy3dD88GjlyJpL0bI9FNxNNJxN42gjlghiQ6nXct0x4+ymi8PiuRazTxYmiOsp4HzoM29zFxZbmQ4jVe073VuQA9gFHcKuWnmfWhDt3jluprnyN1o55PQLHbhuINc5OgPqC9NeMZ91BWlwnEZZ7e6V8u7aTjYsoyDTWOEpbTHIjKuW5cqruEa3i1x7alzkcjtSRnRlJk+AdrDYwC6kPayEoFXpvnNHz6LWUmdO+O6JAMlfOhrCSKW4tZe4zxxnWR0c86Oiufvdw6svcBIpcruRnqQnvIXhu+1ncFAo3J3NWm4ZFyM6QN/dyxUeJWP3q6gtlUpAzcx0oVoJYIZbV2y6OQrZ3IHI0ErSbGavbGHC0W1up9iFI1E89THc1MOtyxlLY3zuBtVFrKsVmqk6umrxqSgkaQN2OxFC92I9sF4+TdwJaKhaJ1Uso2yNWQfI0Jw028cUdukT6U/CXycez6UxkSaUwRRRrgEqxb1uKOe2FvFEioCFbJbxNU5VHiNy+tGY45ZG/jhdpGTS2G7vQ9Kt4cYURrYs/N373d0rTC6lQFpHbQATgNy1UHDbSSRPLLvMYtGPKqKVwpjr+tCyZIcRCCLAjuNETA+KnP6VobG0jSO2iZVeOFMZxkZFI0hSI6JThFOvA5aulWcNu5IIZUbZckDHjTSbcdBa0S48bl2iRO8k8hVtO+3T+adoxW5mR+Zwo1dDjn7aACvOkbrswPSuszNdypMPxyKVPLapOVxSAugjiFkbmKMI+TG2pQP0oa/ttNu9tKSEmAYHxxTjUBKoYdP4oW+EizHLI0JXCMeaP5UsJOzR7EcFiLIvOGZnnGSM7KM0tilllaRZUjAmLGLP9pXly8eXvrQyxFkdN8FFj28KBS0dkhUorGJiuojGV8fyq8Z+2Ope2NobO4iuUkupgS+CnRccl9eVen4fZ3g7aWVfvKgoRpdcb8/byqy9vJG4nFEI0dpE/pHT3YivJceVNOHXEs1oDerEZlJfWqjGPP1tXNycPsB62LA0E8kK3MOmFT2UeD0A6Y8TTBownCbMRIIoix3lbY78v3ogpZXgF0XjtLxfxNjIbAwCG5r7RVa8MF0AwkQup1Kx3GfH9qWclpmk+iqyP3aaWKXLAgFUXB7x88jFFNNbQA627KKEFm7R8nOegx78edLjbXSXLSrIjK577KPw45EeVWRQi64h94nVJo0XA1f6h1JpU0KFssd1I8zIs6oMxo8jKvswozXpLCKQrN2AhlZQHjExAHs86IhiCxxPGVZW56KreIx4LynCjVn/V5ftQU5VxDyfQRPbrc2KLHOy6MAAf3DqprKcQc3PGbopbRvJNIQqMrHQDnp1ArRTS3EFzAuzRyKqBjyxjFHQlDqlSNe11aQSNx76MMjggp0AWMD2zRo+vScY193HdHh7KW8Rlif7SiLs3imG4ccn8Qae3TSNeQaZBojByAOvrpXXt0u/wCqFDSRDKkb4H6ilU6bZNdlUsMVxJHLLGNUWyY8Tz2/SlK2Ub8WmR5mCyyrcIoY4BX9DTuK37aNdPjuT4+dTMcPDtQd1/Fu43NaM5JGQn4ybeN0nmQMVbbI31fWirO5t7pJYJUVos6tSctXX3VbN/l/fTDXEpG2fwr13FdDxWNs9w+jsgn9p6/SqU+KXsdIy/HJbuS7u2tLaOKBoQpkJxq8qVR2rL9m5WeMv2ZLbbe01rLxmm4YsscfaGVsEdV86NuPs8j/AGbigeZxG28oRd5N86f2q8MnSY6bZ8ht7pLO/Wa0Ltp3BYY38q1kF797iTiKQBpWXvaea+dRvfs/wuHiBneeSGNZVSKEjIIxzHlmtHwvhlpw+4jlV5FhmGjRKBnJ65/KujLkhotJ6swV7cQ57G1vJI5nky4K7s3/AKhWqhke74bBEtz2lxFtufxYpLf/AGWmj43MLY6gHJyw5NmnfDeFtw+1W4vJB2kSkggZ260maceK4sSbVWmXS8LtL6wmjdyrMuGZdgtJOHcMfh/FLdJSH0KdM6brp8M1onKtZydmyvDOuSDyIrnDbXRbG3nMc0ZBCFWyEHhUFklTVkuTpg6cARLqa+uArrKMuM4r3HOFNJecOudAWCIYCkEYH1pyz9pGIWTMSYINee5+8XEiDv4bCjVnYVP5Zdipy9iG94b2yx61btA2pUMh5Z6mucW4GnEuJxySLEnZhRqeTAbyxTmdFV4+7qZtmGndaz00lxbXzx3KuElk/phznT5j6U+Kck7Q8bsLkidrSS3V2TUNLGEDBHlmkEX3Sbjqdu7MV7qllyF251poNdvCXm04UZ8j+1THB7bi9mZraKGK4yGlULgSfSnxSq0GH4JbtZbe0lNrK8rdsveHdLezyo97C84n2TxqZEYDtQTnHxpoll2hjQ6cR74xsp8KnLrsrRooGIdh+Ll8Kk8gjYotuHm3t5YEkkXB23o6wFtEZrgr/W/ArNyx5VTHcuCtq5y+nnUbeJ5brQ1rup1Bs4HwoW3diK22U8YtdU8LtJL3cAJHzO9PbUYgRRpHj5GglkSW4ljeMkjyohzFHbqO27ORzk5Gdq1XURoxvRRNw2Rop/xSaiCpAwxqb8NIkjUSan06nXy8KZtdwx8PScamxjJrsM1v+OLAMg5itJtdg77FR4TbwWZa7XWzONESnAWho7T7rJHHZWpAZhkj+0++nS2SjUzS6mZs5oq3EcEuj8Tv8hQjN2N7KBbiCY5fU7AbeFWPODF2QXLk869xgJbov3dtUp3Y0NaOrASY3xzpZP2hJ6kWX5d7H+pCGRmCg43BxQKWsVvZG3TuhQC4Ubt4UWjPJIw1PpzyztVscCzzHcspAJONh4VlJ9B5AXD+Hxx8NvLoxF+6QQ2NfLwoHh0CXUEdxb26RjJYIXIBbxNPJYmgVzGWLHPI1G2jitoANiW5notW+VNGc01SM/f2sksvaMSOyP4PGqLVkhZH33bPPmKb3sYW6ZmyQRnFLTbtOQQhGltsULtErvQdM+XwoyW51O5t+2t4w/dC1YNMMiF8aevtq8lJu+RlE8Kj0boXx2ENnDGyyquSdh/dRESCN8889cUuubeSa/WXOY15eVGRtMjMBvv7KZu0M6L7iMsEYDBXLZ60qsLR7y6mDM39Ru6Dz/amPaSAjP4T16V77yIVYRhdfjjpQTpUNFr2SbhCWUZZ3ByO6oGwoDTnQ6Dc1ezieHtJXZnB8a4W/pR9N+Q55+tE0qfRVJK1tiUoW0+G1Me1F1ahgNMfP2eNDhe2hK6dhzGM0M5ZY5rdDzwMU0XoVbFrMhDa0MgVuY3oG84w0VxKqRgKi6QeppnJEljbqus6jvvSsRmcSyFVK884q8KKqjqk39tIyRjtVXZRzJqpUaJbeGRcOBnA5edUW97NFI/cCI3IjrTO3m/8xumSw5n603FrQUqGPC3S6DxKNBA/E3X141b2SF01fiVufjVMSNawws+7vnJArzXHaszDZUGyiueSt6Fe7oukJa6168Z2Cj18qq4hCZ40CYwOYpdeXkaSoruysTkeNXx3jSsqqcjPWjxemCn2HzW8sSx63LFUAHjmgxHO0KQqh1aj/UPjRn3xPvEascnlkURdXCOq6cdwZPs+lMtDJ0CytPbI9zLICGwqALkKCPH9aIt5DaWKO0RWT8O25omVFjggRGCA7YxkeyrFtw0AjcglVwrD8JH0rn58uwyqiktG7oYdIVjyQHl66UU8afdlETEMo58vdQhvBGrQwKgZSFYsd8/WmKzj7opU6pG5kDmfXShPoWXRK31nQrJp01TMGRnJRVDHmo5+P8VZBdpqC5wcb59cq5dzFlYqcjrSrsmSwiwxx2wVQRkmr42L2b9ogK+J+R/elcUpkUZ3A6jYrUpL6OG7WGNy8WMYxnf10pqvoo9hUzdtFAiyaLmE5wp6/WqredxdNGzEFenQ1CeNtpOg7wNdhmW7UsCQw5/ShWgOSovlkS4DOhBZDhhnf3/WrIS8c8cjvpZ10lV6H9DS9IpPvDOjYwd1xRodSw2wxHSgkCOmT/zB42W2iOV1ZAxyNWXM4gKytH2hU5A5j+KEhgSK9ebOVO+fCrJZo5O6xYjwGx/mmemmPLTQNbStfXAQhBLLJ3lzinF7w+ztmEOdWn8QffOfEfpSPhNraWfHjfszSSf25PdB9lGy3VxPfyyXbrHGT3Ex06b1dSio/wClV1Y4nS3htUljRCVUd1F2x448KiL9JDFGzBQp1Pq5Mvh+9JrRpf8AMyUeRueR0FRtOIGaNUWEswkKuTzG/OhuuSMlYZNaQ3jTPJCrx6soCPlQccQ4gjwrjsY2xpK9R4U2FzKkTxAIEK4Vhvt7KDsw8QZUCgn8XSouVgb1oplRUOp3GMbseZNKpbgyyBIWyX6SDb+ac3WlQTsWJ/CR6+FIeJXFx99s4LW2xCBnWnT9qbFsSNWd0PJKIZZi8mNONOn4UdZWP3G3l7hACbDmTXrmKTQr9mcrjvdcVYeJyEIjA5558qNuzdsOtLSN7fSsx1PuySc80MLZOHXStGqLjIIPMUxtoI5IVdco4ztnOasmZXws2l26ORvQcgv/AEWs8Szo3aA/6hVq2NvPcJ20Xao3JsZ059c6En4aXkLo5A8KJtQ6MuhyMHlSKVbFUq2KLnhtzbcdktY0L2xXuZ338PbR1vAOH3aR6jkrhschTlbcvOJe0wcY3oGW2YzSO76gTzqjnqxpNVaKuyT73/TbIOWIFCLbPfcRdWOmCMj30RA0cF53QcedWzQf1HdXILbbfOlUkKqSFfErW1SZbu2OoY73jVf31UXUjgK2+aK7AQuyatQfmT0FDz8Mjmz3SoXlvVdMfTRaEkEqyJgbfGiprcyKXIDE/nUojClusf8Ad416Wd+z7GJBuOdRv7Eq32Dw4NhLCzDqPZQsMsUSJEshLA4JxXbaOWNn6b71XdRJJE6QH+qarfpjLvYdHdp2/ZhicdaYpcxQ2cmhQZpf7uvlWZtLG5cq8h0sNs0Y8mUMTDONt6F8XoTJS6JMZg+51IRRVu4VDsNuhpe8sgXfOF386KtN41YkkkUr6IP9C8oY9ge91q6JmihRV3xnSBQ6qwOdsc6uD5XSaQaMmRFxthzn2UPNqkVlzsfjV0sfcyp3/WhoFLIeZpl+ga3aBjqSRTIcAdQKuiukVcFSE8qKSJRqZhnO/soT7uzyldwPCnuzXXR2Zllj1YKoor0F3FhYxyPnVpTEJjfJz0x1oJbSODLL7s0B3+h3ZxtpZTgA8hyNWyShI27v9vWqYdSx+zxqqWbXsc+JpBUyUeG77HGKoZVIZs/izyqxyDEVANCJqR9ByRTDIJs7cPNpLZHhU7myZySjBVUVXHL2RzjDnoTVk1yGVsNvzreysaKrNCJezZj5g8/5qEuhJyRv02ob72IpMEnON6lKwMZKnvGmcdizohxKCO6ttWMkchQMNvosxBJzY5wdqsgnZJir509M0VcQJcYl3zy25VRNrTNDTqQou7NnmiihxgcwalA9wLgRGJdIGOWaNjiaMag3dUda8GeNS7/3HO53+NO5+joc4rRK5mMiRRkYVPXo1Vft2VqXRcsTv7audtSB8bctqlJCulVIBGM5xtSJkm09gKWqyxdvPG2sKSM+vlUIhJHbdsU3YcsdKZysjKI8Dl8vXWo3MqiyKqCfZsabnejRl6Zn76VwRpPeGM0fb3KtB2bvlyMevOl0dzCyMpI1Z68q9DIiM8sn/pUVVR1RZws+xt/h3xB0Gqe0JI2y7bf9tXv9hOJBEUXFqdByCZGz/wDbXq9XJxRP0B3X+HPEndXW5tFI7uA7Af8A21R/+nHGYZQYr200nYhpH5D/ANter1MkqF9BY/w+4m8Qf7zaAjc99t/+2oxfYPiwOlrmzI3Ozt/xr1epaQjRdH/h9xJcr94s8NkHvtz/APjyoC9/wy4myARXNmjg5La33/7a9XqeCVjxDU/w/wCKyRKGu7UbDkzf8a5D/hzxO0Pdu7RgSeZb/jXq9QpUZrRYPsLxVTqW4s9x1dv+NSH2D4mxaR7m1LDGMM3/ABr1epFFCxLU+wnELe2kIntSzNtl2wP+35Unb/D/AI/KXH3ywVCCMB3/AONer1WaVIt7DrP7CcSiu0JntCjKMr2jH/8AGmcv2Hvi347MgcgWb/jXq9SOKCweH7BcQizJHNaqxOk/1XP/AOPKuv8AYS/kQES2iFTk6Wbf/tr1erUTXZ2T7E8RERVZrXI3BLt/xqNt9gL+NS73FsxYY2Zv+Ner1GEI30OipPsPxM3G81noIJ0h26f+2p3H2Cvy2pJrQYOd3b/jXq9U2lyFl2dX7FcUNtgz2e+34m/41BP8PL8umue0Oo/6m2/7a9XqelZktlyfYjiMUjMs1rg741t0/wDbXT9juJknVNaHB/1t/wAa9XqSUVYr7OSfYviUg09raDbH42/41yL7E8Tjz/XtDjc/1G3/AO2vV6mUI/gaCv8AwfxIL3ZrUbZ/G3/Gg5vsVxYggXFmMn/W3/GvV6hSAwL/AMC8XEykXNlj/wBbZ/8Atq+L7C8UadtU9mVxn8bZ/wDtr1eqihGuhktFV99geKlCYriyVg2ASzcv/jVC/wCH/GSgAurLcb5kc/8A416vUIxVDeiT/YLjKlCtxY9Ocj+/+2pv9huLMCPvFn/82/47V6vUeEfwk+yEH+HvF0lJNzZH/wB7/wDGrJf8Ob8yKyzWYzz77f8AGvV6s0qB6Lm+wnFEQgXFnkcjrb/jQh/w+4oW1febPOf9bf8AGvV6kSQrRxv8POKOjIbiyyOR1N/xqUH2A4qiAfebPHP8bf8AGvV6i0qEpBp+w3FFUZuLM5599v8AjVY+wvFRIf8AzFnz/wBbf8a9XqZQj+GomfsNxQrjt7Pf/e3/ABqofYXii5Ans8kAk62/416vUqig0WD7C8UA/wCvZ8yPxt/xqafYXiPPtrTfY99j/wDjXq9W4oVJFU/2C4owGm4sx7Xb/jQr/wCH3FSpH3izx/8A9H/416vUUkNRbF9geLCMI1xZHp+N/wDjUf8AwDxMuCZ7P/5t/wAa9XqDigtKyw/YDiICgTWeP/W3L/41W3+HnE1fP3izzno7D/8AGvV6iooKRV/+nXFnIIubIb4/G/8AxquT/DviuQBcWWN+bN/xr1eo0iiRVP8A4ZcWOrTc2IO2+t/+NWW/+G/FwpV7mxODgYd+v/tr1ep2kZnJP8M+KByy3FiCOffffH/tro/w74yMZubE4wf+o/8Axr1epWlQDk/+HPFW5XNkNwT3m3/7ajL/AIacVZMfebHbxkf/AI16vVq0H0dT/DjiyRKBPYf/ADf/AI11v8POMDc3Fie7n/qPy/8Ajzr1eo0hfQOP8NeMtK+q54fnfcO//Ghk/wAMuPa9Bu+HkEY/6j/8K9XqdJWUXQCP8HeMGVpRd8PBByMSOP8A8Ksj/wAJuNIjl7nhzYOQe0fP/wBler1dD6K3o//Z\n",
+            "text/plain": [
+              "<IPython.core.display.Image object>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 2
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Building Clip.cpp repo from source (not required)"
+      ],
+      "metadata": {
+        "id": "D3MQHKeixw4b"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!git clone --recurse-submodules https://github.com/monatis/clip.cpp.git"
+      ],
+      "metadata": {
+        "id": "sZ9i_hR9YzD7",
+        "outputId": "cca7e28b-2ff2-4d2a-949c-a189eae5bfa1",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into 'clip.cpp'...\n",
+            "remote: Enumerating objects: 610, done.\u001b[K\n",
+            "remote: Counting objects: 100% (117/117), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (73/73), done.\u001b[K\n",
+            "remote: Total 610 (delta 58), reused 65 (delta 42), pack-reused 493\u001b[K\n",
+            "Receiving objects: 100% (610/610), 345.21 KiB | 11.51 MiB/s, done.\n",
+            "Resolving deltas: 100% (346/346), done.\n",
+            "Submodule 'ggml' (https://github.com/ggerganov/ggml.git) registered for path 'ggml'\n",
+            "Cloning into '/content/clip.cpp/ggml'...\n",
+            "remote: Enumerating objects: 3426, done.        \n",
+            "remote: Counting objects: 100% (1336/1336), done.        \n",
+            "remote: Compressing objects: 100% (187/187), done.        \n",
+            "remote: Total 3426 (delta 1198), reused 1212 (delta 1141), pack-reused 2090        \n",
+            "Receiving objects: 100% (3426/3426), 5.12 MiB | 26.76 MiB/s, done.\n",
+            "Resolving deltas: 100% (2292/2292), done.\n",
+            "Submodule path 'ggml': checked out 'dd1d575956e54c5bdc07632f25506b3b1884dbd2'\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%cd clip.cpp\n",
+        "!mkdir build\n",
+        "%cd build"
+      ],
+      "metadata": {
+        "id": "dOUvI0VCh9Da",
+        "outputId": "d6fc6481-cfb4-4e89-8ff3-48bef0f8f147",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "/content/clip.cpp\n",
+            "/content/clip.cpp/build\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!cmake -DCLIP_NATIVE=ON -DCLIP_BUILD_IMAGE_SEARCH=ON ..\n",
+        "!make"
+      ],
+      "metadata": {
+        "id": "1-I40r-BYzA9",
+        "outputId": "6cb79e08-77ea-470c-9f87-4d44d714287e",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "-- CMAKE_SYSTEM_PROCESSOR: x86_64\n",
+            "-- x86 detected\n",
+            "\u001b[0mCMake Deprecation Warning at ggml/CMakeLists.txt:1 (cmake_minimum_required):\n",
+            "  Compatibility with CMake < 3.5 will be removed from a future version of\n",
+            "  CMake.\n",
+            "\n",
+            "  Update the VERSION argument <min> value or use a ...<max> suffix to tell\n",
+            "  CMake that the project does not need compatibility with older versions.\n",
+            "\n",
+            "\u001b[0m\n",
+            "-- CMAKE_SYSTEM_PROCESSOR: x86_64\n",
+            "-- x86 detected\n",
+            "-- Linux detected\n",
+            "\u001b[0mCMake Deprecation Warning at build/_deps/usearch-src/CMakeLists.txt:3 (cmake_minimum_required):\n",
+            "  Compatibility with CMake < 3.5 will be removed from a future version of\n",
+            "  CMake.\n",
+            "\n",
+            "  Update the VERSION argument <min> value or use a ...<max> suffix to tell\n",
+            "  CMake that the project does not need compatibility with older versions.\n",
+            "\n",
+            "\u001b[0m\n",
+            "-- Configuring done (0.2s)\n",
+            "-- Generating done (0.0s)\n",
+            "-- Build files have been written to: /content/clip.cpp/build\n",
+            "[ 14%] Built target ggml\n",
+            "[ 23%] Built target clip\n",
+            "[ 33%] Built target quantize\n",
+            "[ 38%] \u001b[32mBuilding CXX object examples/CMakeFiles/common-clip.dir/common-clip.cpp.o\u001b[0m\n",
+            "[ 42%] \u001b[32m\u001b[1mLinking CXX static library libcommon-clip.a\u001b[0m\n",
+            "[ 42%] Built target common-clip\n",
+            "[ 47%] \u001b[32mBuilding CXX object examples/CMakeFiles/main.dir/main.cpp.o\u001b[0m\n",
+            "[ 52%] \u001b[32m\u001b[1mLinking CXX executable ../bin/main\u001b[0m\n",
+            "[ 52%] Built target main\n",
+            "[ 57%] \u001b[32mBuilding CXX object examples/CMakeFiles/zsl.dir/zsl.cpp.o\u001b[0m\n",
+            "[ 61%] \u001b[32m\u001b[1mLinking CXX executable ../bin/zsl\u001b[0m\n",
+            "[ 61%] Built target zsl\n",
+            "[ 66%] \u001b[32mBuilding C object examples/CMakeFiles/main_c.dir/main.c.o\u001b[0m\n",
+            "[ 71%] \u001b[32m\u001b[1mLinking CXX executable ../bin/main_c\u001b[0m\n",
+            "[ 71%] Built target main_c\n",
+            "[ 76%] \u001b[32mBuilding CXX object examples/image-search/CMakeFiles/image-search-build.dir/build.cpp.o\u001b[0m\n",
+            "\u001b[01m\u001b[K/content/clip.cpp/examples/image-search/build.cpp:\u001b[m\u001b[K In function ‘\u001b[01m\u001b[Kint main(int, char**)\u001b[m\u001b[K’:\n",
+            "\u001b[01m\u001b[K/content/clip.cpp/examples/image-search/build.cpp:97:39:\u001b[m\u001b[K \u001b[01;35m\u001b[Kwarning: \u001b[m\u001b[Kformat ‘\u001b[01m\u001b[K%d\u001b[m\u001b[K’ expects argument of type ‘\u001b[01m\u001b[Kint\u001b[m\u001b[K’, but argument 3 has type ‘\u001b[01m\u001b[Kstd::vector<std::__cxx11::basic_string<char> >::size_type\u001b[m\u001b[K’ {aka ‘\u001b[01m\u001b[Klong unsigned int\u001b[m\u001b[K’} [\u001b[01;35m\u001b[K\u001b]8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat=\u0007-Wformat=\u001b]8;;\u0007\u001b[m\u001b[K]\n",
+            "   97 |             printf(\"\\n%s: processing \u001b[01;35m\u001b[K%d\u001b[m\u001b[K files in '%s'\\n\", __func__, \u001b[32m\u001b[Kentry.second.size()\u001b[m\u001b[K, entry.first.c_str());\n",
+            "      |                                      \u001b[01;35m\u001b[K~^\u001b[m\u001b[K                             \u001b[32m\u001b[K~~~~~~~~~~~~~~~~~~~\u001b[m\u001b[K\n",
+            "      |                                       \u001b[01;35m\u001b[K|\u001b[m\u001b[K                                              \u001b[32m\u001b[K|\u001b[m\u001b[K\n",
+            "      |                                       \u001b[01;35m\u001b[Kint\u001b[m\u001b[K                                            \u001b[32m\u001b[Kstd::vector<std::__cxx11::basic_string<char> >::size_type {aka long unsigned int}\u001b[m\u001b[K\n",
+            "      |                                      \u001b[32m\u001b[K%ld\u001b[m\u001b[K\n",
+            "[ 80%] \u001b[32m\u001b[1mLinking CXX executable ../../bin/image-search-build\u001b[0m\n",
+            "[ 80%] Built target image-search-build\n",
+            "[ 85%] \u001b[32mBuilding CXX object examples/image-search/CMakeFiles/image-search.dir/search.cpp.o\u001b[0m\n",
+            "[ 90%] \u001b[32m\u001b[1mLinking CXX executable ../../bin/image-search\u001b[0m\n",
+            "[ 90%] Built target image-search\n",
+            "[ 95%] \u001b[32mBuilding CXX object tests/CMakeFiles/benchmark.dir/benchmark.cpp.o\u001b[0m\n",
+            "\u001b[01m\u001b[K/content/clip.cpp/tests/benchmark.cpp:\u001b[m\u001b[K In function ‘\u001b[01m\u001b[Kint main(int, char**)\u001b[m\u001b[K’:\n",
+            "\u001b[01m\u001b[K/content/clip.cpp/tests/benchmark.cpp:38:73:\u001b[m\u001b[K \u001b[01;35m\u001b[Kwarning: \u001b[m\u001b[Kformat ‘\u001b[01m\u001b[K%d\u001b[m\u001b[K’ expects argument of type ‘\u001b[01m\u001b[Kint\u001b[m\u001b[K’, but argument 3 has type ‘\u001b[01m\u001b[Ksize_t\u001b[m\u001b[K’ {aka ‘\u001b[01m\u001b[Klong unsigned int\u001b[m\u001b[K’} [\u001b[01;35m\u001b[K\u001b]8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat=\u0007-Wformat=\u001b]8;;\u0007\u001b[m\u001b[K]\n",
+            "   38 |         printf(\"%s There must be at least 2 directories of images, but \u001b[01;35m\u001b[K%d\u001b[m\u001b[K found\\n\", __func__, \u001b[32m\u001b[Kn_labels\u001b[m\u001b[K);\n",
+            "      |                                                                        \u001b[01;35m\u001b[K~^\u001b[m\u001b[K                     \u001b[32m\u001b[K~~~~~~~~\u001b[m\u001b[K\n",
+            "      |                                                                         \u001b[01;35m\u001b[K|\u001b[m\u001b[K                     \u001b[32m\u001b[K|\u001b[m\u001b[K\n",
+            "      |                                                                         \u001b[01;35m\u001b[Kint\u001b[m\u001b[K                   \u001b[32m\u001b[Ksize_t {aka long unsigned int}\u001b[m\u001b[K\n",
+            "      |                                                                        \u001b[32m\u001b[K%ld\u001b[m\u001b[K\n",
+            "\u001b[01m\u001b[K/content/clip.cpp/tests/benchmark.cpp:156:23:\u001b[m\u001b[K \u001b[01;35m\u001b[Kwarning: \u001b[m\u001b[Kformat ‘\u001b[01m\u001b[K%d\u001b[m\u001b[K’ expects argument of type ‘\u001b[01m\u001b[Kint\u001b[m\u001b[K’, but argument 3 has type ‘\u001b[01m\u001b[Ksize_t\u001b[m\u001b[K’ {aka ‘\u001b[01m\u001b[Klong unsigned int\u001b[m\u001b[K’} [\u001b[01;35m\u001b[K\u001b]8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat=\u0007-Wformat=\u001b]8;;\u0007\u001b[m\u001b[K]\n",
+            "  156 |     fprintf(fout, \"- \u001b[01;35m\u001b[K%d\u001b[m\u001b[K texts encoded in %8.2f ms (%8.2f ms per text)\\n\", \u001b[32m\u001b[Kn_labels\u001b[m\u001b[K, total_text_duration,\n",
+            "      |                      \u001b[01;35m\u001b[K~^\u001b[m\u001b[K                                                   \u001b[32m\u001b[K~~~~~~~~\u001b[m\u001b[K\n",
+            "      |                       \u001b[01;35m\u001b[K|\u001b[m\u001b[K                                                   \u001b[32m\u001b[K|\u001b[m\u001b[K\n",
+            "      |                       \u001b[01;35m\u001b[Kint\u001b[m\u001b[K                                                 \u001b[32m\u001b[Ksize_t {aka long unsigned int}\u001b[m\u001b[K\n",
+            "      |                      \u001b[32m\u001b[K%ld\u001b[m\u001b[K\n",
+            "[100%] \u001b[32m\u001b[1mLinking CXX executable ../bin/benchmark\u001b[0m\n",
+            "[100%] Built target benchmark\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Usage\n",
+        "- first download a quantized ggml model or build it your self using the information provided in the repository\n",
+        "-  now grab `the model`, `the image`, and the `text` you download to compare, Here is the Usage commands :\n",
+        "\n",
+        "```bash\n",
+        "Usage: ./bin/main [options]                                                                                             \n",
+        "                                                                                                                        \n",
+        "Options:  -h, --help: Show this message and exit                                                                        \n",
+        "  -m <path>, --model <path>: path to model. Default: models/ggml-model-f16.bin                                          \n",
+        "  -t N, --threads N: Number of threads to use for inference. Default: 4                                                 \n",
+        "  --text <text>: Text to encode. At least one text should be specified                                                  \n",
+        "  --image <path>: Path to an image file. At least one image path should be specified                                    \n",
+        "  -v <level>, --verbose <level>: Control the level of verbosity. 0 = minimum, 2 = maximum. Default: 1                    \n",
+        "  ```"
+      ],
+      "metadata": {
+        "id": "h3VwlTRY2lD0"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# downloading pre-trained quantized GGML models from HF\n",
+        "!mkdir clip_models\n",
+        "!git clone https://huggingface.co/Green-Sky/ggml_laion_clip-vit-b-32-laion2b-s34b-b79k/ ./clip_models/"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "83U-xBVV4a4f",
+        "outputId": "c2cb3692-bc6a-4b1e-c620-9036a1b25aa9"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into './clip_models'...\n",
+            "remote: Enumerating objects: 32, done.\u001b[K\n",
+            "remote: Total 32 (delta 0), reused 0 (delta 0), pack-reused 32\u001b[K\n",
+            "Unpacking objects: 100% (32/32), 3.70 KiB | 631.00 KiB/s, done.\n",
+            "Filtering content: 100% (3/3), 469.74 MiB | 46.56 MiB/s, done.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!./bin/main \\\n",
+        " --model './clip_models/laion_clip-vit-b-32-laion2b-s34b-b79k.ggmlv0.q4_1.bin' \\\n",
+        " --image '/content/cat.jpg' \\\n",
+        " --text 'cat on a Turtle'"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "PXoULIhz2qJK",
+        "outputId": "3305089b-6754-4c29-9bb9-affd10d20f47"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "clip_model_load: loading model from './clip_models/laion_clip-vit-b-32-laion2b-s34b-b79k.ggmlv0.q4_1.bin' - please wait....................................................clip_model_load: model size =    93.92 MB / num tensors = 397\n",
+            "clip_model_load: model loaded\n",
+            "\n",
+            "main: Similarity score = 0.278\n",
+            "\n",
+            "\n",
+            "Timings\n",
+            "main: Model loaded in    72.49 ms\n",
+            "main: Image loaded in     1.96 ms\n",
+            "main: Similarity score calculated in   269.00 ms\n",
+            "main: Total time:   343.50 ms\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Using the Python Bindings"
+      ],
+      "metadata": {
+        "id": "kKGzNLDQyPfc"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -U clip_cpp"
+      ],
+      "metadata": {
+        "id": "QK9_j5SuYy3Q",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "46ff0edc-a498-4e46-bedc-9d25fe14a69f"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting clip_cpp\n",
+            "  Downloading clip_cpp-0.3.5-py3-none-any.whl (349 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m349.7/349.7 kB\u001b[0m \u001b[31m5.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: clip_cpp\n",
+            "Successfully installed clip_cpp-0.3.5\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### downloading pre-trained quantized GGML models from HF"
+      ],
+      "metadata": {
+        "id": "qKXPrZjWyllm"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%cd /content/\n",
+        "!git clone https://huggingface.co/Green-Sky/ggml_laion_clip-vit-b-32-laion2b-s34b-b79k/\n",
+        "!mv ./ggml_laion_clip-vit-b-32-laion2b-s34b-b79k clip_models/"
+      ],
+      "metadata": {
+        "id": "Q3Hqux91ZlDk",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "0bc40416-8ae7-42ed-b6a8-512fea262aa5"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "/content\n",
+            "Cloning into 'ggml_laion_clip-vit-b-32-laion2b-s34b-b79k'...\n",
+            "remote: Enumerating objects: 32, done.\u001b[K\n",
+            "remote: Counting objects: 100% (19/19), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (19/19), done.\u001b[K\n",
+            "remote: Total 32 (delta 8), reused 0 (delta 0), pack-reused 13\u001b[K\n",
+            "Unpacking objects: 100% (32/32), 3.95 KiB | 506.00 KiB/s, done.\n",
+            "Filtering content: 100% (3/3), 469.74 MiB | 41.28 MiB/s, done.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from clip_cpp import Clip\n",
+        "\n",
+        "#loading the ggml model to Clip\n",
+        "model = Clip(\n",
+        "    model_file='./clip_models/laion_clip-vit-b-32-laion2b-s34b-b79k.ggmlv0.q4_1.bin',\n",
+        "    verbosity=2,\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "dBL2G6A1nDUz"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "\n",
+        "text_2encode = 'cat on a Turtle'\n",
+        "\n",
+        "tokens = model.tokenize(text_2encode)\n",
+        "text_embed = model.encode_text(tokens)"
+      ],
+      "metadata": {
+        "id": "WHRejjjGo8qy"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "## load and extract embedings of an image from the disk\n",
+        "image_2encode = '/content/cat.jpg'\n",
+        "image_embed = model.load_preprocess_encode_image(image_2encode)"
+      ],
+      "metadata": {
+        "id": "RVc_e19aq1Ku"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "## perform similarity search between the image and the text\n",
+        "score = model.calculate_similarity(text_embed, image_embed)\n",
+        "\n",
+        "# Alternatively, you can just do:\n",
+        "# score = model.compare_text_and_image(text, image_path)\n",
+        "\n",
+        "print(f\"Similarity score: {score}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "P0m3XMv6Ygb2",
+        "outputId": "653d3624-3e58-42aa-b872-a9c363a6fb0a"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Similarity score: 0.2775198221206665\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "text = 'dog eats a banana' ## unreleavant text compare to the image to see the score\n",
+        "score = model.compare_text_and_image(text, image_2encode);\n",
+        "print(f\"Similarity score: {score}\") # should be lower than the prev score"
+      ],
+      "metadata": {
+        "id": "pV6m561DxVsr",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "c7367a3e-12f5-4790-a103-ad9303d04aa5"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Similarity score: 0.10214703530073166\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## More Real world Use-case example with fashion image dataset"
+      ],
+      "metadata": {
+        "id": "DJSf9d6xJOvP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -q -U datasets"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kipYEwmdZWNU",
+        "outputId": "bcdfbc8f-379c-4660-f336-3647d9aedc4e"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m519.6/519.6 kB\u001b[0m \u001b[31m5.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m115.3/115.3 kB\u001b[0m \u001b[31m5.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m194.1/194.1 kB\u001b[0m \u001b[31m7.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m134.8/134.8 kB\u001b[0m \u001b[31m7.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m294.8/294.8 kB\u001b[0m \u001b[31m10.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from datasets import load_dataset\n",
+        "\n",
+        "data = load_dataset(\n",
+        "    \"ashraq/fashion-product-images-small\",\n",
+        "    split=\"train\"\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 209,
+          "referenced_widgets": [
+            "4ae67bba152f4240adbe501402f70e8e",
+            "7c5d5c25159343e2ad0756ec6346bc6d",
+            "7525713bf9434a8e83ccdd1bc94792a8",
+            "746a421cfd89487585007264cc316536",
+            "8d4f2cea3f02404ea5aed908d6e7ac38",
+            "b1d89c5c59ab4c169ba53e5b01602590",
+            "ef1c0a8257434468bb70636ac049035a",
+            "023c6c4ed3b446188eeaaa8151649fd2",
+            "6e9e8d05043a4b1cb30af96f34ab2d97",
+            "1b763c56ae2d46829e53e18cbd6ae7ef",
+            "5abc9e4f2eb6438e86dd127f9f96d08a",
+            "eca90f32fc9248769e710913f60b9b7c",
+            "6d1630037e604e83b8b37b13221c0113",
+            "2701f0097b2e40f58d3d2933c40f5ad1",
+            "fc6e9db41ffa469d8c968afe968f8333",
+            "68711a15d3454c6da258d61210b6fff5",
+            "f5f4d0cc28d64341b290eef632dfd6c6",
+            "4a81afcd4c2e4b9e9973600c21a6a03f",
+            "fcd94e1dc1bb41e2a9e26e9eff76c540",
+            "d0596dc4deb247a8b3af85c619adec7d",
+            "6857472d8e4b4dd68278597963525e1a",
+            "61e755addc4c4fe6920be4081155c766",
+            "6632fa54917a4a66949ac64be2405eae",
+            "252bc9f78759418c91bcc7a162fed88f",
+            "74e10b36274d45adb9ddf63f10824b86",
+            "974691f61e5846efaa42e118cd87ff72",
+            "989e22e99798474089ed8c55d9adf74f",
+            "020b30456ac04d02b0d511a9780e0169",
+            "9b88d8521b964d829c0ff02e53983197",
+            "3088b25b28d843888b3ed4443a43cd4a",
+            "2b76a7691c33466a908d23d8c5698867",
+            "f9e253e85ff942b4b7025fa80bcd43c9",
+            "109cf29003f8412ba5d9ea731f95ec3f",
+            "a58c4bf3ff87443bb130154914fd6d30",
+            "d59eb2b6f7a34c828cb732a8ac86febf",
+            "8233eea0e1404d59960253f136c7c098",
+            "f8a61b8bab194518a303bd620c244186",
+            "f598bcca46204914b14767473fefd867",
+            "412e57470bae42609ff839adf0e2f802",
+            "41ad3ca4daa74aa494de4d4b56d166fb",
+            "2242e5ca5f5943efb9d6cc6158954c8e",
+            "f27f0685c73944b794af96df74fd36bc",
+            "13e4be26528b4d1dbb5f3a8be1458635",
+            "7486b22826a74aae85071f33f0fc3a17",
+            "1a4295168897427eb269166acf54b014",
+            "165cd045e8f144ecb7d0c3901964259e",
+            "1f5e7e234d544e5e8637b67f876d7397",
+            "be7fceea155642f5b983df24bdd7ca3f",
+            "c892d6a91ccd41b9b2a34831dd566555",
+            "6997b6fb2bac419d85adc36f415587ea",
+            "648fc8fc6c804aae9faf02f09a64e2b4",
+            "a1670f5b5fc3434985acbe1f5cb61f0e",
+            "8739d5ebc54a41529741cc43b91ade67",
+            "7607d0df712a45499051e8ab1e7a1cc3",
+            "c50b5960a4614bdd9ce3c940e3207a35",
+            "dfc716ebacef49e1aeb4de6a22303aa2",
+            "d0e7e6ae228e4eca92d1c29bd51e281d",
+            "00618ab3c8064ead9c5e36c36f15b9f5",
+            "4482e1cbf57c4a64886843cf0945ceac",
+            "9e8b1fba499b4333b460022371ec51cd",
+            "da665853f8144b7caa80a54034499bc9",
+            "58a9d43ad9654e39aa3a022b6c7bcfcf",
+            "ba3cab9e1105440299aaecf75b533468",
+            "1a8d331fc5944af788491ae42cc2631d",
+            "31dcc7dd63af4947a793f9adc4a43846",
+            "40bbfc78bd494552ba6f9a17ea1aa9bf"
+          ]
+        },
+        "id": "YIr29y9sZa38",
+        "outputId": "f0552157-bd24-437c-f5d6-ae49acd5165b"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Downloading readme:   0%|          | 0.00/867 [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "4ae67bba152f4240adbe501402f70e8e"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Downloading data files:   0%|          | 0/1 [00:00<?, ?it/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "eca90f32fc9248769e710913f60b9b7c"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Downloading data:   0%|          | 0.00/136M [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "6632fa54917a4a66949ac64be2405eae"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Downloading data:   0%|          | 0.00/135M [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "a58c4bf3ff87443bb130154914fd6d30"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Extracting data files:   0%|          | 0/1 [00:00<?, ?it/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "1a4295168897427eb269166acf54b014"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Generating train split:   0%|          | 0/44072 [00:00<?, ? examples/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "dfc716ebacef49e1aeb4de6a22303aa2"
+            }
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "images = data[\"image\"]\n",
+        "\n",
+        "data = data.remove_columns(\"image\")\n",
+        "product_frame = data.to_pandas()"
+      ],
+      "metadata": {
+        "id": "Qns73g2CZh6w"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "product_data = product_frame.reset_index(drop=True).to_dict(orient='index') # remove pandas default index and convert it to dict"
+      ],
+      "metadata": {
+        "id": "stF7ehVFZm0X"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "#create an image dirctory to save the images to loaded with clip model\n",
+        "## ⚠️⚠️ currently clip Model it only Support loading images from disk not as PIL or numpy array for example\n",
+        "images_dir = Path('images')\n",
+        "images_dir.mkdir(exist_ok=True)"
+      ],
+      "metadata": {
+        "id": "lUafnezDauhy"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "image_files = []\n",
+        "\n",
+        "##⚠️ it take about ~30 min to embed 5000 images of fashion dataset\n",
+        "## in the next cell you can download already 5000 extracted embeding inseated of waiting 😊\n",
+        "for idx, im in enumerate(images[:5000]):\n",
+        "    file_n = f'images/image_{idx}.jpeg'\n",
+        "    im.save(file_n, \"JPEG\")\n",
+        "    image_files.append(file_n)"
+      ],
+      "metadata": {
+        "id": "mHvrsGWKZ4Y5"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from tqdm import tqdm\n",
+        "import numpy as np\n",
+        "\n",
+        "##⚠️it take about ~30 min to embed 5000 images of fashion dataset\n",
+        "# image_embeddings = [model.load_preprocess_encode_image(im) for im in tqdm(image_files)]\n",
+        "# image_embeddings = np.array(image_embeddings, dtype=np.float16)\n",
+        "\n",
+        "# if you had already embedding saved as npy you can load it like this:\n",
+        "# image_embeddings = np.load('data.npy')\n",
+        "\n",
+        "## 💡💡download & load already emded 5000 images from fashion dataset\n",
+        "## if you had already embedding saved as npy you can load it like this:\n",
+        "!wget \"https://drive.google.com/uc?export=download&id=1kiewhrTHokuR7uuIYscOd3tGRVISXETF&confirm=yes\" -O ./data.npy\n",
+        "image_embeddings = np.load('data.npy')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "UwJ3ox4ab5R7",
+        "outputId": "4c75e599-e81b-4a2b-8646-d8385b2f53fb"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--2023-09-13 20:37:26--  https://drive.google.com/uc?export=download&id=1kiewhrTHokuR7uuIYscOd3tGRVISXETF&confirm=yes\n",
+            "Resolving drive.google.com (drive.google.com)... 142.251.2.102, 142.251.2.139, 142.251.2.113, ...\n",
+            "Connecting to drive.google.com (drive.google.com)|142.251.2.102|:443... connected.\n",
+            "HTTP request sent, awaiting response... 303 See Other\n",
+            "Location: https://doc-04-4s-docs.googleusercontent.com/docs/securesc/ha0ro937gcuc7l7deffksulhg5h7mbp1/apveta40b3dk2j1ontg5jj81f158mk65/1694637375000/07515041808419291303/*/1kiewhrTHokuR7uuIYscOd3tGRVISXETF?e=download&uuid=02003cac-cc45-4843-91dd-51c10f91b89c [following]\n",
+            "Warning: wildcards not supported in HTTP.\n",
+            "--2023-09-13 20:37:26--  https://doc-04-4s-docs.googleusercontent.com/docs/securesc/ha0ro937gcuc7l7deffksulhg5h7mbp1/apveta40b3dk2j1ontg5jj81f158mk65/1694637375000/07515041808419291303/*/1kiewhrTHokuR7uuIYscOd3tGRVISXETF?e=download&uuid=02003cac-cc45-4843-91dd-51c10f91b89c\n",
+            "Resolving doc-04-4s-docs.googleusercontent.com (doc-04-4s-docs.googleusercontent.com)... 142.251.2.132, 2607:f8b0:4023:c0d::84\n",
+            "Connecting to doc-04-4s-docs.googleusercontent.com (doc-04-4s-docs.googleusercontent.com)|142.251.2.132|:443... connected.\n",
+            "HTTP request sent, awaiting response... 200 OK\n",
+            "Length: 5120128 (4.9M) [application/octet-stream]\n",
+            "Saving to: ‘./data.npy’\n",
+            "\n",
+            "./data.npy          100%[===================>]   4.88M  22.9MB/s    in 0.2s    \n",
+            "\n",
+            "2023-09-13 20:37:27 (22.9 MB/s) - ‘./data.npy’ saved [5120128/5120128]\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### saving the imbeddings to disk for faster retrieval"
+      ],
+      "metadata": {
+        "id": "GQCPpfSmF-y8"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "np.save('data.npy', image_embeddings)"
+      ],
+      "metadata": {
+        "id": "HpUc39sN9DHw"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## USearch Vector Store for faster lookup"
+      ],
+      "metadata": {
+        "id": "XZKYIKr-F-OF"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -q -U usearch"
+      ],
+      "metadata": {
+        "id": "kGgOvX5K7Lpv"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import numpy as np\n",
+        "from usearch.index import Index"
+      ],
+      "metadata": {
+        "id": "vy_zR_117RUg"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "image_embeddings.shape # ndim is -> 512"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "OkyrldQoRCg_",
+        "outputId": "abedc107-1ed3-492e-d285-baac198c16ab"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(5000, 512)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 62
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "index = Index(\n",
+        "    ndim=512, # Define the number of dimensions in input vectors\n",
+        "    metric='l2sq', # Choose 'cos', 'l2sq', 'haversine' or other metric, default = 'ip'\n",
+        "    dtype='f16', # Quantize to 'f16' or 'i8' if needed, default = 'f32'\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "cRNqCxYa7RQo"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "## each vector should have corrsponding key hence range(...)\n",
+        "index.add(range(len(image_embeddings)), image_embeddings)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "U3KFXC3Y9zuv",
+        "outputId": "ac007afa-9fb4-4473-a738-21438cdf7465"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "array([   0,    1,    2, ..., 4997, 4998, 4999], dtype=uint64)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 64
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def search_images_vecstore(query: str, index: Index) -> list:\n",
+        "    \"\"\"\n",
+        "    extract query embeddings and run it against the usearch vector store\n",
+        "    return list of keys, distance (keys is the index of the crosponding image)\n",
+        "    \"\"\"\n",
+        "    tokens = model.tokenize(query)\n",
+        "    query_embedded = np.array(model.encode_text(tokens))\n",
+        "\n",
+        "    matches = index.search(query_embedded, count=10)\n",
+        "    return matches.to_list()\n"
+      ],
+      "metadata": {
+        "id": "zvAi4CAg7RNx"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from IPython.display import display\n",
+        "\n",
+        "\n",
+        "results = search_images_vecstore('blue bag', index)\n",
+        "\n",
+        "for (img_idx, dist) in results:\n",
+        "    display(images[img_idx])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 817
+        },
+        "id": "4ga4d4LSBGB2",
+        "outputId": "0331998d-4eaa-4c0d-c4ff-d9b4470d7d75"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXtUlEQVR4nO16eYyd13Xf75x7v+0ts3KGy5AUd3HTZkqWrN22ZEt2G8Wt7TpOHBSJ26BxW6BLUBhFgSBAGwRJi7ZogcANnBpd4LhF4Ra1jMSyHDuVtdkWKVIUF5EUOZzhcPhm5s285Vvuvef0jzckh5TkOmmgxIDOH+99775v+d3znfs7555zSFXx0yb8Fw3gzyLvgX635D3Q75a8B/rdkvdAv1vyHuh3S94D/W7Je6DfLXkP9Lslq6B/uvYvq6CJ6C8Wx59KfprN46dLrKpesw0RGfy8NvKX02zobZegqg7G107gL48wIJBViBenL3/tq08fO3yOiJiYmCEqIkFF9epM/t80I+84otc+cNN9rulu8CUiXsI7cRqpKAghBGPM73/pf3776y+eXHjxk5/98FNPfKYZjUztGLvx2QxAEFSVlAEoiSqRQgmkAESVAGG2YFVVCqRGAWaBEhQMDT/m7ZEiULAcXZ/MW862SqCrthsja+fL/Wi2r2d/77/85isvnfvbf/Mf3nv/AULUaNTSzBqyaZoyDAhYvRPjhluaNao1IMBe/4euHenVy68dXD8WC/P97x0+/+bcRz/+wNh4M6g3dO0uAGAJgCgxQxFWzOzSqX/wxS9+/lO/eKU9/cSnf+bXfu2fjIwMLRULQ82xZq2ZRHFWT4eyoaxRS7K40WhYjsoq7+c5k4IV0I0bN0+sG10/uWHT1HpjqKjKyKRZlhARyECDtVaVajbuFTkRG8MA9fLckh1q1gXS7Ze/9S++9K2jv/9v6Lf/1i/8XYZRBXCdMOzgFRPMhfMLx189Eix/9OHHwDIxtuVTH/rVf/vav7amlpIWK77bbmUm6VTLCdVE1GuIjY1M5L0QEbMNWqmqc5WKkEGjPuTVO583szFlOFfW42EvBVmbcGoQixYA9yUPUhnhLGpQROpdHNVCqY898gnTnP/jF75x+96HR0frBL5GdFYBiFHWmdfe/FHPx/d+ZMvkOgkMhjXUq7rz7YtV8KxsFCvacSwwSiA2tlFrEBlAIAQ2LkDh0iyznBhEqhqTmKThxSeSxhQFVxHBlCbYKgQPZnWVhoINw2hRdvNOwZGte7/c7v3OF/5dqz/zqc//7K88+Zu/8Vv/mMwa8wDgGRHpD8cmvjW65efu2wwTuyAJsfooMjb3BQVRRCBjbZKKsrKIxCYhz8oI6jkQs0gIQVXgPWCMJyJVFUNGENATVVU1ZD31NCA1mQ95xNYF550zEsVUJyJyQQ0V2qs3bTa6xy9vPP/a4uGXj7/vvv3XNU0QowDxV2cKFP2Rsq2qRgXAQmtZEVuVLE4jm1m2IuKCMxSZOBLxToKIc8GRUmZTQmSYYkotWRFRdQFqhCR4S8xk2bDhLEhJpAAIEdRADRN57xLrgpSeTBTKqvKvnjz5xOMf2b1n22RzLMsyrKFFBsBgCCTv05FvjZ45ilUy4fbCRSmXVZzzhYTS+SJ4Z4lN8N51VUrn++pKVhF1Hp5VVCmIG5j4wDGRMrERGAreh1JDHsFGhIjYaBSzqdt6IxpOuOahqmSZXagWu7NvnD67eOVio+F9xIQb2QNgR4gIH8rmr/Tbr79+TgnGqANOjU21mxNNG1SoUFFxliwFIo69iuWaMZGGkpmNVKUPDv0ap7m4yvdFYCJbSaAk8WVBiAGBBqPKTAQl9FRMLVAFGBUnZRTIqfOVCIKg3LZzd78/f2BzFBa68A5rYgoLhVEPsp+cGvqToebhc6e+9txLn3ng3pmV7pF0Anse7fiiAwMEGCYYJQIi1BuAobynLEiHKM9JCtiIJWiUKgt8STAhjljtwCtpFKkI4hgUk4iJNXQ7IIuiYJ9r6BvHIYLCm35houHNW3dcmTt7+KV0397hfrN2A2glgAxE99559+TU5Obk5Pkf/Hs8cO/pdlh88xKrIdsILGRTsFFOiBOlYOJIlNUmJo4krVPcBZFAJW4OnAsRibHwTsTDGhIlIthESdg5jWNvLEXjcH1qmBAcqkJtpMFDScPpUBv63qnTx77+jO/UdMckbZ640TxUGSSscWY+9/f/2nPfPuVbZ//gm//xWb0HrgcmTZpMTkAEZksaPBkjykqCJAKnsEzNIQ0liTBBELTM2dZC6BEzub4EA2OULUIJDQpBsESV+tJy5lGRMqKUbKLGU1WpajQ59j/+0zeq40fHp0af3Dt3V41uNA8iVWUQIE985MPL7uzCy1/69T/4k5P1hm3WQmuebRYiw1KprYkwJ7FQxAYW7IhEPEoTIk8UETsh1aAAAntSq3BkU7Jg51Ug1lNkNRiCoHAQBNNjRGKZi1IBzmI4FfiUcHnucve2x/NN3SxbGlDHNdBMECICREBW8bmP//L2Ax8ZrnlV9pSqlqKOtFKwWjbECiYrGhkfxQSBKiIiJBS8lgEizGxsSogUjigVa+F8UCgJM8gkTKQqJssIXilSw6QiiUUUifPaaXFiXDzc3vtI9cBT/ZFbjM0AXhvxsa5uXphApB7gDz70BYNbYDUOaC5c1F6LPDiwURILqIcyopqyKpOqauk0eJSlphGRwoUQQdkTImIleE0Sii2yVASKIJYpSQMBNoJhWAYbcEpxRgi6comNcel6sUPozO+cnt61+4O4UZiuhrAEIbZBZWjDpp/7q08hjquZ83vKYvPKoi4vQn3o91QJcaRlgTInRIhiiqyJmDTARqzQICwOPhBZjSLxQQMTWfIgz8RWg5AynCoiTlMA6gLYssvRa9OVOc6v+GwkQ+e+oVef6nz57jjevvf9AJiv7wwtBvGgAkpKKmADLO/e/9DFN83s/MLZ+kZXLOt0p2u5XkfeAYYH/KCqg7gt1FL0e6ReyCCxPomp9EqAOkQKMMAaEaRAEI4yKXOyMYyVAGILCkqBAO13eOlcCGHvSOvJsZN37Gz2lrN1ex4HWETWgh4E9QoCmIjIqEBxajFfeW32qbvT9ZNVr5r//AOdB3dfkryjGkBBYwsjpI6EoAowcUxBEISUSaGGqXAkBEo4kMJBlWILV4rPqVaDsSRQy0gjxJYjSypatKXbGh4xj48dG2vqXNgkd/7ypz/5BOEGxKtRHl2Pw4WIlFACJ+b7vx7et+XApnDkhQztn93dvtgZeXN+yfgcJpVGDckIEkMmQdljlWAjGNayhAU4ZkbQAFVhJiZVowFo1IkZIhx8YEPw5EpBUBeiciUszSmjyfmrP+wYWf/cPe9/ZP+hL6iuxXfdpq/tIa4aNy6XZa0ed+3oMd51etfHprEt9FbiRHnn/VprivRReeoto7sieU5QKDEJMxtSqpQlqLUQJQkQr8QgouCvPTUQg1VhhQ0Fx8G53pLJW4htb7o3f36D0a0lzJkLl7wSgcON+86ralcodMAhUPS85aSJyhnti7XPLO6bXgkIbYGh5nqA0G8j9MkXpqrUi5Q9rbqad4MSEWlZinikCallZhN04DJYrJoYXqBkjIEqQZSM9Lu0shxYDVvbW0yH+WMfXXp0s7+46JaDQG/Ozthr2uVB6EdUqpYCI1BlLQpic0k2fv/Ewdhfot3eSzxalJUv+spic64ZtlAbcVUJPEQhYBfElVpGGhxYJalR2TcQJQOpqY1YWaqcgqN+jtKhfYXyJUobWpad3Q+9cvcHH0+/uSvu/3Ff+04RQYVpDfBV81ACwCACUAnyoi8i2mxwLaMkoiQ6PnTHwpWsOfs8vJPL07ta02nRhmRa9KTM0V5Q57hfUOU0rHILayBLIEN5j8WHKFIKJMLMakBEKB3AXK6gXFKjWpWSNd32uzC264Vi/0zLo9KOdwDkRlWvxqkD1hOCATyIvTdxAkhQJWNVfZVFl3bd/770+OT4d8+MlTIfbVs5TxtXTnU2+R7YIpSlUahVioOKkga1EUgIiTonRlEGjpLAjMpTnksWwQfkK+QKVYIqyh41NgQXx7PPF5dbZzcfwnh/uXqbZMOaKVz9NxDEB5BRMqtESEaglNV+hEOhoof3tmAW+yvzd2XHfum2kzW5EPKSfCGslrwGp75QceQrVE7LJahX57kq0S+59BoqTSJjLIJn1xPXRSioysFMMd2Xfuc3tn3rTpphnyJLjHoARt8J9FVxglBWwhYiliyKkpaXEAjekfpn3jz49Yt72zt2X0JUSLwhWvrswUU0akoGVd+7nCWoCMPAO3UVeSbnyJUIFUIfrsfdvqqIBK6qQEZDABvOhhCP3Df++sc2vLGxkS5S1B5uIE0NMSA3cd71bYxenUEAUFWqit6KrrQkiqn07EohMSJqZKHaugDGlpFjy28MzZ2t1WXElO3xLbRwTjstjRKCaFSnoqBaKk6IBRxBSGoxTKyGEQQKGKVKECVadQMiY3q7Rgui2rfbtz679e5uxLGlemwBVsXaLNN10NeCEGakijYbJKy1GgdIpJqXbJPgK3K5kUp7Jak7eSHjdjwZz+TJEtW3yZb9dOIlLXLElqAwrN6RjbVyFBlopaWSjYktEGtZEBMbBFVDJiCwtW9c8JcPx60DO5b2rqfC1erJkF2TOngr6GtiACNeNSBpKrU0Ti3VBSR5Tuhr6IU8hzioY+mdurL+8vIVN/GGrhtDurUWazpzYWF4k/aWTTIkYI4qFaPqJYERiAtKbCKPKAlqjKlT7KXsQuFgjp2JdnodK5fj+dly3ZYGUxYPeFjWWvI10NdHSQHxrpaQL2EjFHnodbVXoLwClyNUJErkNZCCJYmWarc2i0uxOdN67YK0ToyGwNa0TBxcYFOEokakqkp5U+OUXKkwmjU1ilB1pHTQHKGgMieOo15HN23bu2P2yKwpRzcONZOmIbo5w3qjpgUwABFIBWS0LDkv0O9rewH5CoqO+h6BVR2RJROJiaCVNkdWStqvZ3Zs6F8q8sX5aKxmH76v9sKl6NIZz1lfbMpaalkpjymDjEFvSeMIwaMqVEoS1WSIQl5M3XH4wZ8/uL21udtZUDNVs5YGBs3vCJohAJg5Lbu+KKlfSL9DeQ5XUP+KVn1SUfXMEdir64MFwVBCsNnxC7x5XNLhcnHJtbszO4a3bhm98pWVZGlBUfXVNsGqriAJiDKxlrxX5zRUYNJQwpAOb83X70SaPu+2NxrTqm6qZggSAIO3B81XPyWCxGXwAg0FeYEvUbRVAkSVGapCFhAmoxCQwJdEhixfXBwjSXWsXpbL33/98p4N0aE9u5/tPoHeBb14VE2dCLCRIhixwVgyqhIolGpqAKthdeD2hXJoouJRCrQxSyCDUsSNNr12wwhAVTMyDYYnpjLnbkfKJeRXEIShYhJSQWzBkVQFYEBBvVdWQ5aigNCgquspOjFLHLpdnNShB7Fln6YJTr+MOCMp4UOwOfsIGsgXYgxzrDZRtg+PPf/YVO/kzF1/OHqfSr4lBpigwM2aJhpksxVCgMBEwITrctdTtyPFCsplDqpk1HpECShiMkETcG5EBF5JoAhMDAKpRMMI/YX+5Otvnle6jPgZ9O/HUHODUFn5Jd/mKENRiIkJpOoRJWosNPrApukPjZ/dko6daphO8I3UbFuXAlCIgte6F7tGyQSQKhShxoVUufV9ljJA1cbQAB4CQFGM4AklURzUsfeklShQeTWJEiCOyMBmC+VGXjmjfASc4JyPi4XJaCJKZD4sk8kAUYBMpMzKUZLpremlvKy91Lvl6cVh31zeyLUdzVQhDKa1BYOrSfXrFQwoiIxJGAYUvIhD2UfoIxsyloLEWokQkYH4inxXXa5ERglSqgaAyBdKIEQSZyFd30xWbt385sJi0Z72RYF92+M7tzb/6EUHidkaEYEyKWVF58hz0abm9pfufnBxZYGsrB/2U7WIIIob/eH1jS0EOoioBTA7xkaRt5w4uC5v2IqxKQnJWHX63pHXrI1Pni4vXQAsuqHwUQ1stN8WYUgOw6oBsdVQIVjESUfXnZ2WDaOaD+Vzs2cfu2Xv/QfchTl36nwd1jPFQhT5/mTrsnFxb7Tuqh65ZdXGznrSAALYEG5eiDewBxMpATh0+zZ8781GK52oDS/BLs/NcZJeWfKn5mYObKZ1ppxzJiub6tzK7Q/q+Ba9+OrttcPB2NayXW5r0fMRSaiP6dBuXb601F9yvteNtkfbo+FM/9fM/unICh01GBMK8D1r0st7P3BlvPngxFznwowxdd/pR5WCARWA8Q48LUpMAIih4a7bDn5hxw8unD16bPZsuVzpgXvVNSKWzpVNRxc4GwpPPSWpSZbbxdPtcjmOdMsdsjJ3z8QKbzezM+2Xf1CFkBXV5ZKaNLwzS098aE84caJ6Y2Hpa6fuWBi9A5Mpzrwi84c1bmBoS3/nk7RpQ7pjvDz3H8KRF7Hj4G0PP/J3Pv0IBrWzt0TUdmDHOpiKYpD58FfO7tows3JPoz0z84FPfOzD9236vW/MnnMjl6u5ervlZ7nf00cf2tysmdrM8WWaMnHtdHv70tEfJs0ajW554NFLTY6rfueZcxeWagf76/d8w2b16tlx/5pr18bM+ZWQ/PVf/ext69Nmlv7v//PisL76hjsv7Q237dy2+x/ddc++/R++/Z7NY8O6utIEekPhb1D8lGvhnweMhqd/+J3PfrcMM4vJC1/++feHmOTbz1Lbj4Ywe2lqk8cwLVcbJ+ae3NxKk2GfDL30XGt2Om3Yyng3M3UbHdw3xq2R4fpwfiYpOmprNjFzx1u9E/3M5gt5MbZj5F/9zj83GH3xe8+UnW/v32WnZyna+jN/5RMfn6iNNGxCGPCcvG3Eb0EYsOAgMGGASF+niZXpc4de/dG43378+Pna6Ew2MlJ2lpbDOtPcG8b2kfPt7vwPzj1967rezq162/58pT3dxn6d2JGRa9FEv6Urr12qm9pWf/jRh2ppZKtD+lXlo/xQvGF7O/W/+MUvxyeO1OpbNq0bOXH5YjMZ/6Wn7t88tN76AFVPYvVmU34rewz0DgI08OXvnEZvvl4ve3NFu8j/xkO3pHeaVle/MruvDDvZFyLl0NFvdZ195dxIq9X9wH0Tn/vUxLF2+vXOPp9upXJJ6hnPH876K7Nm8vlXVh68z/ign3mk8Z8Pz0yX2yrb6O/9EPqXdi0enfd3fLf/+G8/tvfAvm1GhY0RUgsDlmvQbnLbFgqQABDQwHACuNk99892H0k29/5wtjN3du7pZ6YfuWe9in4wnP5vL9jQ2Itt98/VMDR3OE6mLr6weKVdfPjeW3bHrXvnfve5xbtpYrciXWzUkL+WqX/55SvtIn3/geZ4yB9IX/+v3z9qbn8qhN4Dt2e3RcO/e3LyV37h0S88+T6oMWCl1cL1dX+iuImnaVCAv06Eokq4MPv6f//qFy9enH329eap7sayPn5o+PymcGT2Is/PpnkROqPmzoP1HVn72IneicVJP3lwy9jyjvT0ueO9Tkv6Q0Pj28f2jyysr4dnXwkz8V1obFpHb24sXm63rO9klIUde7oP3ja5MPHw6MFP/tPH7qnFDWtudHy6io6uBhrXNU2DKs4g56uB2EB1amr/Bx/7e//yq195deoQNMNS90fHZl6fKYazKWjgZOHh7cXu9X65p2dlvBq/i2r185dWLp4vU8+58beOXrxjbFmz7Ngcz9hdGNoA+IWFTutcdzjbPLZu9MCdtUOHpvYcfPSu2x/ft2kj1A40t1afSiAwSAC9ybjfvkllMM+LKwt/9NrJbz5//Mz5+Xj2iG3nHkVUi7Ztx9T4SNaol/Fky22KYrOuTo3M5K0VVxVZM56YGI4B5cxHaSlWqmpyZGS0kVHlDWF8fHz9+o1DSaOWpPQWe/1J5B1Bi8ggv+rFtV3pXOmr4KExm0FoEZk4MTBWiSgoGUUURQpWIlIyRApE7/xgDzUg/OkR/zjQUASCBgUJQxWW1BGMQFeL3kqqCvKqyhSDhK72k1yv6DCreF3TQACAiaE3BZtXn/mTzeGdQa91RHrDClYIga/SDq+euzpyfc7A6s+b9xkQhZLyn7k76se1uPFgdQwSPCS6Cg40uIqwWnRSQBkQXT1n0MMzaP55az8ToMQw/z/9XD9O02ses9qoc02dejXns6bOBFWsDg2mN3hPa1T+5yU/BrQAWGMgGCyamzBctYg1QYJC17Tu6DsA/jOQxk8AWtfo7CdolLwZhCjobaLKPxf5v5UEEgSH728wAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAVIklEQVR4nO16eXCd13Xf75x7v+Wt2AiAACESpExtlOWIai3blBRrkjh20jZxYmfsuk2cthPPdOpJO81Ml0zbZNKmk0zT1GnaaZJx7Thum5Hs2LXa2I4j2akoRZIlWQspiaK4AiABYnl4+7fce07/+B7ARVwgDaNOpjp/AA94793vd88953e2S6qKv2zC/68BvBl5G/RbJW+DfqvkbdBvlVw30KoKhUJwnvdFB295Vb0gIMj5b0E2/7/1iHH9NE2kBAKDRAERURFRAUBkABCR9wUuBqAAFKRMoM19bhH1dQNNENpYU0WYmdgaYgCZy0VJFWRAAEQFSgolKBQEJQBCRNiasu31Ag0wFCCIgBm9fv7aqdUXXl544omTc8v9PJdtI9F77tz1Yx+4dceOGgMeykpEg50qmK6+/AVC1zv3EA9+5pnjB58+Or1t5Mnnl5994dTYeHm0HB07tba40rv9lm0f/bG7PvzBfYE1HmKIVT2RAQTgjZ9vCehiESIF+Hc++52vfOulofrYi0cWep1WORQbSLVardXKcVxh5qTX3b1r4lf+6YdGR6pKwjAXrrOp+79w0CICJgb9l88f/L3/8XS/l0Vh+p7bh9991+zUjuEoCPs9N3dm9dVja70s6Lro6MunpqaGvvif/la5FCuUQEoorHwrRnIdQBd0xsQP/K8X/sWvPzJU6vzMT97xtz96oD46NvgAQBAFk+Lp7736H3//iTQvL86f2L9/z2/80k/CCwzT1gzjoke+MRFV9bLx0nuvqg987aU7fuC3PvrJf3/s2IniLecy55z33jmXO3HOOZep6OHDx9771z7zkZ/74n0/8q+/8cgrqppJQeR+i89/M5SnUBTOrvAuY+avP/LqH3z5z7//zurnfvvn9uyZldypFzYBMzOzMWSMGjbGBM7Lbbft+dmP3XFqoT06UnvwqwcBBMQXOOK15Q2D1s1foqKwJnz52PL//pNXKrb9iY+9r1SJXabGWjARsOlVBC6s1VoWcX/nY/fumKo6DM3NL7740gIU6gGI6pZ47w2DJoBAICgTkYLclx96OfedyODuu25mMTYkJeA8AV/6FFUyxtxz545mL1GPp587DoJAFbwV6ngzoKF+4OEKIn3su2dXGp2FudP3HbhNAa8eG9FRAZwPkxdsm0iBfTdNCDiI7LHjiwoQma0Hlzdh00YLyxMA/M3vvNZtt9fXmj94/20AmHlzWVIMwuRAzudGpNg2UTEmEE+rKw0ApKLqt4jgDYdxJZCyQsnQ6lrr1ROraefc1ERt5w07AAExMCC5TcodxDxlItGN/8ZxyEZcz+d5ThCYN6C+N2PToIHHPHd4Kc1cp72+c3ZSdaApVd3M2xQAgcgUL6CDBENJJBd4BDHV6jFwUUZ7/UEXPl4c9AuvnBPNmo3W3tntBFJi3WCMCw1UVQlQBUgAKBjgRrPrlCG6bawKocsZ/3UErUxEzATI3HyjHKHT6czumQJB1RfkrRu7IwggREVmAihDvcIT0Ow5o5r088mJMWUSFAb9F8PTG0evee6bnXx8JCTOd0yOYZOVaYM6WKEM8OZTlKBkCt9cW21DNfPJbTfPEMACDA7h2vLG8+lBPNRmq5d5FySJJR7fVlVVIoUCNEisFawqUFYSAhOUSEVZ1QBYXkurVQ7j+jv2bAeEjAG2lC29GdBaWAC43c1EpNFar5RLtVqFiERIIQATFeGCwUwQVSISVRWwSlEs0uJyIuLuPXDz+Piw6kYs0i0Bf8OgCVLUSVnqyuXyoe89Vx+OKuVYASbeyC0l6aVLa51uq53BUqWe5jwR+53TQ8YwBL0sV5/XYv++u/YR4LxYw4otJdNvBjSUHRCwzJ9pJ/1sYf7QU48d+sxvvvvv/4OfPrnUOr3qzi735xZXTp5aXVpYiTUp79xlhidEZNQ14yTZOTv+gfv3xsaXI8MkX/qjr979nl+wlgXKW9TzmwFNQqIgk2S5aBoP33aDHfrCN0+eqh9u9blzbjmG77T98nK3EkYZEZ1Z17m1kM1yiViTQ6+dePLo2cjYPcPxre9613/9z7+zvPKLn//sv4XS1qvEa4Ie5OYeMBAFQ4kHPu7SXnrr7fdMz07kUe3ZR4/Zfq8S4VQziaxVwlorDwLuNNpJDoaBOCanySJ3V862699F9AMHbnr3gR9++tk/+z+PPXffPd+XO1i74QyEgWcPnnVRiXCNymVQtCkUnsjooMrAwccP/4fPPb7/jr2PPz13dv54yZTXO8nU9Gg/V3EaRXa9m9+6Z/TY6XWXeQVy8QGbJElitOojw4srqZpgteE/+IFb9r5jvLe6+MmP3XPr3qkNwJdiwAVZ7rVBD3apDIKDNzDi/e/+/sNff/ilV453J6anfS5Z48Wf+MgPHzmRP33obByFXvrWUaOf3bKnnEs0f6ZlOFRVpzxa9rNT9MT3zt0yOxTHnCSy2m2+6527aqWRuTOrP/Wj7/zIj9+pIMJ5gJctda9M5oqNvhaDRJy3oLlTS7/0a1974KuvvHJsfbgarCwvrzV6i0srh1449p7927udtF4xztNqs8WEV48sz82tekGaCcSruE5z/fhC99Y9tVJZXJ6Uw16y3jt9bI78+u4dY5974Ilv/OkhUhR9qQsVfIlmr6Lp82YkIkz85ItH//RbL3/7qaXOetMrJoaRZby4rp21hV5fdt24pysBiQHQ7+dRAJXEeYKx4tUyK5m0v7ytFo6OlOAlBwJ1pxfWuDJ6z/7JTuJmpsd73fav/vOfGKqXNg16oyuyRU1veIBXx8SnTy994YtPejP08vFGKRDDUTcvNzpUr/HMzMyN75hprXdc5jMvIgBrKbb3H7iRiERZQE7Eq1glp+HJRTq6yPOLWFoPTGmk3TePPtc58trK+nrrHbsnDz5xBJBilQGM12n1iqA3PskMo4Rf+XcPPfXi2oMPHR6KuVSvt72uNKlUiYmD7ZO12V1TvTRjFQMVOCZJUj+3uK5M4nJVVWIRB6Z+RkFgI+tNwJmyOAmtyVKfudKLh0/nSodOrHa6uTFmYAKXa/BdRdMCiPeeiL758HPfeuz42nqWps4Y02hnrSZGa/72m7dFYYUDvu+9N1erZVV1otAAiFOvh4+0cs/WhpYNRAG2xGwp864UsXoSdURERGzhyTbW+4vLLR+Wjx9fwaC3AcC9nr+vah7Kho2I++3ffdgYE4ZqDDggCG0fD265aTrzplRBkvCBu3f93U8cEM3E5cga5Nfhe5DUas7wRZIKUSFYNpbMep/BYtlkYjJx3jmXe2Y++dpCeXjbuWSj7iIQ7OvN44rBhQAvno35428dev7lM9WhMecckw2MVGIbBOFwtbRtON57Q3Tw2aWdE9V//KkDD3zlkWNHvl0OAmOMQAFOcwkr25wZCcq7RD3Bl03a8lINjDKVWSuWKvVyHFIvN61m6fRcY3113d68p8gWN8qcS5n7yhFRwcxQ//n//pRV9nnmvBjWdtckvVzQXltbmZ0ZavX6Nho+vtj6vd98ZHEtqo3dCQopNIEHVEJmT4FFrPDMLFo+18wqkb1xVyWOKEtSa20YWi9uVLOF3C6tdk4cmbv/fbNahOArdPeuCFpUmPnQq0t//syxoQqqtfDcakc0oazSD2IyWOnS4gtdtVov937m0w8urfbqlUiwXYhBhMCSikDhRSQnr9Dcs1GujG6zQ6M1l2X1Uk017XfdateLhGMjwUqjtzjXyFttonG5cnPviqBVvUC/99xJZniyvZyYIiKIZt4ziQmCgI0xijR1ictr5cCBIE6IDVSKxhyg/ry2VDWy/syKP7u66p0YQhixgJNU4ojuunNm/uxap9NfPNfcaJhcvjF5edCqSmQYfPZcc3g4dt12UOHhkUqeZTkogEIFcMxWfK7wpZCNCFgMAWTVC0TAUFUYUSViFjKWQBCDQODfe9fsvluGllf6jz49Z1WE3bPPn858pl5OnOkIiLlwwMskTFcEzcxffnz+4cONieHyQr+j3sOAjdk7WVMDVjS6ebcnnhEIWwMTsHMiHpAM1uTeswF7EjZBSIbEMhHEBBaimbNLK8tji76bOnWOIaSqPi56p+fW8kaiYxErFKQEvmS4cUXQAFabXYpLHFhjUY5du5165TMrpGycQJ2muRSNTu/BTkTUWHhiOOfViIiSGnHO23JMu3ZUmVkd0tw50dMLyYPHTobWlKIoE5LMq/YDa1ymvV6/1ZfRmD3IQhVCF1vI5UEXacqeYYzE+Yl2nmUcBWZm90gnS4+e7CYaMVsVgJmJAEmFUZhwShtfFyICmAznSd7LqO/7UK3H0fgIR4Znp6Lh4aDZVQBjsa2Vo4WVrs9Qq/u03XKtJo2MsUhRZW7JpgEIVCDbg84JzZntiYXs9JmzNrRZ5tkwjBCHKNqjbFQLilRVOZ8tkIp3zEEURSJueS0FsIT+erc0vS0shTpedyNVhZogINig3Ct1sl4/5VJIC6cX9u4aIy2869KC94oRkUHHzvZ33TAUBJG1dsf2GBRlCSsMsZKQqg46kUpQYagKQ82GgZEKE5GqipJlUysFQ/XKUKW23ndHF/Mj89nCCuVUMVHZO3L9/o3TdrQeGPZT4+WTx+f6aUKmODQWuqg3eWXzUMyMDZ/tYHqcllZ0vaPG2jCUKAx3TQ8tNrK5M504jj2EBIOG1wBvMZ+VotMAdSrq2Yoz+28d/YVP3fvdF+bPLHbvvXv3v/nMt598YWX7aLxrOiCltRXX6ttalQPrMkGj2S1NxEURQLgoO70yT0N/9Pt3P36w9bVvvCYuiePy5GhUK9kgtNbSbFRxuZxdS4IgIDIqhU432l8QFH8qQRnwAAnj+ZdWHnr4yKvHVt+3f8eH3r/rr+77+Je+efixpxYOPvNaZDh1oTGqkqy3pLF86gffv3+Q6InSxTnT5c2jgMBKU1Pjna5WQrNnIh6pWmXvXJZkae7Tm3fX9u6sk6iIELvzR7RhMwQGq2WA2Kuo886nn/3DZx59dv7BPz706JNz28aDT33izj/4rb/+0x/+KyvNdGIY48OBiChh//59O3dMUlF5vYFyCwChXI9KkQkrw82Ec0eloGRNZMjCUd5Ld45Fe3ZWHJTkkgHFRmIm5OFIUY4wXGfyXImj4dgsLHX/4S9//Qt/9NL8uSTL8S9//t5f/Wc/FJcoCm2lWsozhEHVBoEUKxH0YgK5miMCqIZxrR63+v7Mmjl+JltZT/ouM8aYkHKSTpJMjUWz0xUhDcIiAyYbkA2Kwo6YwRQws7WWmWFgrBMRa7Dc6P3ir/3JT33qvz3w0PMmwCd+/Pt279y579YZQm4tcp8pCQZDNGyJpwEIC4PK1SgMwyzJt43IiYXewoqM1IKRUjo+Ua6VLTPneb5zPB6qxfDIcy9AVAp7SdpYT3s9TXPnxDNMq02CJLb2hslKEJhmJxdBr5/Nn239q9/4zjcePXLD9rHlZmtuue9yVEo8NFQhMMnl26hXBM0wqmpMENjyLTdt//iH7w5NcPi1xS985ZnlTr7SadSrUTmgamzGJ23ZhN5oHAOAeAnKwXDFZk7yjNbaWb+XZ7l3YjLnTy/0JsfC4VJsA1ojVi/dRB959JTPTleqdnK8bCMFUC1HgEgx18OlPH21DpMSSJQI7VZ3Zmao08xeOr4Eim1o2KWddtr0umOyZsjm4pTg8+J7g5Egq0aBnx4jnqglzq828m4v7SZ6rpnnkG1htH08mhgL+pm0ui5N3Z7pWuJxeq6RJM45p0pcuODrsuqrUB5YCSxpmi6vNj/583/YaObVSqVai7y3jsWCrfFD9RAQj2L2rCJCRCLFmEIkdwCslcDYmYkSuJLn2k9yEHkEAIxBrcS1uBSXTGDoxefXJeek50NjCwYDXaaTejWeBmm7l642eqUw3jlZAczCYr/d7dsoYLZeTJr2V5rp8EjN+0S1mHnCiycFAAMmY7zPxadW4LxIEESBKddDT6xOlVVBcEysKnz4eCPNszLnvaQfl4wCg4sVeinpXblGVCKixlon7SbbJyqjQwHAQ5Xh+XPJ/HKXFUQ0NlbaOT2cdjNVJZEiNqpXEKlqEFj15KGkKpyKBMgpFZeztdZaJqbAq7L1qpymebUaTE/Vuk0yAU9ODA9oQzd/bM08is9VarbRps6yMOVj9eDGmfJIPer280rNDJUCyaTjMyixyGB6oUXaBLJk2TgBoEJErCSZipEAeUZiyQrYGhAxs/fZaN3WylG3jR2T9Z1TkyhmwgPsF8mVeZqg4nbNjN9+047llebCcn9+sdNoeq8YHQ5vmKoMxVGeaZI7FgMvDnBQpyIENsSGnMuJyJggVy9Q771XqKpm4nzinMtc7rLceyWV0IbitZv0xcld+3aSEa+Oi6kvNi/LXUvTAETJAB/4oX0Hnzw6NTMiqXKg4rMsE5/Bq0ihXSrG5Nj0GoExhkxgDNkAJnO5SkZgFVKIqidvvVUhckzWGbE2iEIbWvZwWbp377QqkTJUiVXBl+QeVwPNxkBx/4F9s7v/bG2tXauUkyTJMud8CggNpm5EZASeBcRhEcE8eYFRYrJSqlbY+PVGzwYGlKgyhKBd1pK3TLkjNuyi1OW1Snmt273jlpmbbpqkwW2HIju/1BOv1hYrukIg+ief/pF+r7my1nA+9a6vXrxXr7ChYUNs1DBRwGy9d4loxkjJ9Vy/2e+2Wu1GWIqrtRHvxDAHQQAmMkycs3hjjHPOa26strrNteUzf+9n388w3ivRoJh9PeddsdW7MRdkVQe2L708/8u//sCrR88x1AShuFw0i0uRIfbeB0y55N57VjYmKMp/FaiqV4nCSq0+kuROXFoph3maKYGZSYWD2EOJqNfuBEz/6NMf/Bsfuktk8zYDLnvp7dqTAAW85JYDiH774KEv/c+DZ86uiDe5uDi0hkVcX3zS7bT6nWXnExvVjS3HQTkM436WElHR+oCJBRGTdT5TIYYoGUPEZEslPfDed/7Nj993w9SEiDBf3QSu2VQvmE+hImQ2bhqJgkTVq5KCiVRJoEpEKgT1RFAYIuIB/6k4p96LSK4qnkVQXM4qDj4Mba1WA+BVTHEr4Kp6vNagCCCcH9848cx8wSinmDNQEXIvN7q85HAFUuT1g7cUKPxMRbBxx2VzKVVf1IhbBn3x4y7Y/QUnsDkZAYFEissgRUF+wQWKzUdcvDEZlH8QUi52srGqQFWLC0KXU/t1v2v6Vsj/3zfV30p5G/RbJW+DfqvkLyXo/wutSRJJoQjKIQAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAU80lEQVR4nO16WY9l13Xet9aezrlDjWxKphpiaAW0BGtI7AQG5Ey2BDkJDCcIHCMPAWLkIS/5L37MPzBg+8VG7NhW5ACCkygGNFC2WiRFhZObza4eqqvqDmfYe6+18nCqmtWUulliI3ICaOGibt177r3nO9/+9hoPmRn+fzP+mwbwYewnoH9c9hPQPy77Cegflz0WdMVgKGJV9PwdMwGKoYiOMGgBBFDkXA2AAqgiAlRASzagQmFmQBnyMdADVQ0GFIXU859VVRhgMFFY/eFoHjV6bHCpAF08AJiZEREAiAI8Oh5FlWzOHEQGdQ0MfImEYZCQiquNqobIIgDABOICUkMCABQABiY4AGrVkf/woC2rmXFgEBnMTGhCZCMRG5ICpVrw2cQ8NWCFMahDaeEIXKQ4FwqQDMgVzkENkQFRKCSMDBYFIU3rLQYmfDDkJ4AWqEHUxBEBDDiAS0FDAKMwOpGXXz5987Xu2rXlzm73sWvL5Z7tzALgCa7oWMXlke6e3f/ejeGtN93pqnv+Bf6nv/LiwQIOBiUwxIxdJZCBSy3BB7rCNnss6FF7Ih8owGAKMzgnIIWFgbY372x/93e/990b9OYb999992h//3DeHix3808989z15+vqbHv/zk5XV0MfxjO9d3ZLqMZmef2jH3n+4/Tv/8OnP/liXdhStbADgDpUH1oQYAr3FKAheq5QM0xaNoPJ2yf8X/7gta9+9Z1b9ze7zxxs+rpa98MwQHzylrf86//22bfffufrfz5Pi2Lek/jQ+CK5naVPfOITN998vY32xV/6R5//e0ef+cz1NkF0SOxhXobiYoD7QMxPkJAxDEq5UAHN7z7Ajb88efvts2+/sn7nnXdW64F9UK3zGdanufH784UFopPtBn2c0/4i0nzRCNtQKzN0tOV85/j+nd3DGaN+7Vtf/1//M33qZ/MXv/TCZz7dSLRI1bVuGIbGNR+e6YwNYfH6m+NLNx68eavcvNPffdAbcdNg+yA/uLMOvnabe/v7+2yL4/vdWtn0xBXO5b53zXx2vbixaoyWASyW89RQLn1MyXFz7SPXiz8bu63043PP7Hz2k8/97Z9On/iE+/j1mb+KptUyWYCNoASC2siawNoR/87v3/rTr7y72moTAwm6rgNXpjQOQ99vVZWZnQvOOWLfb0ZVnSgwO3eQzMzMTdPEGGutY8lENJvN2rZVdj5KijysrYxxNuODj/T/6jc+9w//Dua6gu7AI1uJFmBZzbF/TzdUbXCWQApAlYmVwFrx23/0zh//6Stn/e6YdRZD4jTkerY5gRUiYgYbVFVATN45Z8oTaKL3Vo+ZUxMBwAgAEZFjERGR2WLPkEvtZ2lWizmmECW1+KV/cP3f/etnvW4Fc7A6YTCMzqPFZJ7sQsHIhGggwbDeNF//ZvfO7RyaTFbymBVaxPq+lzpE50MIzpEZwRSkxuycc869F4EmSqYLMCLCxDqRA5EB3fakSW3kduiLmjSpHccgtfnj/3rvmb3FF7/I3uAhRqwCcYiXUHsmNgUAYiGDCKmTt26NpyP2ntm/f3w3sQ9hluu2Wp0tLK+TaBmGwRFPwiBnVk2cPAQ6KWR6KSLMPKEXsekDzAzrB7UYWlAMzhOcWiGWba5/8Idv/MIvfvpwBsJATCDA/GWq+SJMYzoLMyrab924m+s2NNYmqKKqE5ha8R7L5XLWLmKMzrmJPIDtkuklExFHpLWWcZRSGOrIHBm0kjWSy2Z70s4cBzcMY9uGB6e3fFgfH6c33hjVtiwJ6h2JvywOgE0BBhgqBAURbh2Vb7x0xESrB8fP7n8k8rwUMucNrgyhmjJzim1qZj6kiUWwe7jtLvMNgPDeIeeYmQADzGrLFHzQIT8gNxDXvu8dIuWuVn3l1fueBBJRYSCmzSOgYZOrro4bswroSy/de/3NDYsd3zmSmmfLxs+QZpZSirYoRaqpwIiIiIwd3HtYLxbNLuOedioziZSSh1p60+xiYWbi2bbXpmlC5Du3j2SE9GGUk5df2RbM4IAAkQiER0ATQ00FGQChGuqrL9852xir5rE7Obm9ux+W+/BtL9oBHFJk9mb2CHSCPWoPTzDpxMycc7O23d1dHh7uX7t2mOZrjmR13oSPlpFPT08Xs3YxW3an1Td24zvrN97cwKHSihwg6VF5EJyxt8YKLHQ3j+mV7zRWbp9sHsTm2q17d1ZDt9jfn+9ca+PHzNZai3M0UcvMqlrLtIOl1lprnRA/dH/OiXdtHTxK97eu29/9tP/Ys8MsdZGWKNHHMlty5SMFzXfb47NbwqKjdBv52l9sC8SPO06Q3fGj8oAKnQFGwTLmL31zdXTvtkvtyd2ja3s7ZbtFGZAH2DA/gN8VIlLVi9Xnc6btnPLL/m6yru/NabNszPmju91rrz+4dadfb12vnXlql3E2a5weNHRwcnSPa100u5vtan6w+9++evLmuy6ne3Aa7fAR0LUOjnZRnXEW8Fe+/H3zMdfZvXfvyFA40+03bubNcLi7t9hJ5pvJGQM8iYTA0zuO6H0PBhiYLXcUJaMX8kUWYznohp2TLdR7oZCaudim1uOhv2k6RCzW65658aneX8uX/+z7hmuSGY+mGhx4BmxGEUX6H3+Wb/zlKjZ0ePBcnC3vHd+bzePx8c2jm6/fufXWbOFmi2dDdJPHIPAkac/MeI/p95kpi1aQkOOc/dCHagkcgWa2SCmlWRs327N1d1JV1/kozXlv2ZzeOZVT5TIDYFzx6Pp5MGqNsRkK6gsv7rz44vzbNx7sHOzt7l+/+db3ou+KnNy+1d28/a0vPBP2lj/9YMtVUYuZGsBEMCIl8A8I45wVdaQU2DFc7YuakGffwrv5znIB4bG/f/fea4x5qR+fzz7Wb8tybr/6yy/88hfSz39u4QBjL8gO8RJog/cRoID5xz8+/tZ/+tzv/c7b//n3jk6Oy6I9cC6V4ax0crK+/eqNv/i5n/vsZnZczatUMQU7IjZTIgL/cNCJY83ZBErqPHuCOWXPi3liHmaR3nrr+92xLRonrtvbm/+zL734T76w8+Lzc48KcSAIPSBqH2WaRlgCghUEnyLzb/6bn/3nX9r/o9+nP/yTP/nGt14dh22i+ere/bdev/GLv8DtPKhZKbUO5LxnkBncpJYLu7wdx9qxdxQ8RBWFidjHdrZwUbwb9g/He7fvDLf9p//+c7/269d/9Tc+dbhgAjwqtIMLZq3HwXkEfPj7aiY1excBgHpoU0YKDUA4Wes3vnXzK1/+2n//6o3FPv7xr/382dlnjtdjv80P7ndDr8G1RASp7EgvdPc+B+I8SjVYNKnBmXcMH5vZjp/1qex/6pMnv/Kl8Fd/vvkX//Kze/tb0wWkEnk4EXNgGOAURB1o9h7ox1bjouoYUhyHUWty9s4d/1u//eqD+30e6eidMxU/S21Rcc7lnC9vvgn6ZCIy/cPM3vspysQYeZZY6+c/e/Qff/Pz1eANBFSI5w+utx5bbv2gx621qmrOWcQzM8GZmch5chdjnBLl8yTuIhZOWJ1zD99xzoUQigyO9JM/8wKh1uJCJJRC4QoV4pNqRAA49wnMDGjJVZRm86bfgtikqkCmo0Q0jqNzbuJyij4hhJTSedSsdUI/sV5rhRtCdC88/1PASEwAgQ3Qq3TqHg/6EtNsDMLZqtv0w95yNw+biTYjm0g1oxDCFMadcykl7z0AEZnIvviYqepEvKoQCAqYJJ9ExJGvWq/QQfigy5pEIiI1y+lq1W0zkakqETlPD4+WUmqtIYT5fN40jaqO4ygiIQQzNTsP+xf1AZkRwQ19Xp2upkpsyo/p0WzuRwdN56gBMLNzrhY4n8xMrTITADUxM2ZOKTVNAqyUrCoxhqZJzDSOQwgBQK3lQs2JiEopzrmu64pUGJlNUQruMc7+ffZYeUz19FTPTGGbfWznS+/dRfJJZsZu2mehlGEqEzE1QgHnXNM0IuK9DyEAJCIi1XsfY/QJ5Ji9h0NVRAaKwD3dRrycsKmCGWbmXJj6uRPBwQf2YXIpTZPe1zmYrjylNG1EIp5KgckPusBNE51nwJihWtmxQXCFFtMT+tPmDCDC1IUlVE8ueO99KaVt2+nCch6JEKPvuo6IYowT0yGEpmmIaBiGpmli0xihqhjgQ1AzZzU07bXWQ1tCYfJi7KCPw3Ml0A4X/buLmtd775kAxBiJTLVOWp/25e7urqoOw5BSWiwWfd+fnZ3FGBeLRdd1w9C3bZtSmras934oNYTQNAmGqhUAM66k6A/005ctBheieWeAEvnJx5FzMcZSaim5aZopOo7jOJ/PvfeTD5nP593QD8MQY4zJn1dfPvoIjsC0caZOwYUrebJ9sFe0i6eYODhMIMws5xyjd85NYaVt21KKiMxmsxBC13XjOLZtG2MchsF7P5vNJkfuvVfV4BvVOuYNCMElmMFAV8L8eNAGAc5dHhFAGgN7Z977WisRpZRyzmo1pZTzWGtdLpeqenJyEkLY39+fWPeBm6bJOXfddj6fLxaLMfciUoqBqmq+gKGgRyLahwFNl/IoIgAao48euQxt204OIaVERH3fT/Hv9PR0Nps9++yzm83m7OxsNpvNZrOcs0EODg7m8/lqtZr2pQ+cR93ZWS53GkyLaQZ6Ep7L9oQwrrBHvE+bQoxu7LnWCiClVGtVgg88qWI+n2+3WwCHh4dmtlqt2rZdLBbDMKzXawD7+3siul6vQwhadXdnZzlL5/pjNgD2g3naD7HHM/1ouwww7zl4ngKbQcxkInjKN7bb7TiOi8UipbRarczs4OCAmbfbbUrp4OCAiFar1dTqVVXJAqhBYVNHdTrr08ljOmRQhgprRbi+iwgMA4nmEFiECD55V0pfa13uzA3SDduQ/M7ecsj92fq0nTeLnXk/DJvNarGYzefzvu9qrW3b+mB33+qPx2jVXDWDKnqSq2B+0ka8+ICCwQ4IjmfN1BrAlBMDIKIQAvHkTGJKqe/7zWYzn8+Xy+VqtZJqi8UihNB1g6rOZrPzZall2+e/fqc3NoAMplceH3+Q9wBDGdMQ1Enb0nbTM3kRyTkzs4gMYzehL6WUUpqmmRSyWq2miLPZbJh5Z2cHQM45pbRcLtVsPegrL6/FnZeXjAS+EtWPB23vcU3nOVBNkUUs5+J9aJqm1qpWp1xUVacYvl6vRWRnZ6dpmvV6HWOzXO6KWNd1KaWUmr7vu65j72p1r762HoVAF6ejK42ZHwua6eIQAZcSt/WqS3FuRiVLSgnAMAwhBMdhs+6cC/v7h6XI6enKjFJqJ/c3VQbb7TbnPOXc3ntz7q9vDcdnFQSo4yvfTPXEMG4wMgIpjNkDNuYx59p1A4xDcOM4llKmIdBgw97e3rbvNpvN4eHh5L+JqJm1ZjaMI4za2VxENtutmTlnMcaz9fbo9vj8YThf0KctAsCqmAKVqhIDFu7f3wxDjjFNbcgY4yTrEAIzr9frpml2d3dPT0+7rpvP5znnzXqbx5JiA2Cz2RDRcrl0zrFKTMEMR7czUJkIULvaXnyCn57+GqBKqkAVvXe8KlmmNGhKP0opZjYFdudc3/ellOVyaWZnZ2dTbZtznoJLSmkYhslbS6mOYGRnJ/k8JqLiagp5EtPsK8EX0mjBmd4b8/FxCp5LFufbmGYUYtHiiVhsLLmqEJGIjmP2LqU423bj+nRNSo58GauINc2saWYiNnIbxuPWL156s1QEMpA5fWrQ50cJZIBIXa+G1WpzMQOqD93L9Do4X3OZir+pUMg5e3aTuCd9A5hcBwByqILY2L07m6PjDgaQuqsl1FfREJuBya/XZRhHKE3awDRcI28GMZ2CuSPOOeecpz7B1HmahgRmZqI55yl1IaKxWGpw+mB85eUzMKB2xSrgiaDtUk/R8emplQpTVhGDEptzzrkAYMpDzuHyOdMT62o21YYl55wz2fnQQ1WzCRGzd9/+q60xyLyhPBVoOy/XFCCQmuLoaLsZBoBFRLWaKbN3LojRw5H4w/E48N7oaCJ7GIah72utWqXWaqJG2m+xtxe/+2q/GgBju9o9TE8AbTCYGU0TUcXR7U1RA7jWqlJEipkx+QnZJA9mzjnXXLw/L4HB5/KAqFXJ45hzVlUynW4DSA3unun/fmMNgtHTuTw8UhhrKfXByRhT6+BUoFpVFeBptKKkU931sKNXSymlTLnrOQuPznPZquNZGXOtEhb+O985A0Hsaf00AZjuThCt4zhuN9nHAKNHhoXkABCRlDI1a8oF3OB9LWWq1Zl5Qjz5kForWWG0hpxH3dmPb781gNT0Ss2ax4MWB0IpxVk15tdObEv7ruvM83a9psreGqvO++hc0IE9eVbTWsmUCKpVVH1IKkW0EJlPPgTnYFyrdn2vAXpkbdpumXLufB4tJ+b3zU5/NNBwVQgxNDAPid2pbE/GYVXA1bx0dVVsM8iZoA+Jm52ojsw5IypmVXWsMpY6jIVdYpfgoporBiUWZmHmfvbctZS8SQ9Tkuq3m4CnLAIUUk0ARhYSnJ1sSu0VUkf22uqA5IMDaeEy0LjVmkeoAIAq1Dy76EPwPg/FBAwy0UnopOYJTewPDtcxQPK837phYMUW/kou7/G9PDRMAiiiMruT9QqRuPUuR6DtN6eYC7FFSuQZpIqBmBkEJasCCIxUS+JARICCGeSICKalFGn3z7adi6HZk4Ju281dSKZ6lfjyeNCCafzDDAFWG3JxF2RhMShZ7rsRp+wq0bzUUZHNzDsPYiOYZwQiwIGlVlU1EzDczHt2pZRSu1UZ7txtkRbtcjv2XAcaB6B9/3D2RwMNAkNL8Z74+GxYPejLVoazvFErI85O2AUNCc75MoppqVW812n+4H1lrlMX/XwS4Mhs6l6riOQs+/FBWR1q2mI8Cy555tMj/ehuMvpg1E+6QVb8qJoCoR/rN7+b7z7Iw1n2c869HN8/4qCCRLRbxiGEzlRijFPvuWmaGH0ILoTQzuKFK6zr9XocRwBE1M7bjy4WcW/gAuF6urGf+QgOD1vQeb38oUAbhHpY66CgrmIBqEcBHNSjVkQBkimkwscK9e/7OkhABCrQqWVM5/GKHIBK7LWCO+QdRAxAU4BQzPxTgH549ou8Aper3ae2x8F63006P/y7V8FxOQe6yo/+37Yrgf5/zf7mafsQ9hPQPy77Cegfl/0fYbQLGpke+5oAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAYaUlEQVR4nO16W7AmV3Xet9beuy//5dzmzFWj0YyuCCEBBgwEGwguMDFOsJ34JUWVq3DsKpw8uFJ2HvLkPCRxuWySGMdJsJ3CDhVsY2LZgDFgbrIEWAiwQCA0GjS6jeZ6Zs75r91777VWHvqcM+eMGCEhFeUHdnX91fX/f3d/vfrb3/rW2k1mhhdmKFpuy0kZB1agsVGdFyyAMkAZLkVYob05o54CNcDf+5Wex6FXjCRWAqmIBSZA3QQAEQ0cIjlYzeghJ4eMfppw+3wu5V8gyEBwUZRCQdL85q9/6ALSr7zzHx3bd/PETY36DGTAExWWQNx/fsF6wSI9hZbCPJu967c+sHdp8As/+5Zf++OHTl9oBlYOs/oMywbvQeXMAkn4BwGac5sDfvl/3C2X8EvvetsdN+//2Ttu/eXf+auTFwTCoFz7DNImkyOGPL9rvUCYUbf8X37/Uw8//NB/fNe/bNhzO37bjx198YHD7/mjP5mN8swxAAhKRwUUHJ/PtV64iXh6vPi+3/75n3nj8qGyRgNeErT//I3X7v/bz9Gnv1AAKQGgSEjQ6On5XOoFA33pj3737bdc//a3HKvFCAUc1rK79baDv3Lz/tEnP8LIFAKIPFBEX+j3l9MZwGwuaA1zZEQAcYz1lu96wL3m9lJKYYOg4ekeTy4leuvr7O+P69eOe6DlicMcBRrOyAZDzMkAGLr9Z0ma5wyaNaMXnIjmWhhmG+D+5OH7Lj74lXzuKeTWAsO4yn1D2bowGeX9G5f83Xc30hY2yAlICPAzJCEUPpAaFMhSuFA8OwzPWaczPIAieqnhkApbVMXpD31x/W3/Wm943cOXBo+M5s3aRjCq+v2qN9i3+Or0U2859uTaAWMSeNSNtc6mpV9hs9xGXxTGRs5pTMwez4Lu9FzTeIs5aQ1GkVvM+esjPhObx87ymXPf2PjCvfTle4uzJzXMNzyNMaiHh8Itr1p+w4/2+9cv7gtvXpHlQ+UeX8AnRAfHULNAM2QGV2BKivDdH/5zBo2cR973kJ98jD6+wU9efGR4z+fnn/vo8Ny5sLxPh3uzq2rlRaOm2ZjJ/LyP5elTGPanN1w/O/ZivOTVb7rtth9/UcUENjhGFoMjg7GZA+NZ6MpzB90CZbr7jHzuIYuf/eTKJ97fmq299I5T174q1P1c9qZE83am7bxyutiv63Ue44I99fhrvv3o8rfv1Xrw1Ze99tg7f/Gdrz9YAA4ICsxblCUcGkmV/+7C8j1EGo9O0+987J7+nR8sT5166BVv02tuO9/M9w2kGPSYCp2LV4YasUBTrAd65vxT5jjK0mB6wyMnr3nga2flwRt/7l3v+KWfTw6SpSIHAxjCcM8CwnMG3Sh+7y/ufuC9f8JHbr14x8tqzXE0WywHmkvuM7lIKbmyapgdl4h5Pr64MZsViQZ9Wre45pYOMN/+4BdH99+955W3/tvf+40ZUAKlAYDQ8wSdMfdthUAtt+W01H7kaUb/Lz9z/5//5p+uvOJHZjdd6ybzum1pUCUji2pbA4D3HkCMcXLxIhG54J1zxgRjcuycm8f22IfeU/7wy//db/37QaFTKkuCS5Gehe5dFbQaGDkTc8tctpN56Nf6d/ee+u//+X/O77h19brbyjGpkyYIFCkZGwAQEQAzIyJVbZpG2qYsy7IsOXhmJjgxFZH5qYcq7NfP/6/Db/2xX/vVfyMFSgBIwHfn9FX1xQgg822OJSzZIPDJtcn73vP+VK8MDx9rompsp3muIrWxL6sO7uaxZqoqIiLiihCqMlSl956ZiU0ltc0suirt2Tf4J7944mOf+fU7P1M2mEgD1e+K+JlAEyxphvMKIFSi+K/v/v1LOay88Q2DkQuX2lnfJ7LKuI3ZkjhiBkFNs2gWEyWDZ+e8B5GoxpTm8/l0Op3NZm3bDvYeacPFSVqsXvfPPvXb7/nolx8ZMEXFs5ljzwQ6JI4eIYkCd37m49++99tLP/TytVZyBldFmxrX5JRlpJGbJCJ5a3Qx7kjCzKqac5acU0pt21qWwvnRbKyTDc+TS4MjK/tv+oPf+E+n27LwZfegvlfQChSh1RzYzSI+/YcfOHDdLSP2fpqnrDNKBEApTprCqHEppdTB7a7aMUQ7luScU8o5W06aokgyE6Q5NUmRZxtnF25/E6bzP/yDP96uDZ4Z99VzZtY5YcgFHO6791770oOnJGKmtfdZk8W2X1Tol0bOJ21TY7uHbo+UJabcxjifxRhV1cxSSqzmdbDm5gerpfNujOWX3/eRv7wwSs8c4+8G2nEFbgDV/JH3/9lBC6Gs106fHc9GdVX0vI/r49QkXe5NSBbzpmhsR7aLupl1/M4xpTZqFuec954YJapJSXVe3PBjnrE7eoAvFB/80PueF+jsiCIy5g8/de7EJz473LNo9Z45j0aji7lt4FicBdLQtqXjCWmOM2gkS2SJkUkicovc5hxFEpG54F3wzAyAyWkViqJQN3UjphQ3ZmO65tDpD344gYRILG/iMJiZYZeqPMNEzFAUCJ/667uwcfrc9bf7cnFhcTWpzdoYRY1dUps3MSZRo2xIalG0zRJFxaAgsAM7MSTRbFDibhNQSskxmkujhrKpUra0d+/xk+e+9IUvOYCZzUQVINBONX1m0AKDR6H2N399z3KvXDv60no43L//xl49kGxtk0SRxXJWMwKY2IMcyMEYxgoWo+3NyBGcKWUxURB7aF6/sMY5+34BUUdVu7K3Xj36+c/eRQaoKcxoK8C2C+fVI22FeT1+/4nHv/7NPfuuPZWQ8sy5sG91pQxOc7QUmSx49o5Ms2mGCUwYSiYmSXPMsSGTbuu+V0ndluYtM5aWljhp0zTUr129GJf2nzz+CAyqSmQgVoM9rd9w1colAI3w7/6/j+9de2xw+DWXzI5kl6anTJCamYiwdyEEH4KK5mbekRWAbkmHiZqZZTIzIzDzdpI3M1aEstyIbUihHg5Sr+hZuU6uOX02RfgyqCWQbpFjF0Geodxq739g7c8/9cV3lCkvHrDhAjfu4rmHN8ZkZt77oiiKonDBA0gpEdG23pFhG1zO2XvvvZeUk2QzY2bnHBmPxlOmPMzmFoJCZ2sXhfXJixuPnz5/9NheGMOU4MAENewg9lVBq9qffeSvFp86e8Pqwb9duXYhlJpy09TOGzOTY/Le2GcBEYWiTiqbITR0NwAzmBWhDCEwc84ZIuSdcw6AzOf1cGFYhdGFMUYb4m1jNPMXzk8Ux08+cd2xvUyOTDe9F+/i8VVBnxvHOz9x5+ulCUvXnTtw09GicHvDML+e7WLOuWkaETFCzhlAVVVGRESONh9nl7pVtaqqLnt7rwu9Xq/XizlPJpPKuWp1X5FlsLJfzj7x+GMnUh0WNHHZe+Ls2SahH4iIoDBAcSVoRTQ4B4JwFmhhhRju+eoTvB6P1Pr1O/7pwC2eGp2ZHn+cqpuP3biXHPcG/SQWc4KXHNNk1hBtPnfnXJdimNl7nzQlESFU/UE9GOSUm9nMRPqr1wTv5u04Ty9Omma4sroo6cTCkZX2iS+f5p+RiwOsWGDw1JSIe7s4nQFXOGyad0YWODjCiZOTpVLPHHrxqTpwvOAqCweW3GjjzBkZDAb94aAoihCCiOSQRSSltvNJqootS83MKSUzK8u6C/l8OvPOLS8vT2ZNbGUyGkk7i22LHHulP3L06Pihtcl07cLZuHoEJGidFdTn3aH2zkwJRlCzACfgTJCYn3jsgesWW7nph4r+omkDG15XHpmuTNfnoxgjplMXIzM7F7pJGYJLKXUQu1N3cuGcK8sylBURxRidc8SYzWaxmaU2zqdTkwSzFHNu5v1eXaxc++TXv3pq/PoXmWZhuLLrP+0cTJkd1JkyOzIwhQicPf3E2lOPHF28hVduH8Jny+O2baJpv1lZWqiqopuqAIjMTDRH51wIoaqquq7ruq6qqiiKDvHmzBMBUJbBEU0mozSfzSYjk8SwEEIIoYlpPJnygQMbDx1/4KEHYSwFDI4UT0vjTCKymSkF3lBAR3//zeLx+3jppqdceCpdiDOrjM/4aWgiEZGZ5pRSKynlGHOMKaUs0SDs4AN3m/PkPBXe55zb+SzHtplNR+sXR6P1FBuoQCU4NrMYIzMz83w+n+S0uLr/E+9978QsYV4Jg1R5N+js0DjbjFsGMryIe+DEv3joCa+VrJ+n8XpDftjOefytc/N2Op40TdM5zJxj285TalUVOSEnS1HaZuc2GW3k2EhqUzuX1EqOsZ23s+lkMumUR3KK8ybnyAxmtlmrh4+M7rnvo5/9ZAEPhbIw7crcHoCHgyoYFkBiQO6Pp+tanslpqnl56iPPbnji5E+e+vQHDr321MLhqlf3hoO66oMppZTaqKrz8XpnTbc53cm2L8qq3wu+VFV2ADS1TTObw6gsy5yzmYXCOVM4X/a9ZFxK/LKbbvrTd/+3n37TWxDbFMrSduVE7zO8I2RYIck5OCqgoeSPpScXz54oDhxSkGla9fKTk3P/O+lwOGTvCud9YB/KoihyKFS1X/A2Yu99l19EhEPZkVsJEtvpdOqIl5cXHRdlWc7nc5h69nE2jamty8qFsI967sbDzef+5pvHL73sloECuAK0eQCMYGU0OIxcKqIN9l07euWPfuvz//ea3s2zPcM0at5y/uRdvaO0cqjs1SmllCQI4MiM2IfAIYbCRFQEgDB3k88BwTlmVpPYtDEl8qEqC++9Zck5w9SZShtVldi1OYciT8qljfiSRb5r1jxq9HIfgWKX5rHZ1j0QAxbAzXRWHzn4r37hV3s333jqwj3NPN9YnlvND91/8GY7fCyE0DVics4iaas9I8y8rR5lWXrvu0TDzKq5k8IQQlmWzgVVJaKY03w+n7dNjDFtj2nLsVkPGN94fV0sk32HRognAAYigmcICrhp0uq2G19eL//j6uBds3ZjefXHLzzYn+WHX/yipQH5XBJRzNolavahk7NOkp1zXZtGO66Y5Ry7AgxqztMWbUygWVJWISL2nlUZRCA2XxONe2Vzy+1kfXT+1HYVApdb2EYAwxl81cee1aeOj66xhaWD+/YP5Ce+cv5zg6OP7jl8WCv1FMiBN5PIFZ9dCDs2byvM9gW3vwRg0pXu6pwj21Q0ZvahFwpXON4YHpqMBArPKVOx0yR5AFkyM4jZCKTo9YbR6Wg8mzmaruxfBN29fOCDywtBuA0UBF2vSETEFFCzzd5aJ2HbN3DZqXYuimA7vieDI8B5BjQroMxcFEXLYOQq8iiXG+N1cwfIoHSFnzYok2fqZqga2CFBeLZuTdPW5RpW3vuiH57qZKmd5Wnksu/YsXdG0LzZL+iQde6/A73pToGuOFBVMrDjLt4ikifjzX967qhvpGYmZMlsQbgfKZQZBGS6wox6GMwxuhLHsXmwIYDKqY2ToOgPm/Fa1etxHGf0xpUVtrMjszkPtwK8szbZYsWWchNMHQBTUkGczlVVSbuZ3ZULIuIGfQ+KLMNe2Lu/JgDs/G7J486wAoAoAAU0pQK8b5haG+d2NTsldi7XFGc2SB1fu87G9nzruHGZCVu4scPudbHvPKBzbnlhsa4qqOYYJaVuHjOzT4qMDWtd7ZeXSxiMHV9hmCxolQmZETxh5jFjFzDlabH0jZvfvIdT4znESZvg6qXkS1ZxBjIGGGAixyCCEjkzUoVZVwy4DnFiIe2HXLJxS6NWm1mRfvrC1966/o2juegvH8k+NzF6XaySz4V5XzSenYSDtV9eWWwSFBm0q/PEEJiHeBiMpWBUM5dGfb0gYsMBerUQM9EglCGpb1uAxUxhZqaAqibJMXW1lqjmbjPb/IZlbnYppvGGzpCWD+dL/+HLX1ij3tjwc6c+/Pb274rVZapclAsXWDu5JDYi6vWqylfeA09r7XmAATUAxCCvGWpTH2xtlsrBUuOLnBs248KjTWUowGwqKio7fDMAMnQVrZmBLpuyOq3MC6o5VsLzXnzHN7/9yvgVd/722y49eaFofurECdmb71y5jVV77kIP+9QSEdRsYVA5ckRgMPFuw0QOMPZmAhjDEwZpGB9+4rFHzzFKi7koPEFnmhpKAgp5W7O2tLmbbvlp7QlSAFk2IqqCG7F+0c4/vzw4Ub8GUnx2aXEkS8H3zg+tXOqJlP01ynmD0COYJh0O6q5JYyDaXQV4keQogIjIgGzg9nx6z7s/eOrIjUXVn8wzdUxQreuaneWm3ewBEKuqiHaNRpgHdHsiAjBjAK33So0hD8S5tv/hAy9ZnPWz3/AWxBvratWklE8VWepYPVaOFyMDSVWXlvtk1HEAu2eid86JdnqUPSdQgWuqjWMH19qWe0vIahZJ1KEYUJhP1mGsWws1nTIEZiI2MoDMpBPP7kbNDFgdNGcal2o7q1g4dFE3ipNuNGjDY8BA5Mk0buumn+owL+JiHABmJo7c3tUFJjbLoCtbBh5gJXiA2MFIACW84Sde+fhHHpzP2kAgJsBL0vF4ujFeizHmmFJqoZmZvS+8K+D4cqbRvNNVQ473m3Sul2KRl5oV4sw4g9mhOelKnk97GgJLUUZfl4ZxMV5KA5A6V+xZXiDASBmA0q7CNgOBFKowUvYg9KBvfvG1X7m//dZDj08ltZqVKIKFxA0HxcaGs+zMmYKZmUmklWik7ZYwS1c7beY5m86Wj+zXRltEZtQzx9fX3pfEEqZDkXlvIZOr40YzCAfmveRcl2CrulAFTMHAFWncd8LXtY03uUigcrhgF2djc54tWS7hrPCgWUiDpZyzy9lMHcjMWJMXNSx0nkQt01aTSTVrWKyZjHpUozAzK5g598mTGS3BuCImIiqKXsSUpbAUJRA3p0+NXnHTHhGXCYTWdUt2W/T4ziNJbmJeWFloZ9n5QkhVExOZEpFjR6pZzQzG5M2ZMZla55lAampkIGJiAlFXtXeJvuONwRwFeCZiAGbKIGby5EqEOD+/vFKrKMAE8G5PfVXQbTsv6wquJO/LomcmKWtROZLchdCky+HSPTkiEsmdNSXd9CfOObiuVUbbib37c86ZmNm5zW4qGdTMpE2qqqtL5Q1HDzAHkGZNhrCztL0q6Lqg4bA/EXWhLopCc4I670pybGYiTlhIM9R1UFRSZzEACEQJRGTcmVLqYnz57ERFqBTS3UC3CiMiqgbyNp7cfse1C0OnBoJ51t1tj6s31a87tCpxygTvvYnm1BqkM0k555xjzlGzdOYpxphSVBUz7WonVSNigLaXbrsKYHuAtDNWojnl2PGKnGcfKidvfPXLSlK7ytrcVSN9y5G9nGdFtShtTCmqtC5AcjRL3eogNgVOVdVUSY1gIqIpCSyEwLwj0zxtaEpExESac1Rl9r4IIYR5zjcfXHzlbTc6qDFMAbgs8M+GHtfuHbz01hu++uj6xvpaIeTKkCG5ZZN4+e7NaMvaqaQUJasAcBzYoCkrwWHTqWJH2MyMaVMfVRVg88LMQi6L3PGSY8MKmimRemYYX/HiylVB9zx+5LWvuvdbf7GxdqEwv7SyOG8baX2K006GjS6bZiJimIiYagghlJ7gRMREZQvlFRVDcJZS6irIEErmSmLKWcZNc/TIKgRd554BzYBPOwXkO4DuHmmEv+0o3nTHvv/z4JeePD9qRyt5OkrNZJamzjHzZhnL7ItQh1CKL81UcpPTXCQTcVEUoahgOefc1X9dZUlEIYRGqaqKvvOiWaeph2r//v379qzsHfhbDu8TDzbxMIDJs+2WvKu/7xEvcTG4OE733f+t4yceSe28593CsFbKReGrqvCBYSxiKYkKylAzwxEIGYBzzvnCe89kZtaB7jpPXYeE2AfP3ntmMJH3XJZlFYpUDEsPy8okzlFXauyutp7hzRpJMIMrAIAAE5DCFLadmXZ0fbpz8Fb/ygxGmwdu//od9hVmYN4BSaWz51stJFFxzils52tkV+W0cZAMD6jCYKoIIYgKbVK5k9iuCCdTogDbDIIR03b7bTskO2NjZo66KMJMzTY9LYE1tWB2HAComPMOUFVhvsyQq0Y6AgwQNKdYhAKAggVwl4V+e4cN5jdXsa3LJluR75YxLwdpe18t72jgMmx70U0BwLyKEXWlJmy3zbsqaLHMxLSJjE1gRuy2aohuwQ1dJ2tHJHdQ7/LDf/rYJulOzgAAks6DL3dmvW4lcufRV+e0AoCIusCbJ9WOr4rLseyiYgAUZgSmXT17BjI2Wzmdb9r9I9S61Hj5J7cFN+fo/eabY6q7bv4Z3stTYPM1+CQpOOc2g1sAsK3gEKj7J3Vr7tQd2Vm8rrzZHerNxs1OH3L5imYGcjHmovCAqinDbc6RnUdcHfQ/3PHCvV7/fRw/AP39Gj8A/f0aPwD9/Rr/HwzxAHEEsH4RAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAARfElEQVR4nO16TXNkyXXdOfdm5ntVKKDRPT1NkR7qyxYpW3KEFnaEw154LW+88S/x33F47Z1XXmnBhSO8cYQsi0FZokTKIsWPUU/PoAFU1XsvM++9XjwAjW4SZIcHHknhuYFFFaJe1slTJ+9nMiLw983kbxvA/419CfqLsi9Bf1H2Jegvyh4N9Dv+Pm7//l/Yo4Emeffa3Vtv5vZYi79jjymPO7Jbs+m4zFN1f8Tl39gjyyMieu+11lpra63W/q5sIj5/4vCYTK8K6d3NjNQI1lofcf07S4+1EBkAV9wkVQWAma+83lf857dHdnkRoapJC8kIkPxZMXz+DTwmaHd3dxEREXePCBF5FBG/Y495EEWE1Na9u4soyd57bRHB9QPufkPz5/Mqj+mn3yGVJMmVcjyqrB9f0xFvQiGJO9DAPYl/PvyPCPqNfEmSILEy7bcx5rHIfuSIuPK6CgO31N4n+1Hscb0HwnnfAL/DvX7mUch+RO+BOyXcYr6h/NHJfkzQ9w/cO4x+QfI4ri7AgfBuM9ARC/zggcC9fPkGjEfEUnuL6E6DUosZGDowwYSerd2t2C2Wu6fd3b1jXTcANEQ3a8v6bu7oNqPdx/ZzwuyN9QkiIVKRGSgBExyB0zUwxO1uuYrVa+2Hw0QVSMo5K6Mtc1K96ouq7jY7kaSAGbICAG8DTLx5wR6ePVMANoMHVJEYiADv0ftgwtTTJgUO1kNjS6IDs+lWOxCIoAcIMEAARKIkanF3ODro4a1KJ1I6YXfvzAkqLuz0ACNixE1klDsGQDWFAvSs1sGOhMYURHkfpmdgdMA9UpvrccMBWpqkfC8CB+AOEZCYjrXWCnhKaSxJBOGdpE3obpJT3oxQGGBArIu/WWglM0BCLlFPIAWyxqAFIVXye4Huy1XKZ3+9x3eu2g9eX+c0Ho79GMI+kzTSAmbm7qqacz44I4KIUtJYyp2zOw8rgl32Z4Ocqe/Uz0o+HYZFlpzzqFkBBcKdcBILMfQEYEpowBmA7hCHpF8OGubfPsh/+tPP/vilTy0n5WzzeDJiIZOC2qxX6womUVXd7YRkWF8zu1qbQ8xs0Z312do8KCR8LEUdIlJ4WbQMpYyaNaBhOcmQ0zf+wfDPd/jtYUHyhtE6RwVQwfLLQX8y4z/84f/6rjzfbl+0fZ/bYXda9q8+PZQzzSnI2ltEJNGshEdGZFEzI9QspsWYiln4ZtPNej1sTtKQ5WQ7TtO0HKeGoXez5vCIMEEMRcax9O7ffCH/Ytf+zVefDUQUVIBuRfQO24MH8T//FD88+TrSrr6eznbDy/3SfHM2foS+V1dHqJGUrWZFmPelBDK9BREd3hSapDNy/XTMyg23gxKSG6Y92z7Onm6r1S7uIlRQLA2aS/pI9I+O9Y9evpZ+9m8/Sm7XqmOqGSN+OejjBPb5Sc4XmqZX/XwYUvNLR01ZFSSMCZAOAdyIYtojLLIFnMqtBClQ61sIlHDNV1dXmodjLOl8W1Ob+zSe5kRPqhZxcjIE8XLys6SbfP5fLvD7v3lR5MkES6PfDykPgv7mi/n3h6fnEctZPjhsX4/XSx1G2yMkDLa419DG6Og97KKeAbBAa611s3AAjn5MgwBJPBcuecxpOM4pDxlAP9FxUAmIYOmWUnS3OaWXJWI4nR0v+9OPiIHRFPlehH0Q9L98ks+d9Wr/+vuvTkfqcvXkwxeWezxPgBNEKCLx9kQE59VFuXsAIhRJAKKJhFOI6IBCYZU6wDrcKQKzpqruIQkR0hP+5HD4wd7+9G/aJ/vnH51CNBZqvoftwYP4amrzZ6+GAcdXLy+Or69efvobv/t7Z0+/ppZBj7CARGj3iHCKqeY134gICdymSqaJAAQwb6qKkGaWc+ZNnwRmJklVRZVO5KWhGDB++4Ap4Z9tmuDAOMf7MF3kuD35ymuR/7bZ/e/pp7/9a9/4NT33KfJWk0rSJAyEIBx0kGGJBAgEwNvaxOjFARDhoWsalVxEwvtEKElSHE1FAVfYMm4HAyqe1GX2sE0EJNlbSB9k+j9+Et/94Sv08XX2Z2X3/VcXOvv5155xvtyWtCkYQ3JwS80SSt9oExFVFRFNFBFdF28wM+pNnVtKWVOkMdMsSKaUaq3DqGPOhLPIaWrPUX6y4AM5/PrJxiHh0Dce72Gmh8v5Rxqnw9Z7/YdV//tlT6Lz4bhMZTjJYlxaax2SwCSg2zHdloC2MrpWX5syHpdO9VLKNNWzs2TN27zsTsfDYQpiHPW4b6c7Pd9Rk84Hn60+D8tp8+9/k3ChwgL3MD8MmroZYtH9hX81Lj6ZuKvP2/Pri+V8tA1CXObW52rZNskYlOYNa54JkhQJAOE80ap+cMem7GjHcw7GdrTDxtl9yjmf5ELOu8AOweaRcR1YZFiIr+zE3TuspAqc3GF7MJ/+2F1ywZbDp+Py9Fm6LNWuylMyp9DSkKeInuAlmuLY/dhrBz2yVbGqresSqaosXSG7kNPjRMp2Ovac89Pz3dFqUJaKy2vLJx9+NtnF0UNHCflQylX3f/IEqYtQCmCxuY/t4dS0O0KIFEjTtJCiqiEZ4r27R4AiWHUZAHJKndak2xCA0COZbNLQfanePKg5CaLBF/NxSE/H7VHq9dWxR0gec06AT/M8bopV5gh5uKB8ELSZRUg3WvOL6RrCUornEn2urRuCVAdrtyAEXFoRRfNu1gBTkpTWRUXC1R2iyZSt1m4GGTbQkoYk5qLWKVqOS5+n/tUxMSLsJk1cpSp8SxEPgg7v7nRKEIvXzcluGNMCa+v5ogTEgW50uKp+hOXD7e5pHqUtCprqtfl1XTZb+kYtQBVVXWoD/LR41+uT09Npo93l0I6SVKIr2MLgZDAiSIkACcf7HcQkRiYV1VFFy5PNNqPv6wQkJlWkZmHdHViX/km2WetrD7ajIMAyUw6p/8qEnHNQrPeIINQjptq+pvpsm3pOS7fr2pRpHDabpN9pVVXUV2EIgPiZ0c2DoLebrB3Ww72NElkpzQVBEYq2oHtYBMkQBuB2/vIqftyn3kWIxEjCIZ/+8Xw9DEKKmZEOlQi69+9ofdZnBoLegwIrwTTbICbQIHvvYEKA4Dvu4kHQAvXevEdtNmzCrMEja3bA3Ky7WcAD1NUjix0hTJl53CoZrXpt3nwYswhEQCCiJ0ki0lprwcPSBmXK2G4Hs5bpMKsmSu8mc+0PwXsQdJ1qq0iSk2jJsZi629rocvNa3UJijdrmQTRlliwtfOqhKqkg6wJXl9ZdCYFEhKScVRliXdriZES1QYgOLUlDq4RIRsDC39T874KOmzxh7cGt/7XwS0/czGWK5v3g43mPGhzCLq32Q346yEdP8s5jZvzJp9On7flJfDo9waQ2uG8tzFiF1IHaRMSdFiEqFl28p4xCI6O691AsGMu2ee1SVQbIIingOw+neHh6J5w8GFwWVfOUQrfqjYePY/5r6y9rD8PJk/KPn2Zd/L/+eLlo0+9+ePTx4/3mw+V6GI9njtOXSS+3Sbbal6swj1szs25hDkBlLS4pANaBWHNzpPC3OlXvK4/1mY6FEXBFGpZ5j5BN0iean7tuy/XVHn922L7Stq1Dja+fa7taDnNU15PsOrLU4ySKJyFTBMFYhe8wepckSVQ8J1FBa2ZmLQwUSXB3Cj1ueoIr/EDwXm56ry6/t62ISD5vgC7DZd9G698Y/NkWT3Q8OVv+6lKf9/bvPvJLT9KXUeWvwvOz1JfhR9fHPztMPH9aPM1eDxvdxV2dACcQZASrbxISBYn0MAsLgblYEhUJAwT0eEAIDx5Ej23BNEnde/pIym+la+a2t/SXnxxKbK5dro+2Za5Gz9ojH6Yf/d72N76Wti8R37fDSZdTKZEErUZEwENkFYMbFrNCd9ekyElJd4c5avNCdRHcNAzt1l2/pZM3oO8fRJJL3y71aFG30n79tBTan4d97zjTX/yr8fV3pvqtT8fnSWpdKvybiR88O/+Dl68qR5Hds9q4UTrks9dxugkGApQghCQ9IqJZZDMVIZFUO6Jb771bzgqG4MY1IX5W1z+HaZKIKNKWmqjyLB9e7Ma/eZ3+wtNV0xfp8uPrT39nSC+e6kHyRny3uXZJaf76t+yTj3351fFsuNxfnGC/TbuzTe/h4reTAReQSgY91MCIUAYgBpfwCLbak5IqQvKB2cyD8vhgOHwsWXFyhjoyf3cvl5F+VcbWehtPp82HaX/8FX19qOXV8cMx15/o9amyV2s62wle6DBdL13QBXRC1j4uA1SqqK4hnXQg1tariISwuRVPAH7ByCDdbeZOGxEh4FmMU9PdydRyfHt/bLvN7shPri8/2Ina6f98ffG962W7nEyaX8vVV2r/5gc7y6VVpkXddD/I3Oy0Y5ZQ1RRy8xWyFgpuYSopi4o6xVOW6Fyap6EsdTCtZVjoOUJNscC39w7lg346pRrai/eTJabP9m2a29LrJje4gRAtpeScNXFQHYeSYPVwjb6MQyZR6wIgVBSUwFo+Aqi1124W6L4evnAHgqqqqhLIcy0BAy/asjCgoo7SlveSxyi108YoT9P24JeFKfU6JViPKWpEJHdgobFoK6KZUbxvUhmUCIN5EnX3nIRkeDcHAELdonULYbeo5gRFmClOV4msmgQq0juCuial6a22xy/Q9FictYOg5pPtSSnPF5jO26w05ojd2j2NNmqcpmToT7a7DK11dq/DuCEZtWYy59zMp7p0C82FFO8Wgdpckyayu0R3AKWUo9TihuZb6OhoDlGQb2WnD4L++sl2JA6Gn3o9DihRz0uSpOoAPRl2olqQDA4U+L72NG597pd1vzbuwz1KpjfAh5zMzJba6yIpp5R6mFn0Fpa0W/TeUkrDkOfovTvChyGBQII7QH+vIuB5knPVi9mD3dRlmbe+VYslIip6p1IiQUK8+2S2N9v0dr20vZuUIbpFRD7ZlIjWzczKkFX1OC+9NaqrJiDc0S3cjeEQGzA8SaNV7PvcCmdmQrIAlvA+fY9dWp5nebWf2ibT47C0PSAdkbWvPyjRLRywkHC99nScWrewkkUUzVLAe2URCQ/nOmpJQigjjCEqSmhrnURSWmBpNbug+pjsPA+cDxjG8Ey8X424G/zZkL0u3AzqcN1cRVIPeps7bfHuNmuHBHvyIMrgrUGFWTswQrNyPy9iODs7S1qurq72+wOAkgcRqS3WdpSZiYAlAZhrO2aeurzY7v7pizLIBPPFeyrpvjwenrl0/8OfXn3rx8f/sddXPgp021tpx88qoAmAB5ubOYJwYGKWcMLFu5olmpJZ2Zd6ktLZWK4vLqZm6fTplaulUSWBkVJKQoGTMZQ8juVfx/f+0bOz33l+9uGp5uKS0yAD365sf8Ecsc+T//DKfnBZf3g1fXI4zL0647qlCEaEOQyBoCRV1WfRlZKVRSKpjElL0iz6FJ9l4ZOTrbXWHVGGi6WH5H0qAJQUEYRFWEmplPTVs/Fc9Ll4obFAhzFRaO8H+gpzAkqX5IBJC5qoJYyYcTNmBQCKqGZVXQDiZoy2Thdvky/02lK+cbRBtACIDODu8krYeo8IYKUUAK0j3JOEJAGi3x9uPQx6/a/1SpiqggKIO0C5ywrWR9czYmz3DsubKzbC3LuD6o4QisC9J016+zjvfx+BmIAEEJSgrGMLekDe5CIPy6M6VFbG1uyQcMCxtk9uvuYWp4eHkKTcorhbNTpC3nQBCERDBLT8nGtC62wcCkis82e6rkkV3gTFB0Ev2CcMgrwGo8A6Bje753DkBgZxNyN/OzWLQEOovBXQCAQi4ebG5C1uuXlL4vZi1g0D0SKcMvxy0FgH/wEPuqiBFW6IJ7cn4ubHvZPK3b2lt4EHGsG7qT1vdkf5GW97s+uVI0LuXiMsepL3YNoNcqMmowOR8e6vtC7gNzt4N/+9nX17AtYZOm7Qrh9HgLydiq8JN95dygn3SPr29OIXMf131/7/vqn+RdqXoL8o+xL0F2V/L0H/H7ZXz34C2smNAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAh5klEQVR4nK2bd5Bd133ff6fc+t59vW1vWOxi0QsJEARAEiLBYlGiHCtjy3Ek94xcJhNPMvb4n8wkGUeTzNgzcTKeUbHk2FalaElsokixgSBAdGBRF9vL6/W+9247JX8sBYO0AIFgzh+7Z96ce8/n/uZ32u98f0hKCR+xSAkIgZQSIQQAQgDGd2rPGMMY41sa3Xz23sode7tNWe/uZ8RCSn6HxlJKSqkQAgA4577v33z2ngv66JYW658qhLhpPCEYxvQOz9xq2o9pZgC4U08/t/iep2oaCMT8QFVVAAAspRACxE2mD+H6vm+aJudcCKEoihCCEPJxoO/F0lJKhN7vlTFGKb71l39ZOJeEoPWRwJigFK/X77l8ZEsDwNmz5+v1pu8xVVUl8EgkrCjEdf1b29y0BUKEc95oNBBCpmkyxvbs2ROPR+8d+R4sXSgVf/LKa0IAxsQ0Tc5Zt9tutupOp/sh3PV6NtszMjIipSSEOI5TLpdHR0cPHNj/cTz7I1t6ZW2tUq9Z4Zjv+I4XaJric9ZxHPRB1pv1ZrO5uLjoeV4QBKqqIoSmp6d37NgRChn3zH17SwsJGAGABBACQHJCEEi+uLJq6oZCMYAMAmaa4YXF5e9877vtLiGEYIzXX4gQCCGEEFOT/Y88dAgkVwgOPN8PGEKkb3DADEd+9oXr/YDrurqu3s0sfHtoCYDe/w/vV8Xy0sIPf/RC27Zdt2uoGkIokc5gRAWgVrPEOeecAwCllFAkhGCMReM5lRK71QoCz+s6WFEBkbGxsc985jOEEM/zdF2Hn82DQRAoivILoe/kHpzz9blJCODMVxRSqzWsUGRwYEAllFJqGEY8nrxy7Vq1Wu+iqCQSCGCMEaUcIAgCT/h+uXzkyJF6tVYqlRRFadmdlXyhUKlTQgFA19Ug8BRFQQjbtm1Z1i8kviM0gvW1QwpBMOYACBFApNmxy/WqYJxS2ul0fJ+l0umDBw/2ZHsVRdE0TVVVRcE3ffWnb7/9gx+94HmeYYQ67W7ICrs+77iB57qarge+rygK55wQsCyLMUbpLx5mt21xc5RwzjHGqqr6vu/7PlVVqmuMCd/3FdNiyFEM8/rs3OyNM0IAf7/I9ccRQl1ficVTrVZL0YyIGgKAqKFKRJvNTkbXEaaA0M3heDfEcAeflgAgJUKSM8Y5X15Zq9ebpXLZYb7v+wKwEIIxXigU0okEIWQln/c8z/eYlBJjjBBZH4j9vTkWCCah3emGw2HLspxON5VKcadjt+u7d+86cGAfen81xUHAFeUXL5Z3+jLGmKKQVqu1sLBQrtR8n3EBmUTS7jpSAJcCAEufKYoSNg0WE77v+z5DCKH3P0kIIQCr4YjheH40ljT0EALRm8kCgEs1l/F/+uGPipXiv3rm05wxSrFC72p5v717gKSUAsiVlZW5ublsrjeVCjeadkg3KFakBM9nCCEt2+u63XQqKUIJxpgQAAAICMZYVTVFUXjXFiClQIqmqlRRFRIJm4Lxmt3tGxxoNuvvvnvikYcOJuMJ13V1Tf9Y0AH4iIMKmm+DaSaIHtIMNeJTPaqHpO533UjID1tJnynVVtlK4wGaqBZWR4eH5uaXc339KwvzWyaHyvm8sWWsVKpZZjJsxDiXXuCGLKPttDGrJIY2T7Ye+emPv/ne6ZePPPo5leggmkB+8Qp/W2iNq0BRl7GyW4xHtXRY9aTKjWxITwSsHUpqsXikVFwywgjK3sw73Ik3Fmo+n5nBwMxCyQ5CF1mHNGrhgkhFsK41AtnGqtKb6/E9qWF9GcL9MewPRi8PTkxfazx5OACkMBK9m5F4+zYSAQg/sBUFG6EIQiZGkrGWiqLRKC8W5k9dcs9ds69Vg6oMcSMdXPdxJJWm7u8e2WnXqy+dnsnFenZvP+S1CgWHzi8T7LVGzPZU3wpCIj44aAH4gkdS5ifu2/Xaqz+uN4JYXAHuADHuHdqHQAXB61XR4UomKzQNeeUIKudrxelj7OgZe6bCbDBpKKNbxFC68RABi6iq9fKl64BIK5q57vqdG4t92b5suL6jnzkinGepH62UY9DZCcue46pGKGKwDX7Pcawvr5VDiSGF3NXu7bbQmILgwHylN91jqILJNkaoXmHffvU810Zv1Mlcs6PFjfFcnHVqY/FoqdaN6Z4BGBlhLRz18ossJBbaqNi9ohuRi3VrzMKbM2RyPFnwEj+ZKw2q0U676bgNKz2248FH28V5OhnxaPxuRuJtoSkgBtpy3QmCroWk78u3Tix/49tv2W7ut75435UXvr13Yrxa60b8pUC2Wvl630Act6/0aNgrtYx2eJspm4VLoFuBknVr3MVK1Oh97QqT3eLkWPTR3WMzS5VvvnR203h2XwrSCePqpQKm993lnvMOuzyQGM6ePR+JaHa7+/fff/0npwqePlBZnVF0bc+eg+2WPdinRPRafzKCfa1ot1ykd3yBqOIK2g6IipghuqpoRS2V6lTNDrdIMpHoH41bVmCbUfXUhUpCd3J4ac/GyXLTGRrrTRom0j7GhsnD4NUL2M1XbPNrz50+er2tZCYcr/3Q4Yevnj0ZFwtbx9VkbvBGOXy0RJoQUJ4uu4Rwr4+0OXgNlEQSZ6Ab4PGFkq2hprl8ZiRtmXZPx9vc1LOC+ZIbO7aOrMx31mwHt6t2XiQnNt+VpQPpU6kAAPAmUNNjCqUAwAKgQXV+/lr5r/7xnRfWghjFOapsGM9cXV7ZNWBOjm44U87PtrICOsh2vVaJNGymgKHx1lKFcx4dSLkuJgwJM4Qtjcejkma17uy45oRpX2ZLUhk90ihVfn2CjeXol1/vDATTjx3aGk4PAwCTgBEgwTDCIAAI5gC3LpWISR8LBSEA5HEhMdIBQRDYRLEuv/f2V7763Leuqb0p1cHhA5vHLp19+8ih3V4sdmympZh9repVVu2GA9mXRaF4qtquUCEyhlQUZbHmYlWLqJFWt95t2pUyd/Ww3t/rBlLrFCZTyNKtqcd+JR6SSj04cij3d69WtpJLk8NxGsu2O53llcWDBx7CQBDGQgJHoNxyxEFS+gAKSAAkvMDXqA4AINqVWufr/+drC3Tjaq29kG/u6Een5pZ+7eknl+v16QoOlCD/3oUkXzz4wC93Am9lubywYre9Om+LXZNKOBx+/d2SlbUwU7NpmuixeiKJmXM/LrRVbfgAirNGvvpwRoYGYsnt/3ZDzElQJZKN/vS7zz/zcJ+hSkSIzwJVNzeMT3U7vhlSf3YguQnNPUBqwAFTQEKA5BgkY+73nnv5L7763o7776/azdpaieD6088cPLmizLcN6U6z+fzBvo1btzmvHS+88k6dhLChRHxhp7TeWv4HYcMk1mEH1bmvYKaiiIiEm3tGUJ/Zf2GxfiK/NrjpM4XFNzclwhNbR/o3H1hda/7RwcFGOPbDl9471FvauX1zIIJ8odI3OJ7N5RgTCoVbj2EUAAECBlIFhDGWzAOiXL629K1XzlVl5O3jp+7bOdwzlonmxmfz9aLXC/UZpVL8pfsPXrhwrnwmttZczqQlFxsY7VAkPNbJ9MQQQl3uYi3QNY0zHsEgOtUa33XqYvng/j49qpx778exvbuv58vGpXdqPPzQ3v1HZ5sCLSzXu80kXcxXh/rTGJCmaV4AmoLhZ5Ggm9BKwH2FqgAAXCCC7a77/KvvvrcsUjqj8f5WcSE5PqnoytVSXDTzoeLq4UOb3n7j2sWlVjjU8BrnItZOF3HJNKBEIqNcDwshrHRICgmgc1nx6ytO98Zlr7ej9j778qlPP3Rw197ImxdPy2z8lL1x2+U3rlO5Gh2Jt93f+dS2F37w8tXZxQe2Dj165BOAVS5ACkAiAKrdhMYAILEEEBjWD7Pi9LlLb564LIXiCG9IbwdaangwejzP1AB1lq49efjg86/MXyjPqiaPkh6DDNnBipAqAp8Q0uF2NDmW7tnU8ZuKrjHuhPVM0a8YyZ6IqkSCbi664fsvHzNzw3tHkiHHralmZY1du3o0ChbJDevMjw7vsVlo+trCyvy82+4QBBjDh+JRWAggiAAI3+WAIHCc986cXy22IgRymWilWj44mTldA8W0irNznzyw5603TixUuzJOQLFaXc6VzUKisL+MkGzaLY5YuRbYXeJLv9PpCB74jqfEEr62yWOKFvVtzuJW9PQ/vTYy1BcC2ucUF0PxIO/a13+6Vlj9n3/74otvnpmeXVvNV77/7D9dOH/2ZpzqA+4hKRApOVIEYQDOylL19Xfnat0gFcEsCHrSmp/oXVsQLH99k3oDPOXdlSCs6GoLBX6VYddzVc16uAnVQSOxa3PWYyUA0CElhGi4FYHp3GpVEw8qVPNgSRdaiKc8aTSs5enFpZh/nnWjNLtvtq35hfdWmwjnxfYhr63T1aqfS9nfefbY8Ggikxn3iKLdCg0AwvdBU1SFgkDnpq9gRT944KHpa7PUl9mBoZVWV8dm13VzQ2NmdGgIv8iDtE1zXihtIZ4x2NLqQgWp+59M7nuwt9OKqxAyDSYF8uREl9vt750ulle6moYM0Wj7MeoqwSJ3zlqhXx3b8XCt47xwcS0SiklpObUCdkLjE5v6Jw59/Utf2jQUxUicOnnpqae2MGDarbMHBhDrQRnBpeufvzJbanVJ2LUsbSCqJvsGZwtuZWXxvuH+dtD8m7/7yUCohwV2x613vUjHWf43v7ZxeGDrN344e+bMmbOnrw0PjnDfxoIJCbbPzGja9XzTiDlOIAE0Krifr+Xnk+H4iWOXB4YS9+8bSM8tNzttzEUqLUnCeu4H379//8FGM1hYXk1Ho9evLj71GKyv0je3SRSBIIrCAJjvte323GpltdSoVFujY0Mm4Wv1NjPSMaWeMMgPTlxzZORaB3pDiaGour0n3LDj56ev/Mc//J1PHXnwP/z3r7z5pnN1uhTgqhWKOF1mhrS1/CINaYHTSUcjG4f7YlHcssurMbVa9ZJacq7QnGjbo9n4laWGQCmD2afOnSSiefn013OpSKHc6k0FudwYKIDBBdBvRhowgACEAUBVSKVcWyrWu4HUVa3dqEsZaLGs3eXSbSgIO4GKgPSmMlsOjD7xuQMP7d3zyU/8Su/kvv/77EuJUPZL/+n3H3lAlaJihvs6qMOURrvdChkCvOaBvSNPPTk5MKzk+rMTW3bt/cQj6Y0Z13WJGqnU3Z6YwYXnCFUVQSyium2mGPGW7QXcmNjYv2Pr1Fq+QuEDcWQsQUqgAIAxKeaL9ZaHqJGIhIGxaG+m7Um7UOvLRuptZ2m5mojwz+6Oq8x68c3Z41fPLZaWy3byH1+4/Jdf/l8vPffKwo0LD9zXLx1H2Cissw1j0VZVPryjl3je9PTyctlR4sl8o7O8XI1oUTNCVSwWFpvRsKIr1EWi67KQjoBjgyJAbGWlZjfKkYh66er5b3ztq7duoSmSwNetzkWj1ux6QkokfI8SHJhau82MgGuUL5camXTfzon4ar594srV7NimhWqdsVCt06Xh8NELJcqvCRkuLZ+d6EtevZJXVCmZls7kOG/OXQvUcE+SBqXCnNthXkcEHVUzOG07rmMYphKipC39AFSNelpEmxjOjG3cfeytZ3UF9470twIsO831K7L12CIFRAImKUWAEGPMcTxBQCM4EByFwrylIMcd6M9evDqNBOJe4eXVjt/1o8sLiLZrVej68W5VKmHDzBhSa4Dd1HHx889MnD7vnJ1uZyac8zeW3a4WZrVqZR65UyFrS36l7EGLOU2d6i4KVasVFHDVUgQoCLq53rgZYtms5Tge83wAoSiKrsTW47EYY4QQBoF16XsgACuN1srBPQ/87tO72536aBZpLi/RkNSc2tl3n9o5PpjpVNvUzNeY7S6szutozWqXqzPXK4WLzUorIeSlBVJqVet+qetWrbDn6zHP7hhB7MC++OR4plyox+LhlcXrjdWLD24cGbB6feQ++UCiUzkncElvp0VAWVBdvrRy9MLKN587FlPSldpifrZcL8/nG3OM+Qi9H17EEq3PJQIATNMqFNaWi9V031CdKToWqNtwPB/06PXVWq2LEmEzu9GiES3V0990ysXWUjydiqSjRs6zSd2KE+b0SZycX66V8ovjo02Fqz6szcx2Z1fopq2fvXKjqIZsK5V558ylfH2JaObxEzMbNj6omUnXryuEYYxVnXNhl25MO24jHk/2jIwlkxldC6/b+H2fFgiIQiggALDCyYWF1y/n87l0SjU0ygJLOp1QMpTJXLxUKNuQiCQnt2ztGao120GjDBgsSaIbk9r2DRtPXD7WbrDhXhP07OVrczqsDA708r5sNNJ7Zb6CwnJk02bwU8XSTCLd72Lbba11HaVpc4ZyviiGLCLB77rMDZpD46PRTZPNmWMdJ1hbXLoxOz8/t0QpXYeWUmIAAAQEsAiCVDIbi5kM62o4EjBJQYYorTq47sr+XLbjw6Wra6m4QJzX6lq07wEttdlj0VQ07Tqzy7M9CSOSyIhOoKQG9mYye0sLuFxr9eWULVtG+4c2VuqdqS27e3MjqoE9hgSOtzt+biDTdHi17SsqIogSrE9MTG7etGVq4wQmrK9vvOV0Mj25L37xi5TSm3etFIOQgCgggWUkGk/F9YUCcjutkKZUKw09MQhGbKW6tKUvpWIodODV18oPP947tIEVK1LTjPBm1rWLr/207naCQ/vdofGNSE8YSsQpcN9bfvHE27OXgrGdQwOpSNf3yuV8KrY12+seP322XLcIciNR38c+qHoQOAhoqWID6wZEyYZjyXikWGwVq7W9+7apinnrVQxFAAwIlUAojkQiiSiIJY+3vVCkt2I7mX6aTJqV/JJBWV9CaTtw6vJSvnx+7/Ydvblwq52vzBlvHL/skHjWaKRj/WsrIYRDhsUcx0goY2NjpT/7zcfXiv5Xv3E0krNiKaVZL1RuzNaXZIDCYY309oUWinmiGhjbmJOAqRD4c1du5DF94kBmabXWfOvooYfuv/UMgBCiIDEgkByA8lQmuXNqsCDIVEadrTkB5wloaVytY8MR/paR9KvvXrt/Z2rP5i3f/9ZZn6Ql5dJhusUwWdq2PVMt0xu1RiokOmslPTmSz9vY7F6eee9XP/MH1bzzP/76WQ+5Aba79lu9UYTV3VFTy8QSR9+7zkncCAun3O4bGktacuPk+InX3ohGZciMJjJpBkADibR/3p1i4AIApAQOkob0vp5ENKxbGur4olCqqU5pMGPReM+V+aXxoewTjzw4lfGp46uRuJP17IRtJLLUJ7vHQvFYKprK1dq40jxdrd3wRaTeWhxJj/3D1y48/91Tv/UbB/7o3z+BQ3UaZtnU1lYRpqYS/bn44swq801VD8fi2srygusFW7aNbN8+noiHhkd7SpXa1NRmBAr6YLAdSS493lUVFXEKPJhdmv3j//zXp2b83GBqMKHHEE4devTYjaZYKcSXX9r34IG/fSnvM0XiwLKQ7/hY0KEMzkVa5aaxUJ4BFtZleXLr4NwKrTY8k9KeTLTbLfy3P/vzTzyc/ou//OGXn1vARtls9iX7ynFSmV4M4Q37A97KoJWEllVi5sO7+q6uOgsnXtnVA5N79/z6F35HEQwh9dbjOAYJhBAOEjAAIalUat/u7XEDOrZQFbi4VBzy81MpIzvQdyOyGRMrnhBEa4Ro2+w0VL8LGi47QcehshW4FRalSQ202lrFxFHqaYag4RjudPU//69funaj+Cd/+GtTOenX1BKUx7Zsx8mdXjanMPdQdpG6bssK9/b2Tk3taa1dmxhLP/LEY7/5+d8OPIGwCugDB1sMIAgmcn2VQTIajTyyf89QUnG6bHrmxuP7py5Ozz+aFVWGMpM73pl3n9q33cTSlVbdDenQ2TvaycTthhbfcWjgs7/1TKSnP7vhvi7NKMnU0PbeZ75wwAz1a7q3vDT3hd/7qx+/8+ojD29gVWP/wZzwvZNzdRkbk3jN6aA9hw+ObRjYlBDH3jk5FsebxtKPPPU0SBJSqATg4H0QGnEAjIAIAAkSENq6cWT/zuFUOv6vn/xEvh6sra2dmy8/tTGiS1YLD+Yb3acPHzIpNDHVk6En7h/ePZxeLQWx1IArfDORjmc2T24/DGaIhNVGJ1ioNUsLfjYmF/Orv/8nz337xZ8+8yujA2b62JkZMzWUwu2dk9EVGC4HsClNP/2pTzYaazvG0o8e2L9crINk0uswCRiUD0JjuCm+QBhAkmgs8snHHtw9pHJpnL5ayE1tO3H5Sipo7U5hYoVPNL2laulzj2/bMtCJJLU3T1fnZhRSV84fXe5NpDcM6mP92qE9wzsm4ht6+q6/V5vPt2KpYV1J7d+3NaInctkJX3Gef3Ma9281JN6WswMbHji8N6eEdFn73z86vWVTLhbSejIDnisvXDiDNI4RfChQigEABCIAGAIAEByBxNu2b35yR+I7L70OSLmer27oDX33+dcfGO8dsYK+oclFN3702srjD45/7sguqcTfvLCMVHTx2tqbx84gGtIM4+rV65iaa8XW5evLMsAdxV8sRwd7+j/9WDqmp187UbO2bNelN5HzaShJ+7YqAp64f2Ksf7xZWx1I0qntu0vlemDXM5kUYMICH30wHI2YDIikACDBQYgypiAAQgO7UPwvX/3WP7xRjKPCwMate0dHTl+/+ktPPn3hWvmGYzbaNpt/c8hob9998Ox87cbyatDEy+UVVWRHs9roeOaNEwuCIIOyeDTQjYH7d+85c/rv11bLofR+qz8nFLItJWk4iGW3FVslA8V3DiJWLO5/cLxTXDSj2asXzh24b9fQph0cAQEBct0N/hmaE4lBAkAHsCqlIgAAfCLVc5eP/eVXXplt0Kf2b3/33JXB4dTi2ZmnPv3YTJefWQmAx/38ksGWcgkaMi2fBR0Xdct8OFuc3Nz78mttRoy+XggFtAl8Pt9sdB29b4jpuQgPtqWDruyu6ckHh8wHe3rKVvzNt27sz7Qf3p3sH9pc44pXW+oJqxAe8BBojAN1AUK3zNN3kE5A4+ixd7/1wwsksfMnx06MjKbTERVVK9nJyLZt+9483boR6L7niOIq79bC2ONCJC1cL6x22n5/37AncMXhvkvcuEWiUUQiJpE70/Ws5pf9tNGTmGvJIb/9uUf2vTN3fTjMJnQ3unFrLpG4uVz/fLA7QDd9J6oYF868V6g3/+abr0zPOZLQ3l5zeGTz2+8c3dqXe/zwoXZIz7c7C2uiQYcCu8BZF1ib2zVd0YEaLQ9Cqd4uiF7DUZiTRrAh5NS8TjU+5CjWI309lumdbPilwtoXxqi07ZYa/8zjD0hE7x26C2AANFbXrlw9oyRzX/32628cu/ipzzx9+drcC68vg2CjY5H79m4d7wmN9iQLttr0Sd3xa4y6oOgIqdwlwlXBtULcaJeNcLLGdGLGIdK7UitnwvZIOv741JaX3vppxNJ++/D+7zz37XB//+M7dlArfGdiuMOdCxLg+V0zrLsuJr73e59/tC+tBY63Z2Lk1Z9cn9o+sGfv6OW57sJsbag/r8TSG02S0PiEFaaqojG36zOumq16xSAh1rNtzXFlTBGe/1Ca7YiF317lpfLy86/mf+O+gZiBTs6W3r66+u+2jiph424uEm8LbSABusKJisMxLRQC2T2yf2d5xf3yiy8mze5v/NJ9ZlxZKNfLjGupZNtj352x901m22XP99qbe2OrTbdCQn3ZPVmFJyIxO79cYkHU1EbiVAVyKl97tH88EvO5hVg0uTB90uRBT3QUwAMw7x0aoA0sIgjQsFqultKRdDZhxvXqH37+cO2Xk1cuz5cda6Ve3jA8tHcsXZhd9uJaT5iUNavaouFwOKdHqNA10ezS2OGkvX9k9OvHi76Dj18vjKfgs5uFBUGrW41MPLiysFJbvpTU3VRvWgBDd6FEvYMcSPO5IBQbCm60PGzpjbZDFBiImqP9oRQkiJnmrOHyqqEP2zSUjIkd432z+armVg9vnlpsBi9dLii6wN3uUhOiojOGm/eNphXRGtkwko6Z52dnEETdmpu/fmNuNr9n12YuOpKGyM8bYx8Sw93+HpFrRGMYvP5kbvXyqtdtkpDaDnTsW+kefdcDm7xity8xZUXNt09e2zWRbTX87splLhPYys3la003GIlrWahNRiPLvj3VS4Z9d2hjCkLDvm0zFsMtrnFvrrF8rDhbrrZ7e8aIqoEXwMe5/KTAkcAIG7EUZmpQblZTSooK0fGa3VLihu+buiGp2Wnx0Q0jVFPbVjMSSQ81GpGI0e12hkMklUrl887IaO76y+eLUUMxBi7NFzBIHviJmH253DA0nTcbhenrCImBkWEpAKk/X1nzIYe5LfR6AEpKqShKIpHI5/O6rhNC6vW6pmm+61bLNc/zAKFas4Ex1TStOzvXbrcppZ7nEUI0TWu32++dPCkxOXrsHcf3IlYMgwiFTFVR6radyWSuTE8vLc5vndo8MDCAMJJCIPSLxYS3hV4XiQEAxri/v79YLLquyzl3HKdYLAeuxxjzPM/zgtVCPp1OG6a5uLgYBEEQBOtvWI++scCJRGII00Bw3/fXtX6aplKQp+dn283W5MYNf/xHf4AQAinRnSXvd2npdaHchg0bpJT5fH5hYSGQIgiaImDr8lHGWKvVMk2z3W6VSwWMse/7iqJIKRljmqYRKQiSGPF6o15nVcuypJQtKVNRc+fWKcuynnjiCcYYxgBApJR3Iz697Yp4U4h+iw5SYIxffvUn169etW2bB4wx0el2bdue3Dw13N/TbrfXNd2apt0Mchqaadv2yZMnK5WKYRgSYSGE6wWbJob+9E//FN2ib+dc3qUY/PYiFYwZYwCwriIGAM/zVFUlSDZqVdd1QUqMKCUomYipFG8cH6eUEkIQQoQQzvl6KoDT9S5dvDjY39uTTmGMBUhCFKIovX05hEjg+5TSda8ghHApyMfxafgXekRN0zDGmXRycmI8FAp1WramGaYVJoSsrq1979kfrHvFemNCyPo3tzudRDx+5LFHKIJWs0koZYw1Gq1UrgcQoQq+GaETwPBdEN8JWgixrrtcn9jXnZsxlkokjlcrjVoVBFBqLy8vJhKJZrMRTaSllDdFm4ZhrHtL3AzFYpFzFy+4nbauKo7jROPxVsvesmM351IIoShEgEQI4btOBfnISnUm+MWLF9djmKqqUko558ePHz/+7qn1BlLK9Xeu/w0C7/HHH7///vs9z2s0GqZplstlz/OefOLIR+r31vKRleqSi/nZuZmZGU3TfN93XTccDhuGMToy9C/zLgAAIbm6svSNy9Occ9M0HccRQhw5cu/E9wKtKMrg4KDneaZpep6XTCZd111aWup07PUGt65e6971wAMPxONx27bX5xaM8f79+z8O9Ed3Dz/wfb9UKjHGXNfVdV1KaVkWF8GHoNcrhJBut7ueSEQIkVKqqjo4NHRvyUz3CA0SAt8nhGBCpBAIIUBICnH7NBcQnOP1mf5nFSkEumMG0v9n6JuyfcdxDMNYT8rCGN8ug2s9aWc9P0BV1Y+fA3Uv0HALN/xsnb81j+tDxfM8TftnCQHn/P0bqrvbZvzc8pGhb7YWUiCEEPxis3Eu10ckIWg9JUoIIPfODP8P5ESJILBgJpQAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAANb0lEQVR4nO1ayY4kS1Y9dzBzj4jMGhE0SCDeUy8QiN9AQnwuv8CCFSxYwGNQI+hBTfWrqhzCw83sDiw8h8jqejQCKRFSnkUozMLM/Ngd7F67HpSZ+P8G/r8m8D/BC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp54JmJhFlJogAOMJgDFZQAIAEwAABjAAQGUIKIJCOIKRAaaudPJRQiIBtSIIemkDcPQWZSaD77wAA2YYYGZACpIOzQGAEg83QB9KU6QCQnBEUBCEkEBvbDXzHAEBuLUYCBJBtcxHsso17mHUHS2YCA5nIBG+DAsyPIxOPBSPuggIQ7mgYQAlylDPStp4gLFrvOG1DE1m2PT0+PoBMBN91cgKEpDua53Z2LvGHBQhPQIlNu3T2QwBiADBodWGCAilIQgrK2VzPzEihQBrg4UosxAoC4m4Hdw/lBCdWQBgFCGSAEiAHy6axrzDks32c98c966e7wWaYDsBBgDKQYczn5hGZAAhxRpEBoGQi7zqRJNvyAgtIgnjTQ1gQgoXSNxuNM6EnQKBNf5RPhEpAPqoEibs934L3yAlEjgjmh8XkbG6zLAICcnRiAtH9dAYTmEB3BozcDNNBuiaYUe953WnlqcwyEbizXbrryc3viSiSH/yQn0xsQMAYELAaA3CBE+ojacsUAJEAQOSExcGCQzaAOmhAMlPhlZKR4eX70T92A9OeaUfMoBSipNiQRER+3zx/2NajzCICHSLCCffBRFWViOCxk4pIEA/BtWPY8rbkZQXo8GhAkg6iTED4JvHXf/8vf/Ov/+bT/Ee/98312v7jZv289kBeTuXdRX09T7/4ZD89Hn++HEfmpcgeJBkG6nNxd7d0JECR6Z4jfJoUgBBlprtHBDOrqhCrKjx6OyFyKsIgs84zSwqzrOanm+sfSf7FH//4z/70mzPrgHaiCibahO1/+d3HX14dlwl/9ZO/XRi/O7+6iXUqMqV+0PTF95UpOB1jvYmZv8/wsh9Zrz9fTeCSxFUaZ/dQEU2a4aN7MrXRt4N1WRYRKZNOdSe1jmGtNXNPRMAl6TBffLz6NKuw8z+M0+Wbn//5n3xzfjwpn7Xc3ZGesa79XSkjRoMv5KtZWY9dZDZ5d3j789vrn11/VvJ3LjX52vuRyoh2qLOCxuqhLFONyOPabgWtNc8Yw1W11trM+rLMXnVYnnh09wympAjzXmsVG448je6rW/bT6F8EbiXchS0wjZ4ioqqjeY/RRpeEc5qPdly6Csv+777/91cy/3491Kqf1tuP3j4fm/CMAl8WYdZSiMiHESBEgzCIEtxitN5RShZZV0OjwgrmE6VHFIDdvftp3Fps3pMD4cjbtfXIeuatCiAziDiBboNYS5nQ+lGMA5L0NtUjVylQMo0//JXZ3D/EerO4Udb9/nKaXGS9WlYfc5mllGR2d4rUaQ7vxAImiViWhU9NRAjCLDrVLAWZPgYjhahKWcaQddVdFaJSipK6u5nV+hhclHGXGwSwjj7CPcLdRWkvc4AziYJKKcxYbPzj6yE5ZMRF5/f7txNVozy29Z+GlanqPDU371lU4X5qqxC7JycVLgLpayulMCDE7GQZ0YeNISTCUoR3WZW4knIaEUFImSctT8wjkXwfbSMTTA4CSVktOH6FwcwZvRZ640QjD/vXNAYqrkt+mPm03r6X8ju7+YNZJ2IVhoQPeIwxRGSeZ6zoNlR1P+9aa0JJhIywvqZoJSnTTpDkPoaBUKTWWiUlAPdO+SSbAKCZDtJIJIFZCGJm7u6ITLklU0gCKSxQzXDdncDNDRA5ES/5qZxOOt7vD/9xvLE+wFJUMTw9RMgzkmBmRMRKbADAzCQEQIh3RTLTrA8fnpZMSTB3VSXJCIBpeEzy6IzKxNuxD+YkWPi6rutqn3dZ4av5JWv0aJK3ESvZ0sauqpKY1qsWdnkx2bIPid7SzXpbuk1cL6bdYF7XtXsQ0UAgnBkgklKUCMJEDMCHtdHHaEEhVUTEIk/L0WstKGAikXwaMzlBwBBiwpCYoh3f7C/e7GQ3zLPv0uS42K68H0VBOw/2tV1/yuNN8fX1HHtpEwWG3wA877s5iFBoGSeP4WYY3k8re8awtLzYX87TnkgnLUCu/cSapFnmCWAY0SCesScdliNOEyvNl0RPSCuBANoyl4eIJbUIoCMX4djx2+CRYy30mvavTdZZ1rBcT5PM73W2SU/eP3265lIpU4jZMz1AxLVkYnu/ul011t6EOCKSIxNbHlJKYVYlJiIGncaSht2rV1XCjv10Ork75DEm6vkOIsLdM5OZsyMiD0xXaDr8xnvx+VQrMREYAWuDKFF9UN76kDo5MiML8awFih4jCJ5Z5omZY5iZiQgx511uicxsNohEhFQ1IjgxlRpt3NzcKFlNJSIzQ30kzRm4P/SQieFhHuYegZudXpR5R0wCFLlwHVVPVUZizvpqOlDRK2+L2SQ7nWdiIUAyOEMIRGThw22e58PhQEQRUUqZ5xnCEeGBCLQ2eu8xLDMjorWmqtM0pUfvfXNWPMW5pCmQEZFIImpCnRMqk0zVoQ4M1+SjNWu9hExzYU5qGcw87w6CaZoygoZ7H633jnABJec93L33HgR3N/PNNgCICDMTESI983Q6zVHevXuHbH7sY4wvbfohy84tdUQmAaJLidL9WJHTvtzanPk5+/uO2u3W/KO3Q8ob5QvIkfgqbJ88hhNCGaRctqtPukhZ1zWGKYuytNO68eZkEdVJNbOUIiBKOEUp5bbf2tr2LFXCzCJCnwr7TtIZgOAue0SOcKLclynqpKAj+353eR0fx2hv5v3ip6MNCwcwFe3JGHl7vFnakhS16CQ6TdMsyuEopZ1W89zPszIv6zrcmHnSSVXLPJn1wtJaQ3rvvXCptUYfx+NxxahQkfO0FAA0E0R3lwgicvfmttpAi3x/SBJc9194+/F84ODv19sf7d8Xx35wZYqCEzxC9g59/bq0YjGG9eOyrOs6zTsI12kiIiREZCpVVU+jNxu11mTaDN0iW2uEiGGDUS7K/s3BWbwfs/nmr08lTUAyFB4xGZrYZxwirOz6hePDhw83b3e/lfu4Wt7xxU+1na5uXiu/fzWtw8aQMZXbMXre7m3qY7XWijLPJRzBREB2O8w7qaW7fz5+bq0Vlt1ux4zjuhyPvtvtjuvp1NZpmpKYSCzcico0K2e3JZCkT206kRQEgbKSqEd45Gl0qtG8W1hfVyKbSQYTJv7lsYt1SQx3LjOBjAmkxFprpYjMdLNkqiLJsis1icjT3SgS5gOeEYf9JXsigOEYrkk7rVBYs956D+4WnB3u1r33vjureygjQRQZ2+UzQFQrmxH1jJhZEaQZymrIIjwuLsba+zADF9EiUoKUVJl0mgCMtVmmkqgqwEqIDBBVFqqTgtxdiI99SSQrO4eRO0eLnpkHnTN7VW2jW7QJmpnn9YMzR8wkou3CTkQkhfsaaTNJCYanMNxMunJQzUJViblMNSJ6X9jHqFxKUWJnnrRM07Tf7dx9PR4dycyiRYirlmAhorolTMwA6pRRgkUysyQFeFeqN/cIIop8WnwANCIYzMyJnEpVluxdMtakDFQGp1jYCTghx/BD3KVswTHSmJnJpiKXhwstxcx7mZoNVZ2S1m5hgwjMSnAkE5IJzDQHwh0+zKxmqqoIkzC0Uo6Z2VKcS6GihSFPjzzirbAIRuyKXlS9amPPelOljeg+atDqnclNGIiEEcxHtjCKIlWIEsrj+spZu1skhVlLb5nLcluViSilSNFIcncAzGyVrQ/K9GHMrFxibVJ07j7G7U0sPZLFXSJdfDSU/ZmkwUJAOBCz6sR0+vSxiDp8+Fhvj7taj30Nplqn9LhOK5DCkkncRhAdl5swq4FIJEmdJ2ZOD1DEunYiIhJVUwVgCQCFZZHtlkVhLiIk3G1IKW+irn41BmeRUklKXpa3b/b7J5IOJAexMJBzBbl9+NlPEZiKmtnVp4/7Wm7WxZCH+RBrb28OYskD3kxKqZOu65o2oDksPDHvdwBaa8jw3hQUBBbhUkEcEUTErFNkW1dKxDARIZXhttvvrxOD1zqI56oFdb5ov/0KFtvFcAP5MFbBfdHrn3/yk++++25d19WltdZaw31W+ZAAPrjsluJs/Q/1LtxXkrZE96FzW+f8c1tHRLbcY8Msycy11lIKgN1u9+233377zR+cR0XKSGzXIWEmDmCYl/ttRID51+qaZ8j7wrN8mYrd/fRF0fEB93W4L/vT72Z9EbzPx9B5hNxYjnBVkfvM/YcJP6X4NNI+TPyh/t8I9+0UBu5l97jIpsGtEciHcjGlP5HSk0L508vxV4fhLEn/GjZz+vV1zEJVcW9jm818MfdR0plpZszMIuZWRPGMeKDxVVXEk0o1Hg/OhwF3q2BztccXJT/8vG3dPHO534wvRj7ogwkPHs/MX1HIg6S3c2B7abQ5NdGXWSx+bcf/G/yQaN39PIH+4ly6m3Ju0+fvpsKdmR8t+MFA/2thftWC//vyB3Cn4a9wfVzv5f/Tz4QX0s+FF9LPhRfSz4UX0s+FF9LPhRfSz4UX0s+F/wRjFnscL9rXQwAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAY5ElEQVR4nJV7Wa9lx3Xet1ZV7b3PcKceOUhsUhIlKpZMmjKsmE7gGA4kG4kyKEAcIEEA+yHIS4I8BHn1T8h7AiQPAZIXB0mQlwhBlISSEVM0xUE0JVFNsslmD7f79u177xn2ULXWykPtfc653c3uVuHcc/fZ41ervlpjbTKNAAAGAcZGAKDoGwMAyAACDEJoAQEYcAABZGADCEr9+QQ4KCwCEQRDELAHwQABYABACQ6AGrzAAV6Hx+XbPrz59abxZ54+7M83HZCBbH2UN7oKAHD5n4Jz14gAymcpyAOaZUKwfDbn7jwSMkBrSYP7G9wvafQCAm0AM8AyDoAggA1ACHBDf9Kws+9kHjSCQRUKGAOUH6wMAPzZshuaBwDih4i5R0zaozQACjOQwhQAWAEwWMAMtx49AwzEfTdWgtWMEAwwZ8HDYAqTXgS9rB4CehDVZltd1O8m7aVvDOMeNwBIP9xQAhMYCAAcfC92wDEMifKeodeKlQQYYI808EtXvHoo6GHE7DPP0TVfaNUpBgzkwPkE3rjc1v8JMBABpgDnbWc9nVZ3N3hi7e/+OJxWM/3M8dDTusQAZ/nZ/d0VUIMpdJAsOzgHhgICUOZ46q/O3YAHQYZpgNVZw/ejQSdby+g0dAVAp1WCgQV8TycF61mYb+IBN8zF3O9+XmoaVB6BGMT5Wgzd+eVV3r1wAcCMVNXMwOTZKaDQOnUOZfB0coJqCmN0wKe3sOxSOfIXz6LIM88QGAJ4oCBYxNR7WERXIwQkA7GjQOTMrfv8OO2BklYApkpERGQDbfOhVheeKyBkW5GATw7w7/7j//zk5kGYTLbP7jzxxMUnLp49d2Zne1r4gBvX5fDOnQnVz54ff+Mr5wuJ45JgKz3rQB4ENdhjqTsA8JsDvXkBsQegMMmznqACta703KZZ8HuHx3GyU3TAn76+/3/+7P3nvvYSdnaOnL95rZFrHxWBTdKy7ra3nolNPdu/fGnPP/WF339yEkqAI8jE2s7MuKrgiEkhHYQRRo9UeaSDpDcQ9+Q0IGUBbFBb0TLcsuVQ8se38e//0/cP2+qg1pmG8bmLxda0sySQUBCpNk0E75wc3MFif7eoX3p279LZ8Hd+98XdgGBwGGaiRVACBASgAj2QtBugzTY01IbMVUHcK9T8nSdNp/CM1vAn/+317//wrfGZSw1vabWzv4g82Q6TCYUAMjMhqKmLrWeNx/sfXro4euZc+fFP33h6Z/T7v/vbv/r8me0RCoAVJWXT2XaLWTE99xkz7X7Q92hpAjZ0gg2gI9AAr787+5P//N+pmN48mC+Sf+K5F3hr707d1UKJOfiCmVWSU5S+APynVz7YnfqXv/5Fh9knH7x3cmt/d1yd39l75ddf/o1f2zs/BkUEw1aRAAHCo+lh+iCrQjBDtN65yDp3tsTBEv/1//78rfeviWJ79+zhyWLeRS7H1e7eeHd3VndtFx1xwY5EKSmrtXXj2M7sjbo4296pbt++dXBw54Uvf/Xw9mFJdHF362tfeurlF7afO4cSMEkT538pL2+wF6QAlLxRT4mjGr/46OjHb7/zkw9vzsOTsTiztbM7b5rjbl5HufTMxRu39kdbE2epIPFk01AWhUtt1zXL0SRcv3H1c0897/y4Gm8LjuG3OjedXNhansw+vHP86e13fvh6+8yFyV9++YVvfnWXgaLX1uuptbIMlF2Gnh668r8SqDFoRBlR1sD+Av/2P7x28+48McqdM42V5EYppRjjzs7Oq3/6w+9+97sfXvkIwGQy0STOufNnzjrmo8O7dV1/ev3aM898bnd39+Dwzt7ezhtvvPHMc1/o2sTsxuOxpSSp8SSpWTLJ03vhn//By+cLjAGSlh0DLqI38Q5wiLDkN1zijNuABGgHCMq54NUfHV09TOXuJQ58krqymqSUIsyPKg7h3LlzN27cOLt3ZnZ0PDs8OpkdBedZZW9vzxeOOoDt1t07Qry9e6YaT9hXKphsTc1ghFaFfRkmE6m6etHcXC5/8ObB3/jmOa8YOQcRMKlxdgtWZsQrlPuwZYXdAyAEBa7fwo/f/kk0d2Znt2WrZzMwgz17IkcK+/ylS4dHR+cuXDAzOIbjwI7Yi0IU80U9Wy5OFvPYSVEUURJ7ZwRmZnZRBMzkHDkXyiIlVW1fe/vdl770154/C4MnUsAKRrfWyLSyIHBraRPgFEwo54J33v14Vqfdc09Fo1aUfEhqLviiKGKMdRt39vaIqGkaMFfj0fb2tojM5/O6a0XkeD47f/48ERWhSirNyeL8+fN7e3ttijEJM5dlqbCma41QjqqJ8/PbB2+8d+XZv/qstjItyNqaKufXXiQD3lt2aYgHBx8gDwQBDg7x5l/8AmFaTncOm9iSiXHlXEziiuALiEgb097Z84u6DiEYsQJtjIu6LopiPB6fPX9uZ2eLiFJSAGY23dnm4GNTE7ERnPcEizEayDsW5urcUz9+/9orv/bs56YOZkSAiSMI2AABM5gVsDxPs+owhoXM6xu35ndOGnFla0jkKJRG7ELZdV2XYlGOymo8Xyx8EYxAjsn5VjSajqfT7TN70+3t7d09JW7bNqUksHI8MmBZ10QUQlCYwsg5XxRlWQrs8HiB0c6tpbzzwZFm8YWgyxlMeJh0sqHGE5BAmgMZAZYdfnb5mh/ttupaY/hA7NmHpOqLysh1kozJFeWybp0v6qZTM1FVo3I0JvbLpq3bRlUFBsdqNp5MvPdmVlSlCz4HF0QEgL0jx63Y0VJ5fO6nV/bvJiQAxMwAEiHREI/wgHtFjr438xZ/8f41LrZahRIl06bpYLxcLre2tqqqWszrrut2dnaWbZOnYDme+LIwJgOiigGjyRhERVU670/ms7Ztm65dNvV8Ps9wnXNm1sYupRRCqEaTu4uu2r5wcNJevho7oG0jyhKmm/BYYACaugYUKlnMdcJ7v0itldX2XqOY1w0zS+pgUhVlXddR0mgyJua268qqApHzvm4aMIWy6CSxd9Vk3MYopj6Eo5Pjn77/8//1v79/+aMPBaaElFJRFMwcY4Qag0xUVZd1x+Vk/6S9/OlhC1A5HYJu5ewzA96MiKisAiBwAUBnII9ffHwz+RHgxcg5ahfzuFhOww4cDc2ITjsJpJaTPdzPDyOIajLdPXvmxRdfFJHJZFKWparGLhGRmZEZA6nrCOLIS7KTeTPeOvfB9Tt39WLBcPCOEqAEYbAB7MEAE7GmlEO3aLjb4GdXrpsfJ/Jg8kzLkyPqWm/myNhlOjARERuxgQbjDxibsSmpkiqBmOu2adp2NB5v7+ywczFGVXVEnpnMyMCg2HZNXTsyVum6rhhtXztcvH1ZaqDWMLgbSjkqY4KoASA2ZJvu8O7PcbxIkQtlV1Rlapt2drwVnIvdWmEyHCPLHP18UmJj5rzHzACrphUHrwQzMzMRUVUHcs4xKBMjEFtM0nRsKMgKpk6h5fYP3nhvCUiAIWTQDsnlgWQjwMh5Mc3e4Zvvvu8m262yMfuiaJYn3WI2hrbHR4jRUiSVDNQRciqEGYARgZmYs4E1Iqqbhpir8ShUZVEUVVWVZcnMnp2JOgMDse26pkUStO3EGUuXFH68e/n63Z9cQwRiLygBxCFxn0PJbhNTAq4f4ur+7dF0NxorMTOnrpN6vrx79+6NaxLblJKqkgmgK4JnsmSF4JwbdrKIZMFHSV3XiQipQY0MmhKDrEt3bt0+PjiMbRebumTEeuF8Ec1pufXaO59GIPWKI2t2Yc7JK/IGU6Dp8P9+9H6npuzIeXYBwLgqNDbXP/rg4Pr12LWSOtGoqgwwjBjE2Z1gR+YZ7JCJTmxbW1u+LFYsMjNmLopCRFJKAOq6/vSTqzdv3GjrpqvrgpKzpKrJXLVz4YOr++9eidIb8JyIU6YhsVM3FlHOGvzorfc0jGplKysLI0MYTbZN3fXr145P7moSETHRzNG1d5iZvaFccquXy3o277ronA/jETOnlCR10CiSiKhrm6P9qycH12NbxxjN+XI8aWPyReFCmMf05k8/iICgBAIIMGUAsWtT4qLaEuC/fO+1VO7x1lm3faaWUAtFni5qd/FzzybH1WTU1Y031zVxOa9hTMSS1PtgBvJeiaIYjE3JorFhxDzyRUFBErWi6tgTkNqki5gWbZd2p5On98KFLSXEw/mioaIh70IQ6bz3wY9+/O6Hh4oFkGgCBBCzdk01Kr3jusXVG/GjK58KsZGbL2bMYKDwxe7umdnx8XhSLhbHxCYxaUwmaqopqoiISM4kmfUObi94A5k6A4wVLMQ57ceG0aiM2h0dH8Zu+be+/dtP7Y2uXblcVUWYTFBUwlgul/Vicebs+XK89WdvHKQ+Je8A5qQCoGlSWWIUuKtPgjYTF7eDjtFgMePmyHWzyonUx3vbkzL4FR1VNauw9VR+cFsnj4ygxEocVcqyLIri+PDO13/ly9/6nb9ycO0Dp51zbl53BJ5Ot1OSxWKhqrPZbG3GDFyMRgCqkYfhzsG+NLM4O/Dx6GwZt2hRdIeVnNjyzqUL23dufPSlZ58clVllwnufzatnZtBm2pSGdD4R9WniIRtvYAMZWI3APJmMu3aJ1HznW1+rsGxnt0tHDOuaxjGmk3HpmKBZw65wM8BN24gIDL/6wlP/6l/802/8yrP7H7y9uPH+01u4OEo038dyv9CTnUrP740d9xqAmXOab2VNaAjsMwHoVCVCV4eFWImr0bhp2+ViNi7c2KULE/zmi8/Pbn40v7N/bme6PQraLjjWpK12bVcvN+/FIHjvnXNsxoZLF4q/++3f/ON/+YcvPLVjJ5/Wty5/6cnxV57eef0H/+PzF7e/+etfl9SqavYXs0HOynitSU7xRAHbLHoosYGVqE0ynW7XdS2pPbNVBuAP/8Hf9t0Rd8fx5PbJ/ieYH465C2lJ3YJTs65+AN6ALDDv+qTz3gg7W/jH333p1l386M9/9uqrr9az49/6xlf+6B/9wyee3/vem58aCu89gJSSd8zMSZUcZxkPU3GgR07tGtg2E+kc2ziajJ07MZLpiCvgW7/13DvvvvK9P3/t6S9+/dLTT5aFu/7JhxRnLz3/zN/7zm/4Vb7Y2ItYKAqIwpmk5Fwx9VhE7AToCH/wey/8/d974fKHR09f3N2e4Gc3oRKdJ8/OE0eNTOScSzpQdpUZvKdKRYZTRTKEarSslwacO7tXefYAAf/sj/7mB5/8m8XdKx/f+fDM7s6lC2e//Tvf+eoXywnB9Zl8BeBdFjAzoM4xkMh4GliA8xNEhWN87Qu7+ZGTMofPTkQQY2aziDBzTmQOlq/3DdTUZS/ELIc1nJ1AsxRjDmzbu+248g6J4ace//qP/8msgQmqCtMRfJ8IRXAZMQG4Pwdl2Vo6Ygemgb7rOoPBzFSVBumSgWAwy260mRHBBs/a0NvczBCCwowtu7BKRKrati0mROBgvFdgwoAihF5duP5vFWqpv69ANMhJBaQMdSjWaUiDWlJVVbWUmPnUtFMzzjy2oZBgSt5gMDIYqToitnVd1NjFpIvFAmemgDoQjLwbSlyqsASidUk0x5MbIh7S8Lk6CAWBTYFE8JyTqANCVd0kbfZDciQyDFfeT0YwYxgx9VeSwvqBIGLXih6fzNWmTAw2dDGHJTAAAlUwg9a1JEMu760fP9QeSWEGo9V86quFG+OiuvZLVQYVbQDBaP3LwEagnNgicSCn0CE0c1zGpHdnC8t1MwDOE9m6uOtWHl1/Q+3DmIGwq5oA5W6RKfVhGfpKDBGcI3ZEup52UFUb4pcVp3vQRqYEIyYjA5mQGYwUSi6Qd2I8X7RCvs8NOAYAE5iCByNouWjOmQMepkNx91R9iYgYBOqnQO6i5P3MeXauNlSVnLNBgeQNNojBmC0rFDMy6xcuQKEGB++CgpZNp8Nkihk6OYDZhNkBSJocWNGrBF7Rd2NAH9yorwD2IUm/gV7Sq9Ms50OBXGEiqJko+ioZkA+CTBnKzAZfq5MVO60XEDkC5zUP7F2xcj0IYLD2ywLoVDFPJQHKDJhpjKr96gbnnKp2XUdEOQBpmo7Jm+XhIyPOfoYRGwEaCWIE7eFrAglxEUjaWqUrJ5Orh3WXc+ltWxH8UMLgviDKfSw7fPzAC76n9khkyIPIHHwwggI+e0uOyTERQU1VmR0RZQuysVyDe6lDDGRmBjMywCivSVBzrKZKLrSaUh5JsmwiHjzUm7febKsatXMOgIlsHnXuXkN9n7Lr95j10SsZ84MIlz0tVQ0hxCg9bdyjlyBgkPSaLg8mNCFGwIEdABIRgoHZBe8H7QEmMxsq3+u8B2CG4cDQo1xVY3Jm5r3PU0IV7nHqtcMilc883Gs0gRgcIwRkw6sqCviiDwhUexVE2lvEzwZ9akwAMPveU7CHIbkP9AOaZnXbc5SRtacSjAlGImoqKSWS5OCwQY/NlnGfBj0QjCAihMrMQlEAYAYeDzffT+uN52VdyEZ9MezoGI5D8GVRVESu61JTd5KMyGXtAbAZsTEpUU6SWb+obOPWDICIUkrkWETKsswzFA/q+QNB37cFAH3Qlx26vKducefuEkyuCCEE51xUiTEmFR5Ml62J0f80M8v5U7Xe6zAjNbBTBRGJagg9zXB63n9W8/cMB63LjJRiJHLMHIE2oSxx5ZOrXdeV01JEnHnr2rppQln0a0JWouztvoGMwEwwg8AMxj2pTVJy3td1HUIZY4usA1boHwH6QS1XS5m5D8ysLyQtm1aJmYnJsQvwzoA+JuDsdTyAkr3GICYbtkGrMRSRumu7xwH7cNC5sXO9w2bwDAFmJ4uUhETMzHtXlqWZZV4SOSLi7CJtrOTLFsd6VWI0LCHIoA0mInVdL1to8cuBvofPmcQG9N63Uu8tHc9nSUrruk5SoRKKwsw4YxrcutU3BtC5I2RqRAbdBM1ghdVN07aw8Pgq7yGrNfun9hsCNE3n3BTg2Ensal8kIipoyHtQ/pAN8VVe3QYDtLfhMDPttYmqOkc5JRmlXzX3eKDvk809XciDbYAokohzzhVFl1KMMcaY6UFELoRVTIA1aAVZH9jCuFfTBpgpiUjhaRWzPZ6UM+iHn2u29loNRC7G6IlGo5FzLkrK1bScTN8EPWQ8bDVU1lv5NTdyioc5p7nvfdxDQee1hIRVpU5WKydNzbI/Ds1rE9jPF0svGkIg59B1UZIpFFIoiK131PpYM6OAgciiA4gU2muPXEcimIM50yGCBOjRK8YYKkDqCdB/sluWQEImsesALDs4hzDe9dXWyWzRtJHYj0aTne3d4AoGp04kiiY1sWGhJxlYyAsIlqAtJ2UhMxOQWTmp9pqTI23mFbtUSxLAhceTNBTmVmEjVh2Okb2D48IVLeADDpa4e3RSFHvJkWnSSN67wrlyUgFV0zRAv2aXTE3NAIGp80YKjayqYgAJQYhAwQeeTkI67paLu2XhhNBJLPyj7Yu/3/fIXeUQsrhSSo14LnF7X5azo3Jrh63h2JlwGgJbDIxaJ3n7rA0pq5pBkqkoFGAxVXixrp7XFbeVa32pYYycMDYoPWrh1anDtLnfCGJQ8t77AAe0de2ZYoytiBrgvQ8FhWDOCdGibRdtO+/aZYp10kasM4pwbXIx+U581BA1JPOCoHDleMvIKXtXVq261956bwE0RvooxNj0p+mBSoeHKgRw5fLPr1y9cu7FFzTsROLouDXuJHVtilF9sUVElqu45PqkNQcRR8YgMVJHRkRGDkwn886HPeLYdJrS6K33b/71V/5SoCCPsYD6wQ4TAyAHR1lLd511oKriL37+ydvLO4mjMhdFUVTj6aTkaQmm5XIpOf1FAITIiAhGasrGDpJrpAQiggKBpfCIi3mcH49AFZwDFktsjR8p6P6dgH5VsK3X7ytBYCYxumKSgATMEj7ax6tvXz6JWC6bpmlilJhSjClKGo+mAlNQ78oaK4GNrTNWkBmZMrKk2YiTqiMdebm4Vz6541956ctffXYSNiPjxwc9CDu7G0gx+jCKigiA0RiynDpBJzCFGFJCFKQIySvADXk25cfHBk6zyjey7E2xEUIAGZ44j70R2hOc24LVNVUB/JlxySbovCyVN5MeK9CZLDJocQIKw6rsi+HtmM1EGzZU5+boYSNwXt8aCABZgrWwCGLwCHiE1vOnVcbQlfUvRl/gRZ+AzXdf9zrjzREUu9WFBBh5MkFn617QoGT7YGNY6ShAtoXc+zoPbfcHpJtJm3X+b8hl5d9p1bPNvm1KMTcBDDEv7NIeq8eG4DHAX30/TuvXT9O9j8MDiGUbmdX78G2C5lOH8ssOyJW6Taz3P+Mxofv7Xr1Y71jNy+FHfldgnTDijWs2cawCTQeQrdjCa1Lj9MYmzAfbi9OgVzBPC/t0R3rEAiPcl2ijvtjygJbzgT1cyj7N6oYbs3mYBo/BZyDXEU+d95npknWd5n7fYH1FPzqnO08bn/6CNLwGARDndKzA45d/ZUSHVb0PaXrKyp4a4g0a24Nn84A7u+5p0Idm0OGFF3aP4Xv8f4v4aTRb5QZGAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAe0klEQVR4nM17d5hV1d3uKrufs0+dM70wODC0gYEBhiJKVCwYa0g0aiz5YtTkmvjlidHcL818xiR+xpJmoqISE1tQEIMIqIh0GMrQYXqfOVNO3X3tte4fW8ZhQAHjvc9df5xnn332Pvtd7/6tX1+QMQb+PxiMMQih93nGi9G/85izvMA7+IzrzwkxAAB+Dqa9W059AGOMUuqd9z49HJRShNCpuCGEZ4nyCwA9EiWE0HVdAABCaBSCU5k77RlKKcb4tL9+YaBH/vUwhQBQAJCu6319fZqmAQBc1/UAUUq9uzDGCCGMMcaYMRYMBvPy8nieP6enf07Qp6Jfs2bNgQMHent7+/r6EomE4zjDUxqWllGzdRxHVdVoNBoKhaqqqr797W+D/zdMezQ//uQTy5YtQwhZhs0Y4zjO495bWB54AAAAyJsAYwwhJIqiKPKMMQhxQ0PDyy+/fNFFC13XRQhAiM+IgTsnxODECiOEcBz37tr1v/n1o4FAwHEcn8+HMQYQUsa8iUEAKKUQIcYYABRCSBmDEKbSacuyOI4TBEEURZfS119//aKLFjLGIDwrbXbOoAEAHqMMgFWrVqmqGgoGIWSKooy8wPtECDEGAaAUfKxwvJ9yc3NNSycONU2TUrr/wAHDMGRZZoyNFJBPE5jPCRpC+Ohvf1u3a8fY8hLXdW2buK5LKT0hEh8rOMZsyADECHjqBSHHtkWBC4cCrutDHHYs+8hRvb2tpbOrZ1zF2P9bxsUT5fr6A2+99Zaq+gihrvvxqoAQYow5juM4hDHkOMRxHC9KHJYEQcKY5znZtokkSd4Mie0Q6kbCwd6+/taWJnY6RX5aDJ/K9GknPby2/vrXPxFCHIcjhDiOYxgGAZAR15Nn9vHwvjIAEKUEQkgpAIDyQgFxDZ5DCCEOYeIyl9itbR3wLKzsGUCfFrEnpitWrFi/fkM4HMxqBqUAIxAOhxFCPM97ZCOEEICeySCUua5DToyMltU1TZIEQ3cJsQHEjm0CiAf6+4YfcUYJ+SyZHnX/sNVdvny5JAm6YQFIIWQBNcRxPCFU101CbNd1qaflABUEgeMEnseCIEiSIsvi4GBC0zSMwxzH+f1+jDEhBDD36LEGAIBna86I+2z1tGfeEELr1q37j/+4Mycnp6pq8qJFi1566aXm5laEkEMoAJSNGAihE+IBEIQcz8uy3NbWdt/3v19ZWfnmm8sPHz5MGQQAdHd3A0hrps948MEHFy9ePMLQnjvTJ03uxHj19ddmzqy+9pprpkyZYuhWW1sbACCTzWqaZhgGZeST6wEGAAAMJF6SJElijBCq6/qCBfMvu+yy66+9ZtuO7Uuff3Hjxo2iKBqG0dcfX7Vq1eLFi8/I49kuRMYYgqi7q2PaxIllY0tVNWQatiiKOTm527ZvCQaCZcVFY88bU1RUFItEJUlAAJu2lUgkunp7Orq7Ojt6E4mEbhoXzJtbVlrc3NysKMqCBReeP2/+W2+vuvfeeyFiGPGpdBZ8utL4hMGzFw8AwEcbNyT7B6P5uT5F5TFGCDS2tjU1Nc2smV5aVCjIimVZhqXbpkMp5XksCJIsiLZtxuPxAwcOHGlovP7q60rGlOiaCRHjOCQqPoHjb1zy1Y1btkJeuOSSS9a9s/qMMn0G8RjpnhuGwfN8xaRJiiIxFxiGwQvC3No506qm1tXVrX537dEjx7u7unTDABQySCGEkk/JLyiaVHnerJoZCy++5BvfuG1gYCCTyUiKXxRFy7L0tJnU+6PhiORXHcexdOPUl3xuoEf6RhjjeDwezcl1HbJ7916M8eTJk3t6ex9/6o/vrl9nZDOyXy3KzysfW9HR1i4pcllJ6Tvr11aXlrU0N++u27n02efDsZwrL7v06zffVFE+ZmAw0dDSFAkGCguKh4hRVlQgSYJtE0IIOAvxOLNMu66LMU4mk9lsNh6PP/7EU+lUYnBwMJab397eyfP8rBk1eQWFoYA6NDCom0Z+YQGlJJVJcxyHGJg4vnLChKsETty0ZfPK1e/+c8XKa7985dFjDZqmmaZ5+WWLvvuduy+67NIPtm2rHzxi2Jb3uJHB0anEn8G4eH+xatUqjuMmTpy4bNmyCy+6eObMmctfe3XFyjeoC77+9ZtFUdy8+SNd13t6+kxT9+6ilAoit3Pndk6UGlsai/OKp1VN5SXxvffWLX3+xR//9Odza+esfPONp//yTGnpmBu+cvWtN339l79+LODze4hH2YdzYNrTl2+88cbevXvvvvvbx483ZrPZhRd+qX7vXlHgFEWBAK9ZszqZTCbSKcvMQoCYSwEEgCEAKcgAAABCYCDe2SAeO9ZwhLg2hqyouPi6a66v27G5YtyYUDT04YcfXH/dVYsWLdpXf+Bfa9+rq6ubOXOm67pe/HZa+f5U0J4cb926dd26df/7xw84jmPb9qFDh9745+s+2bd+7Tq/4kulMp0dbYZhAAD8algWZV6QIMSmY1NKiGXzAs5mMy4xDcNoaW7OicVyIrGOzs7nX3g2ElD37Kkz03pxcaki+12Ou+3WWw4fPf61G2/YuXNnTiT6GSb99CrP4ziVSt19990//OEPA341FAkue+nvj/72MQSZKIqSIvf1dKfSGQS5/LzCaF6BX/RlTfvSRQsifpVCAAC1iYUpWrbspfauVsQQhdQF1Kf4VH/YIrrASxBiTdOqqquefOy30UgkHo/v37XzgZ//4sKFl6x4c/knNDMATkZ+eqYRQoAB27arqiaHw0EAELHdHTt2QADKysqyWf348aOEkGhOQcX4CZFwHghGbMtiun6oM8H4tJEY8gdChqEBAJxoUUAOuK7rxDuJbRmGYdskJz+P4zhdNzketDQcf/jhR37+0M8oY5JPmVlds/a99S1trWPHlH8cqJ8C+/SgvSnGYtFwOOY4bk5O9Fe/fvitt9+O+AMDA/G2jk6X0JLiipLysT6fj1JXDsYwY2Y62WYQ3WJOyuShA5HP6m5DuaV+xUd1LTWUMLIpBLBDnXhvdygQtBxbkWRJEg4dOfzEU0/fc8fN/f39u+v31c6cNXZMGQNgOLUAAAAj5IQbBXT4IB4f+P3vn5wwYUJJSdHDDz/yzDPPRAIqpW4ikcKILyopLi4pmVUzzedTGpo7mvdslDjeF1B9jmvaVhhSOpjocihmJNvZkx7s6+/vr55dW1Qwd2goIfvELZu2phLpnNywovgppVomu3PrluL82MTyMn/AxxBsa2kvKy/1YpSPJeQzZHrYBP7mN7/ZtOHDv738jx27dv7o/v+UBLm1rYPjOElWSwrLw7kRgYOyKAHI6ZaupWw1FBAEwaa0palRYC6HQMpyQqqfIgwY62xtoczybBNj4MixQ35/IBaLmUbGshweI8umBUX537nz9sbDR5559Z9TJ0997q9/njh5EgUMAcgAhSOCLO60K7Svr++999679dbbRVl4/tlnhEhlTOUQdZt7+mN5hbH8sKIorkuSumHbtuUwkcN50Zy2rs5jRw4FK2fJhWNTqX5JVbXEEG3cU1BUKPqUhqMNHR1t3pLx+Xw8wpZDMCcpGHORMpDsa2tv+nDzlisuuKA4/8Pm9vZX/7n8F5N/BigDpyTPuFEnPNlfuXKlIImXXnrJ+vXvH2/uClbMddJNpuXEYnk+SY5Eot29vWjs/IqqmZijDQNZmB2yevZ393Tmzbh4zPmXi7F8O5uxEe7v6rIjeUbr7lRioLx47IQpkwf6+6O50fo99clUStP1wsJCBggM5ksQp4Z6dtXtWzh/3rxZM19b9W5dXV1HZ0dpUQlgDAA0ciWe5Gt7ySvbtuvq6mZXV0cikXfeXgn9OZgDTnYga5GgoiKEIGMUSrGScp8i5gSVSDAUCQYlR7MIU4srbdvuPFi3/vH/atv9kRzL4/OKwhAEJKW8ctzcuXO/dNFFNTWzx5x3HmU2zwu6rruE2N0N6ri54VhBX1//gYOHZ06f7pelxoaGA/X7AaQUMHYy06cJEBobGxuOHZ97/vz21raDhw8Fcsv5bN9QOiOKSklZKQAAIORoqfp/vbDllccPrHpx919+1rn6uaCAGINDfa02hxs3rY0f2di2/V1Dy2T6e/MEgKjb2dOdSCQsw+rs7BgaSECIRVFY+KULoCC7+qCrp/lgIXDJ3gMHw7k5ZSUFyVRq06ZNACDIRqnpU5gGAPT390uKPGnilLo9uzIaRNR29YRm6Ln5hQXFhbZtA8Aslx463tzdFZd40HD0wNFjTW0WoqbOB2KEkyu+fHPpRTdWfvluIKp8pOCowRKWOamiIhgIuJAW5OeqgYDruslkStfMgpx8x8po3U1SIF+QYXt7p2lYE8ZVaKbR1t6ZSqUgRqO0xUl62ovMFixYMH/+fF9Q3Ve/G/ljghzK9ux1CY6Gg/G+fhewVCoViwRmlBcbxO7t7MvNzYlFQyJGPA+N3lZT8atF48qv+iYT/Iahwda9IsQ8z+/YWdfdE0+nhiBG6VRWlvy2Yxw+fLioqIiXfHp/gxCqVcPFyYHegYGhSZMm/X35ysrKiX6/nzEGwad7ea7rYgy3b9+alxdDkGtvbIZKEFkDhmFgXuiPJzCGPIaJjMYzCJgJHbOjI+vzqY7NOjo6CovHxDv26/3dRkkz0DMsmBM2Bljzbl0JMRd293R297RD4OlcFAxEAMTptBYK6YrkG0plkw07OOJAiJvbOy67eCG1LY5DCGPIAGUUjlAin4D2coorV765ffv2e+65Jzk40J/UxWzCxT7TtAHgIYcpIAzgnvbOQCw6ZuJ4XTMdxyW2RSkIhgJ6yogFwxktld+2FbpuU6PNfLJOkGRpocJwODeMAaMUUAgIsTuamijjLDubTCYRpgw5rkE4URRFvjfeV1Radsc3bnlx6XN9fX2/fvi//QF1pIR8Atqbx9Gjx88//wK/P9Dd3ZnNJgEhrgEM0xZEATKHImhkMxWTJ9/3yE9CAR9FCDJEHXtwaEAWpaajDdlEhnIolYjLnDxPFDVNS8QHZs2fWzym2HYcCABFkDGmiNLql//51MO/sh2ntbGxYuI4DDnKCIRQFMVsOiMr/vsffED9059//4c/fGXJdQsvWMAYOA3T3ilRFDHGlmW5ruu4lAFIASOOhXiFMExty2X4hru/OdDVBUju3p11sbzc7Zu3bt28ubRkzPd+cn8slvPq0r9t2fSRGgzd9YN71y5/q66urqe3647v3u3z+QRZMnWN5wSG4FfuvO34kaMrXnlZkn0YQwgxhcRLUHlOqezzl5WVYQwd2wUAMeaeRnt4dYZ0Oq1pGsYYQgwZggwAylyKXEoYJYRQUeaGhgbefmuVpuvvrvrX/n31e+rq/uvhhzpamrdv+Gj7xs1r31n73f+8r7+jc9O6Dw8fPvzTR365b9deRNnxY0f/9vRSPZXd+tGm5cv+wRgMRgMQUJeYPIcAANAlEADOy6ohxPEiYdR1XYQ4cHKaD41iurS09MnHn2hubPL7/YIgENNwGaGUuKZj27brupZhR3Ki37nve/l5eVXTqwuLi+acPz+ak1Mzb8702TPzCgtq59VG83Jr5s8rLi4UeeG91Wsrp0zAolA5YSLm0YvPPb9nZ92MubMBcM2siYBYXFLGYQEiHBo3G/ICY8wfUAOBgGMarU3NAAJZ4sDJQdcnoL33cscdd9x+++3r1q0LRKJ+iSehchQqg4BktGxFRYUkScSyecwxxrKa5rmOsixrpiHLMnVIIpGQfYrtEkGRPAFta2lRFEVV1aP7D6aTqcmTJ7uO09feBQC2HFv2yVOmTKOMQMGvhEp4nncJyysooJR861vfevnV12+7/fZJkyZ9KujhccsttyQSCUBJQUGeIwZReKxPki1dJ4TKso8wCiHECKVTqU0bN7Y0NTcfPW4k09s3b8no2uH6/Q1Hjtq6Ubd958F99WXjzrvhGzd3tncAAM6bWMmLQktb69jx43bt2nX00EGJwzmhCHNd0zSxP2plB3kEKSPTpkxrbGzc8OGGn/78Fy88/0IoFBiV3RsNmjH25soVu3fvtgxzUtVUs/uI5VJfKOZQp7Ozs7g4nwccxMiFiFI6vaamcsqk9vb25/74dPXMmpra2VOmTs0mUkt//+epU6aMHT9u15Ztf3z8yZpZM13X3Ve328xqAb/a2dpmmmYgHKJQyCsooMDNappSWAlcg2NEkuWp06bsqdsrSkpuXh4A1HXdUbWY0caF4zhVVeMD/U1NTbNmz+Gfe4m4tqjGfD6uubnxvIpKBkHjwWOlpaX5BQUXLLpIEITF115t6sbU6mlHDhwMhEMLL1uUTqerZ86QfMqXFl1CKZ06u2awL97f0zdj9qyS88oP7tlXWFai+hRHMyrGj+vqbjcIUhBvp/so4IqKc0uKCrds2xqORJqaG+CJ+GXk+GQGXnIWADB16tRIJLJx44aqqdX5hYFUTweIlEYjsXRycO+uXQTAt//xum1addt3NB9rMC0rHI3MOn+uHPCnhhKZTGbWgnkXLLqopaEpHA5PnTVjYtXkvLy8zs7OCVMmMcZ6Ojp9qn9K9bSPVq/f/uEGXdd6ezuF3HHYTCA3qxMyZ84cQ9f37dsXi8XGnVcBADqR7T4Z9HA6xwNdWlpaUVGxbdNm4JLFl16Z6awXRH8oFBE5GB/q5wDs6eh85IGfmKZ58RWXaYlUYWFhIj4gStJgX39qYCibyRBCfKo/mJvT3dZhGAZjTFXVhiPHTNPkeX76zJq3X3596e+eSutaOjWYsEF4wpzsUJeIeQnz11x19fvvbRhMDJWUlNTW1oLTpUdPBGEnoHslyiVLlhxrbNi0eeNXv3ZjRBGT+9/NZtOI411bS6fTkMM7PtxkpDKCLJWNOy+TybQ0NZuGYThWJD+3rblF4gVCXdswDU0/sLde17S0liW2nc1mRUWWZHn98re6ejpnzZ5+rLFJT2et5r283mfazuzZ08rHlL7y2uvBQHh6dXVJSRk4XWA1Wk97n7W1tUWFJc8/+3wslnfbrTd19HQPDSVdRgC0LTNt26bf73/6kcdWvfIGY5DnueramelEYsqUyYVFBdNmTBcEnuc5nyiNHV9RO39OfnGJLAu1C+YXl5RhjH90212767ZVV1cPDQ0NxvuplU41buN5niJ46x3ffP+DD/bt21daXDZ3bq0o8i7zqo/uSNCnSdZ4+mX16tV//tMfbrzxxsuvuOKWW259//0NatCPITJ1gwIWDsWICzACY8aP50URYg5jjDgMAOA45BhW1shEo1EEOegSwqggCY5DZFk4VFd/9Ojh2bNqksl0T0+Xz+czbcsn+3lBWHzFZQ888MDXvrakpaXjpptueuSRh0+UQ0czfRLo4Ss8j6+1ueVvLz5/y+13mKZ+45IbjrU0qGpQ8Qfi3V0Y8z5/EEHOSCYCtVfgwlKSTli2YSLMBD/ubbPDeY6AsJYFSGACR1JJtmcDsBI+OVA9Y5ooC7t37SHElNWAIvoFgYuEgy8sfXHbjs3f+ta3f/nLh++//35R5D8razp8dvg3hBADdP/BA9FIKJlMhsPhX/3qv79x512O7fZ19ymK37asVGpIkWU5GLCPbaHHdyqqP0dRSkpKCNUslYh4yHWgCczOto6saVDT5kTgyx9bXlRg2vbhI0eAwPnlMHEszoc4UbjnnntycqORcBBCqKqqJAkeceDTsqandjdQSjHiuru7V7/zzoyaml7DLCwtC4ej3e1t06ZVZQ2SHOzVbN3UdEIdDsscICZ1p0+cePklC4dSaV5EHC9GgqFEIvWb3z4GtKwkCcHcfEXmunt7mpubAQCBYNjikc+vQkBvvP762tradDoZCgWDweAHH3xw333fO1U9fwJ6JPmfOKwcBwC4+66716xZ+49XX7nphptcAufMrIFza++77wd1dXVP/+HxTKeNOegSYjlZyFzOFHfu3LZnTx0FDDLA8zxjDGKEsOsPqTyHEkN9cZdoWWNsxXkP/vih1oYjr61YYenavNmz5s+dlcmkMENP/M/vksnklVde+dlV0NF5j+FBKUEIvbhs2VVXX1FeuuXCBQstQ6+aXGtqhp7KFBUUNza1lY8tozbp6umFSLBsYyDRxaDIQQ5CBCGFHIaUOQwAaPOQGz9uUnNbK3XTd9x+Z8XYMltLzJ5eU79/b1lZSTabFXnplVdeefvd9d///vfvuuvOk6WCjnI3PjU/jRBHCAmHAs89s/SBH/2gtKSkatqUvy19loeopflYQ0ODaWiTxk8KhENHjhwZGBgAjBmmo2lpCKgNAGSIg8gfDhTk5uXn50fC4enTp/9l6fOZZGLbti2lJUU9fb2d3R2UEkBcyzTWr13z9AtLl3z1hieefBKcqVZ0hpKcV75IpRKr3nxD4PmVb6/Zsn0HQigUCvlVZcumzUXFpdXV1ZzIjS0ewyAIhUKHDh8OBoOiIg/1D+TGYn3xuCL5EqnU7t27h1KDiqJAl/jVICdKbW0t58+eveTqxelU4s2318xbcPGj//PIsDf3OUGzE81gGOOhwf7XX3m5uKiot69vcHAwPy+vcsKEPfsOvrb8jV179rqu4/cHcqM5Y8vLEsmkqqqBQKC7uzeVzXR1dXmWPOAXKsdNmFk9LRqOHG88lkwm83JzqyZNFmRpy0cf+XPynv7LX8AJMJ+zJDc8GYwxpTQSjamq2tbUkJNfEA6FGGOtLc0Txo3505O/a+vo2lm3a1/9gZaWlu11u1zX9VrFJF6QZXlMaWFBXn5FaenUaVMKi4qCaohSOm/+HE1Lm5qZGBoYGBo81tR09fQaCABxCCecuX/sbFsnGAATJk/51/JDgOMDPlWSJEmSs5q5c807Bbmxyy++8KvXXmU7TiqVSSQShBAKAY+gLMsBxaeoftcliaQWiUWASzVNowwCyDFB9AXDLW2t3X1xr5voLLvFzqqg76VJxldOjOQVyIIIGbNtO5QTXb/hw6d+/+dIJBLLyRlXMaaifGxhYX4oFJIkCQGo61Zv/0Bvb29Tc2tLS0tjU8ukqilP/e5RkVFBEEKRHH9ANfTs/v31ffGBnJwcBgDDXxBoxhiEjFKmqmrGsI8fO3b1VdeqwVAwHN658zHCqE1ZU3vH8eYmAN6HGAmCwCHMQeQ4juu6FnEw5mVBVBT5YP3+FSveuve7/8txSTAYHBoYfG/92g82bXNd16/4IADw7NrtzlxmhhAC8LGfNXfe+dc++vixpq7FV166ZMmS6hnTN23bDpjLQ8BLEkAQQQ4wBiFyAeVEgafMh30YIYHjGQSmYza3d+XkxtrbO5e/+cY/Xvr77r17MBL9fn84HAZnDfoztQcAgLkQ4hPFJcoYuvyKxbt378YYl5eXW5Y1ODgYjUZN0ySEeLzSE5EGhBDznMLLogAQxyuS3NrWEYvFFl9x2cYtm9tb2gVBAJiztKxJrA3r36uaOpWdqT3lzExDAADE4EQ5zHUZxmDO3Nn76vdEI9GBgQGvliwKnCyFeB4P98h6D/a+QggxhrZtAwTzC3LjfQMr33pbkqSioiJCiKZpCcMIBoPhcBgCwM6ue+1TmT7VJnl+9v6DB665+jrGGGGUUgpcCiFkwIUQchzndV15BxBgxhhgjEHqui4hxDIdxpiiKJ5a9KbU1tY2ZsyY+n17VFU9y768c+gW86peU6dUXXft1f9avSaqqo7jWJb1ceaJuKZue8deQd/rLUSMeiGzl7vJz8/nBSxzIocFjPHQ0BBDMC8vz+fznQXFZwJ92ml4r+Xmm29et26dF9xLkiSKoigIAI1uHfiENoYYY5iDuq4jBBRJJoQAgBijCCFV8RUWFnpdWl+knh4JhVJaU1Mzd975Gz/aEAwGiQN0XXepQ5yPqR2O7Uf2bHihPkQMMsBjAQCIMSKEYARc183PzwcnxO/fEo/PwA0A+N69321qPJ5OpwVBwBhD9HFjPQJw2BX2mmK9WponvoyxTCajKJJ3CWNM13Vd04qKisC59E9/HtC2bVdVVS1e/OWHHnpIkmXGWDQa5ThuuCl9JM3eNw8Nz3Guy1pbOwkhmpaxbTsUikiyXFFRAUZJ1OcD/VmBA8cBAGbPmaX4fAzBbEaz430cRBBCiNgIkwQAABBg76Q3JUPTdV0HAACIg8EgA0BV1XHjxoFz2dfwOdvrPWT33nvvhg0bFEVJJpOm5Xh226Gf9CQPt+eM9Bn9fr/P5/PLCs/z3d3dqqpu37YlEAiMXAOfPT5P//Qw6AcffLChoSEej4dCoUAgUFhYSAjhed6rsBJCLMvy+/2WZXmvnjFmWVYikfDcXcpYNpu98sorA4GA57Wf5dM/5z4XeGL3Sjwef/bZZ+vr67PpjGGZCKH8/HzLsgBAjDFCiCyLHlyO45LJ5ODgoLc9QxRFRVF4nn/66acrKyvP2F/674IeHsPtUZTSRCLR2tra399vmqZpmrZtE+oSQphLh7cwQAi9duVAIFBRUZGTk1NQUHD2BH8xoMHJu2vAOW5oGqVnzv6hX8A+FzBi58Kof4Nw9P8P33U2Aeynjc+5EEeNYbN39gZieIya/Nncfs4bGdjJAfOp1I667IxjlMdyNrf8H+A3ZdvUfUQnAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXPklEQVR4nO2aaYxl13Hfq+os9769X2+z9KzkrKQ4XEakRFOSYZGKLCeyZTsBYwQIEiAIEOiDAwdC8iGwgXxIDCRwgCQOFEMREiQ2lA+xEEoGDVGRBImiRCo0hxxyOMPh7D0zvb793eUsVfnwevaFQxqmY4SFBvq9fqfv/d16/3NOnapCEYG/akZ/2QAfxD6C/rDsI+gPyz6C/rDs/UMLgAAAX3t73UfMLAAiwiCTMXLrsFvfvk9739CCAHjDW5ENPhYgIpCIiAQYBUQEJ4h4DVXghit8GNAILAACNEFAYERkhsiAGN+5mH/xK3/y9/71D49cGikkRGS5hojXqPkOl/+LgQYhnNweJ/cmL0BEiuCPX+388j9/4acvn/rbT279o/8z+ncvdRiEkKNs6ESQAQCR5c85l+QDGYuIRGZ2LMLCIr/zX45u+43ntvzKH/7pS2dF5M2V4ql//86X/+js8qBkkRCFQ7zun+MdL30Phu87YBKYeJgRNIsQrq4V//A/vPLSG4OaiX/wW4c/98Q2RiHAr/1k8B9fWN5qs3/x7I7HdrcBGIQiMgFBZFQf3NnvG3qiC9lQCC+N41e++safvXt5uprs3pz86qe3nro4OHWpW0tNzdJzPz1fm5lPlf+Fh+Yf2bP5gW2NXbPNP98k/EDQABCiHF3LL3TL44uDE5cHFy/1Rp1ePuy5cT4cOWMxQtBCYG0l9m17M4uO0Teqyaa55r5dm5/82NYnd7VnG8lfAPR1s/6617w4iN880T/fD2trozMnLpe5ywb9YtArs35SbUnIQ94P0aX1uZD33bhPSU0ZS4AYQ2QgozdtX3j88Qf/1qfvf2p389qEFhJkvLcJejdPCzAKCQKIICIAfOd09sLpXn8Y1i4PF0+ej8gmsaBNvro6WL+gbS1pNMvuevCZTiohBCgzldTIaImMAAqDNQq8p7Q6d/+ef/Ls4c/vazMgTbQm97p+3+XJGK8sxgIIAC+vlH9yerS+XvbWx4G9qZlKoxkFfb+XtuqNqc1+uEyRdb0JqDkSoqKkxhzLUS8MO27UKUb9bDhwYZwo4NHg6y+cON31JBje525zR+iNpRQBAQh57Pg7p8YKJM+CqiZrF84Wg05jtm1BVGptbcr5XCVNTKqhGEM5jGUvjro+73E2CHm/LIZ+1A35uMyyrOTBONp6M8v91777DiDo90MMcLfxDEKAEAEU0LfPZavDOFjPkpRWLi7lg1EEGfd6/e4lcWHtrZeHi6+LG63+eC3EQlea9YVDSX2q0t49Wl1M2/Nlv4uxdIMVO7UTR90x4fLipZlNm156Y/zdQ5uf2T8TBQjpHv19R2gEAgQBJqB+we92XDEu01QPshIqlekdu8br3XPf/4YkSX1uT+f4D1v3HR6vXUTnZnZ9llBqu58oV8+qxpwe9ZVObbXF4iVXmoIr+rG72Fda6Zi0Zr/90uln9s8pZAAGRrgH8jt7WgAQRIhE1gL3RhEYsQLi1WDx7OkffnPz/sdc54LE4eLrz7f3HG4t7FczuzAGNCmXQzdYFpOMlk6LKN8fYGpHx55zw/WgNQA0dz4Se5dPvvbtfV/4+6eWWz9+p/vUvnaIohTei7PvPBHxSkxDeGEYLlzqRSXMevnYO8ee+8P5XQfc6unRuZ8VF475zoVi+R2hqJQhrQySMja4wC5XxFqJ0qiMpqSOHERE1VrN+x6tNtJKo3n0v//2+WOvfOvNVQbRCvHeAqn3mogAAHx+uSxCbDatKzyW3b2HD+N4+fKRF2zaoPpUbcsel418IK11KHPmoNEigngnIhGJmYFF64S0IkKiNOsu5/3lhSd+ccuhZ1bf+N6bx989ulQCcLjdKnLronxnT8sk7o0AdHopazSqTKbore99YO/hL/1NXxbaVlEB6ZRsSqZKHNmVSsD7kqVMSYxJQDSyC1KyEJsqcBTUocz6p47YdDpfPputnO6fe/u1//n7Ry7lIngrjVzZIu4JGlGABVF1CznTydOKvXzqfAgRUcpht7ntwMzuxyrNeVKK+6tpa0Yl1RBLEdEAIjgsY+4DgaMYNSqSoJRiZlQkXNg0URjXT/2Z6CRptNaO/uiV19+KiAQ3e3WD+Ma/3kUewIgAcGE9z1lrq1ZOvZ1gKUqbpLr9wAN2ZsE2ZgRKrCa6Ni9AxFEUCcT1Tv+zj+360qcf6I1y0goAnMsEzMRzsSyS5nzeXVTVaQnlws89i7b65k9+tOYFAAQEbieJ6+0u6/TG81wecuFKZgtlRhBjXpZY1mdm01q954u0vgUh2FqTUBhAE43H41//zMGnH79vYa791ulL755fSgwQo6BCpcUFXW2IiA8cy3Lzx34+adX2fvEfLy1dPnGp3LwjnRxvJg6+pg28HdmthgAIAgArWfROQuFivxujlN4pIZXoSr1mmvNJtcWuoFpbEIzCcjx65vE9Hz+4aTTOj5y88AuP7mYGCRGA0GgEBRJ1tZZOL0iMC4c+3dp5oLj0rjGJjAe/9/Vv/tev/wEBxhgnnr6Kfnt33tZYEABGJbPz2Wg8WjmTKpNW66hwNBxTWt9y8AmWUI47xjSIoMjy+7dPHbhvtj/O1wdFZzBOrP6Nzz1ceIeIgiZKEIS0sY2Z5/Y9XpvZWgzWRhdPCbuiuzJ29iv/8muvv/76RP1XcW+diHeUh0RWio4dO/bSW14ndtjtapvYmanhpWWsaJeH5tx8LzhXFJTU2Kau18XoltZ6//vF40WMwl6BFnCFC1pZjiWZCpFWSGXebU8/XmlNu2Lkeut53m0qPRyseF9uOvTXrbVXQW/FvRu0iKCicea+/E//FT3xD6a2bRv2ejZN3agoi6zVni+zftJqdM+XnPcIkKIC11dKDUbDXq8AjETEzBgdKmMQApPSCQGFKPWkKSL9S+dmdtyfd5a1ScWNfG9l7fKlTz31+MGDB5mZaCIBBiCQCKjuTR4Cy73uUq6zcWAAHnRckY07nbTZZCGTJMF53Zhm50iZSIAo/UHvUw/t/b3f+pV6av7Nb37pqYfvf/qT+3/3N381sBALk4pIgAy11vrbr5A1+WgQfIG6SiZJK43BhbfOH/mJSJwATxIVDAKoROK9QSMgc7XePv3810fLZ32UvNeN3ifGIohNdPfiRQKiShLQIJAb932IzWqya2EGUS3MNlrNamoqW9tNABZwiArQoDL56oUYBlL68dpFOzWNEm29bed2Ub765vG3z1/sRCAGwQ2+iU7u0dMAuxdmfvGXf627sjS6eFzAuOCzQZ+VaK3H/Ww8GA87K4TGVqaD98KBAF3wziOQ9gGiK8ui8EEAOPqALEAqxlj2l9iHcrAKAL0zR1sL+8mXtfn78tI989c+16iltJHWYdxQCNyU3LkjNDMD2mgbtdmt1dmd5agXgwzXVtbPX3LOBcBYDAZnj+Wjrmlu4lCCqSIisBg9yS+wUgpRkopRKkEWRgRlJRYYXcz6lZmtvbNHKbpkeluR9atzu9yoJ9O7+qzwhsTZbQhvD42IhHRpFE+th0Nf+DWTtE/84AUCLAfL4DKljcvG5Xg0XD2tlPFuhDohVAyijEZUMUYBIp0KGRIQicBOgFinwBjd2M7uilr3F09M7XhQfIhlUZnZbhHe7MQXjg8EIeIVto3z3g2cd9P0bKIO7p6b2n/Ij9aG775sp2bjeFydnRXCkI+p2kBQAEFXZyEEASaiiBqFiAhESAG74IOgMqKqCrUxJkpAUK2dD3aOvaisMfM7x/2L2iqstpAqMO77qBFgI+16jeUePA0AwGINNKYq9Wbl3e8/hwiVuYXa7CbUFQ0cnWgkU5sFABHxUqqkoiptjl6QgRQjReaIQiQQSxERiaBScWV9x4Mo2D/zamvrvpCNwrDjS6dIUDOHcktbgwAJCTJvHKnvLg+57jdhFoIz9dM/+u7qO0dq03O12a3jznpwnskOVxfLUSedmlZJDXVCQsrWERlQsaD4QoK3hKIshCjei9KCjEqTTSpz96++9X1ETNtbR2eOMYjrr0jWjeUYGAfjjaAagehKnvWu0DeaUfrc28eO/q//HIuVmd2H6gv71y+eXD17fH3x4mjpbNpoAOrqpv0qbYJMEgHkyigcRKKLgQA5RDAoyCwBgEB0pTHfX3wzjLo6bbELZdklk4qyxeqZYvVi9/SrR8+sA/DG3rKxgNwd+oYhbBBWj73qhquk7NTeR1TMG1v2rL371nhtubGwa7i0OL1jT6U+LZp0xWBklAjCCgFRBUZALstSgUVEKYpYjHRrzsXgOpc9sHAYLp0wJjFJmkzNjRZPijLDM0fyGJ1jAAhXMN6Hp4UZAKqpij4opWpTC72TRyqJ2vLIz4/W11ZPvdGanc+GK6VDnbS4cKHIfT7y0fnIwBijEKFIZGKtEgQRiVhtpwsf1405Ga0pQFcMWFRldntjerOtVHV9Khv2UIK1hBsBBsG1NO17QSOAMALAnvu2i07FZZhWxFTIWOGgk2TnoSexNq+nDtT2fYJdWbpx9E6CDy5GBmAXYxQBQZLgmSMgGVsjQDRpuv3nzMJhIWxve7gYri0d/YGEqNtb0vpc6C8dfe3I73xr8WfnugAgwJMc/k1L3h2jPAYhgB1b5lFRohL2vXzlbCWx9UZa1mpZSSZtUYzDUydCcFCM2VgiEhFFgAgAbHTiXXAlAxnQgW0K2VB8QRVo7PxEnN/DPEhb82lrbvXsm/nKufqmbZw0WsXS3zi85Xuvndo/125UISIroZuivTufXAgBoF6t8Hjloc980oyWB53luUOP1rbvKzuF0YVzPuv1AICIfD400EBtSCtERKQQWBtyZaE02nrTMWqhUgQRmUh8nm4+CHkvO/6n2tqkOm3qLYXY3v+Zqe17P77VPL71AEOECe6VOsl7yAOuFHXIqkO//o/ydCFbvbjtsU+pTQ9kwWCSDnqjzuIiBzb1aUREhpj1gSyj1SZBBBHhECWWSJqUBiTvMtRaRAAVmZqEQtXnage+MOis9d7+YdqcVY1Ng0vvzD7wiIvAAgRqUiUDuc2OyAB8YzUQWECRAuCjPTv38C8lC/u2Pfn52gNP6alZIhLH5ahX9LuVVqPanmYGtEkMI5/1VFIxFpXSAASRhRARUYDITr46Dl4pY2wCqCSWyjaaB38pmqlysOLH3Vpr6tjJxa8+/yZNKn2TUy7evIDQ5AevFjWBZaOABX/8yuJ3v3/05Hf+R3Vmi975YCwdMoQQIojLCwGotaaUBim8aAJKQtYXX6a2wjoRZCQQRmARrZlQKUUqiTEiCqV1BBYRtCSazPwBau+zjQZ4WH333H/71is/O7UMiLyxCN+c3qOrFVUBARERJMAiwsuL+Te+9/alt17dtOcAtndkgwEjSASOUYJsnJOtjZFdtm7TlrYNinmZ9a02yqZApLUGICDUSMAsaCQGDRIFySaEOviS0BpSoCiKrd73KZWkHPKh52//4LiAIES4nelJvQeQCESQEOBCP/zu8xdOr0bkytz+w3s+8VBRFOxc8Bh91GRFcnalThtaa+99KEdmal7ZqijtXBElJEmCqLQmADRGATD7QpuEqAQU8CNla7HIwOXB1q1KbHWG8xGgThd2+sEwbUz/9I0z/eypdlVP6ho3pxAEr/qbgAMA/KfnT33nxTPo/fJSp9luMkdEFaOJXAIAg4ggoUajgwclwszAkdIKmopwACCtLaJCrZC0tRZilBBUUmVtGW0Y90gZL8AhiC9EBK2WxHrnTNousrKa1i4srx09vbah1lu28g254EZxGwHg2cfaC02Te6cIVLUuAqF0HCMIiUiZF4qStN2OMZb9QdJoEZH4Ak2qbMM7ERE0FhBJK9AGEYFDABClkZSpTiGqiBE4ciw5FCKitEXQwXllNBpdlCPv6bXj5661BNycFtvYJREAlFIM8aF989/4Z0/umUIwqdbEHBkItIoRy7J049KJTxtTqFQ2XK9Ot21S9cUQSOukCqZSlqVSChG11khaEYlEpQwAoJD3pW7MICjggD6IF+cz0QmZGnvv8iyMeggqac+cWlybCAFvaVqYyGNSWmEAQFAhyuaGPrS9CjZFjcI6xsiuDJ4JlC+DL4NNq4mx9Zm5vN8Xk3L0yILK2MYMMzOz1YkCrZRG0kohkRaJkA8wZPWt+4ADkJ3kChkIRaHWEHyM0WdZOR7ppF6IBQECFIk37YhX5TFZ/gABFAEgLI1CUrFcRobovYSCBcHH4MvcZ2VQkFRreX98+fg7je37SSWgSCUVZbQxRjh4Zq2NoAIViSyDp+CLfFDd9oBK6yHLgFBCABJNhCgKIMQijPrV2dlysFaWcX56ShAEAUHdFDDdZhtHRBEZ9EfGGJ9nqkzEBUEQgeiZg48+VGqbOoOeG+eVVqvSmi47S4iE2ggorTULxhittaSVAo3GKpVgFES0jbliMEBFMR+yOFRaUAEpJtakXdY11WlxWTbumGQ/AkMEUYj3eEa0GoIrc+fj2JWl8z54l+fDgcvGSSUVYVutIaIxibbGziwAIqoEEYnIKA0ARAQqNVZpZUCrQKCTik5qQIhgkEDbBlXaG8kklBgjAkAsTX0qDLtKIQCJus0x4DbQk42jkmgOUg5GZekhOBZ0mctWVkyljkqN+r1Ka87UGtGHIsuFydbaYJIoikCSJBFCIgKjNKFK6mBqBKxrbUFFRMGNVNpMZnaAz0lZVIbQRFcUaxcFlLYJMwszCESRWwsxd/T0I3tmA0cuMjfs+9J1zp2EyGDQ5YWLbEwSnK+0pgtX+lGGikBYAwYWIq2M9WxsakUQUZlK1aQNBKNq7RgFYhBhUJaSmtI2OO+G64JAxojLlbEMlCTJJ+9vAgLJ1aTePUB/7mPzW2cqtlUniOxzNxjGsmhs3hK8B+9CcPmoH50n1CGMASgIaa0zH2NAo6h0XLXJZGkXEQYyzRmdVCR4FtSqQjZBYDFWyCsyyiQ6ral6S5GEEPfvWfjso7thowWH4D01PZmIrar98uf32vrMePlM0Vmb2bHHOVdpTNmkkvf74/6AQMUiJyKIihmADOjERS0Kp6rVUZnXE3JASFpbAwCoLKEGZFQEFEUwCkMMKm3qxjQpY5Q1tRYKj138O59/RCmMKOp2nWW3WT0mmo4Snj44ffTwln/72ov3PbwHbTNJde/82Xx9BbQCVGX0UsYoBYGK7MmNmWHFpC++dsJAefLs6uZmvbO8eu5Sh1xW9pfJGNQJacPAIEYhsICq1sFHDpmY1FRqbtAfhMoXn973d58+CMAK6Upnwg2HgDu2TkzQs5K//NUXf3yyF8cu+sLlI3Z5HHVDORCXQTEORTeGTIUoHDgWAlHpRGuN4JMkGY6KRsW6Mi/LHIDIVkhXWCdKJ2QrSAaULsuc0KYzu9PpWT1aOfzox37/t5/dVDVMQCDCxMRK6PoI5O79HgAAwvzKiU63N+itXlpbXlnrd30+dmVe5kWZ5eNsmJU5lx6YI0QAZs8AEMEjolUpc9BakyGl1OR+KKAUiQhpZaii00p9amr7jr0Lu3c/emj//u3tyX3xinc3jrf3Ci0RNmoIdH2jzdWikzCULMFHDsFHjMwCUeKkG4yFEUQQBREn4w0pUkCEREBkQKFVhIja0PXx5w0FTxbAm0PTu7UDTa4TAYABkFEAkRCZAVEAgWHyPBu3kSuyYxG5KQ1+3ZpFV6+/UT4DQAEBYRCFdP1Hdyru373xalLy2KAHgUmb0dXLycQPkwHXJzknkRAz4sbXutFPd0Pgw4jqhtIbXOs7AgCQeNUp9w7NV469JCIIeOUL5Ktq2aC/7qkArj3QlddXJv71Arv2kgFg0sZ03X3ham4Jb1w33hMaRCKiEoFrAgOh6xqkNpw3ObDdeyfmJE9+s1BveBoBBhEEtfHkN2rlPfvyNvwtgneq6l037H19tNFudP18mBxIrsbJADBxmcAN3W8fpJnwL93+P+lU/3/APoL+sOwj6A/L/kpC/19XsFdsNksaCwAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Native lookup without vector store (it should be not as fast as vs)"
+      ],
+      "metadata": {
+        "id": "diWviyadHNbL"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def semantic_search(query_embed: list[float], embeddings: list[list[float]], top_k: int = 5):\n",
+        "    scores = []\n",
+        "    for idx, image_embeddings in enumerate(embeddings):\n",
+        "        score = model.calculate_similarity(query_embed, image_embeddings)\n",
+        "        scores.append([score, idx])\n",
+        "    # Sort the list in descending order based on the score\n",
+        "    scores.sort(key = lambda x: x[0], reverse=True)\n",
+        "    return scores[:top_k]\n",
+        "\n",
+        "\n",
+        "def search_images(query: str, embeddings: list[list[float]], top_k: int=5):\n",
+        "    tokens = model.tokenize(query)\n",
+        "    query_embed = model.encode_text(tokens)\n",
+        "\n",
+        "    results = semantic_search(query_embed, embeddings, top_k=top_k)\n",
+        "    return results"
+      ],
+      "metadata": {
+        "id": "2rYXOdgtdKTi"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x = search_images('blue bag', image_embeddings, top_k=10);x"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Xrxqumz7mhls",
+        "outputId": "48a652f9-e48e-49e5-a6df-023b0bf58f40"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[[0.22824887931346893, 4414],\n",
+              " [0.19111284613609314, 118],\n",
+              " [0.19099275767803192, 1158],\n",
+              " [0.189880833029747, 3885],\n",
+              " [0.1881013661623001, 2623],\n",
+              " [0.18806062638759613, 1114],\n",
+              " [0.18627814948558807, 777],\n",
+              " [0.18402709066867828, 949],\n",
+              " [0.18311555683612823, 3729],\n",
+              " [0.1786075383424759, 1301]]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 72
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from IPython.display import display\n",
+        "\n",
+        "for (score, im_idx) in x:\n",
+        "    display(images[im_idx])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 777
+        },
+        "id": "HLy-GjKxfylH",
+        "outputId": "722aa524-bc88-4cfc-8c0d-a3c51be78dbc"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x60>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAIAAAC1nk4lAAAPe0lEQVR4nNVaW29c13Ve+3puM5wZzkiyrpQli7IsK22toKkkB65RBQiMPhRGC7QP/QdGX/oDGqSvLVAUaB8CA0UeCvTBNeK0RRALLQrLdmzEUWrHli1LtkiTIsXhZTi3c/bZt9WHTR4xkmVSopyiGwPizGBz7++s/a21vrXOIYgIj2horaWUAGCMI4RwRr0HSgEAtLFS8qIokyTa/UZ090tUg3MOAGVZck45p6NxThk4j6rUUnIASJLIez8cDne5EXlUllZKxXGc57mUknOO6AghxhjGGKUUABBJURRpmgKAMUYI8X8PGgC89wGf95YQ4rzhjDvvGGVlaaIoCgeLiISQ3Wz06OjhkQLx1qm8oIQTQrxFALq20vvZ2+9458pCA0JZKAKkLNRutnp0oAnRWiNinCS6NIB0OCj/4qW/PH/u9//xH17+sz/987fffgcAojhWRRHF8W62emSgtS5kFDHOl253GRO91eHf/s3fXXr9v7/1u89+76/++tkLz/3gBy/r0jhr4yQxZleWfmScXrm9OD8/3+2uxFFNa7O60o+iJJIxACzeXqjXM4+6Vst+67dPdzqTcZYBeXh7PTDoMJsAGOPAEyHp4tztubn5LxZuraysdLvd0WhkjCnLUilljIkjjohZVm81J5Mkm5hoTk9PP3Xq6f0HG0CgyFWSxgBQ5HmSphtLfx2gx6NRrVYLX968/LNf/c/7N2/eXFzuFkWhlEJExtid+V4b4yilQkTOekSyb9++w4enzl84e/78+fpEbTzKo0jwKgJ+HaABABEIgbI0P/7Ra2+++fbi4mJZllyyEMsopSHwhQt01hiDiISwoijH4zFnolarUYYXLlx48cUXjx6dAgLWGC6Ed45yti2ABwZdliaKxPz8wo9/9NqlS5e63e7+/QejKNK22LwldM5578M9CMGMMdZ67721XmtNKRVCUCCMsQMHDrz00kunT5/6mi2NMDsz/8Mf/tPly5e11u09HQCIosi5EhEDVgAghIQMIoRQSg2H48CcKIqSJJEyllwURQEA9Xr9+9//3qFDhzbi4A5AP4wLv/LKKz/96aVms0k5azQahJCyLLwH78E5tNZ7H1am3kOeK2s9AGz8SikAWKvX1tYajUYcx1rrl19+GRFLtdM4+MCgr3306X++fqnRaEgp6/X64uJiliUekBDCGBNCcM4ppYhorTXGqNIgUCFjGSVCxkLGlAnrcGJiYnl5uSgKRPzwww/feOONnWecBwb9+uuXEFEIsbraY4w1GvW19R4AFEVprQegjAlKOSEsfKSMhYgIYcY4pZS1FgA459ZaxpiUMhDm1VdfVUXhndsV6Irr4SL87Xa77/7i57kux8VIxkIIoZTOkho4JnhkjTfaAVJKOHoCSKWIvTOlyo1WjFBOhSmdVtZbcJ4kWerBjPIhodHySv/nv7hCOYbxkKArIRaWMMYAwNWrV2dmP2ecMMaMMYPBgHPuHSCiR0WoI9QBsZR5IQkXQCgiuvX1tW739mi87tFShkkq252mlGI0Gjjnms2m1uXS0tLs7Gxg/7aDf4WlCSGV2gz54oMPPnDOGIPD4bDRaMRRyqgoyzLLMuep1jZENyklIB2Pi9FolOe59z6J6+12u9VqEYpKqfX1dfQEADzaPB/1ev3RaPTZjZuc850Es/uC9t4zxqqTCqCvX7+utWq19iOOuksrExONNM0oZYPB0DuaZfXOvubkZGdysl3LJpxzRVFY6ycnm+12O8syLuhgMPj000+vXbu2sHhTSGKtWVhYKAqTptnNmzcB6KZQeCjQgR6EkGByRBwOh7du3UqSpNfroWcTE63JVicf21areeTIkWNHn26397Tb7TiOCWEAAEi99yGeWGtDVG7UDk02pk4+8c1L//Wv1298VOqx1ho9jeN4bm5uZuaLqanDDw86jM1KCQkhCwsLeZ4bYwD4RL0ZR7WT06ePHXvi+PHHGSeTzcNlWQ6Hw9XVntba+5ACreARpTRJkizLOJfeGwJ8T+ex71z8w16vd+OzXpplziqllHP2o48+2hXo4MWVvQFgZmamLMtGo7WyvF6vNc6fe376xKlOp8M4XVpauvzGvywtLd1amBsOh947RGetNbasZROIRMqo2ZicmGi2Wu2DBw7t379/ot45f+751dXlcb7OuShLwxj55JNPXnjhuw8PuiJ00BKc85mZmX6/X6vV2u3O6dNnnnnmmwT4eFxeufLeT37yH4QPAIALmtUFIcQjMialTEejnHOBvljrf7G49BkAi2QSRdGFb/3Rc8//3nu/eOv9DxYmJzt5nnvvZmZmtkX8VaCdc8H5yrKM4xgA3nvvSpbVAXmrceDZ8991hicZfe3f/vnKL99Na3Gj0cnzPIqiUhnBhTEGPAEfxZEI0i9NeFhWa2OMevXf/35m/sJ3Lr5w9erHziskI0rlynJfKZUkSYhaAcO9hfB943RgM2x2M9bXB/1+33svZXzx4kWtNRf0nXfefvfdd+v1uuDR2uq6Li0BFvJ5FEWUUqWK6qystUH9hQmPPfbY9evX3n//l1NTU/lYZWldCLG2tqKUgs3kUGHYqaWruBFAz87OLi8vO+eytNFu76EUbt9eeOuty1Es6vX6gQMH0zQty7Isy5s3P8/zPIqFjDihDhGCUwL6SvpRSqVk3bw3Nz978uT0zOw159A5dM6Ox+Nms1lJxQDmLmN/lfbYmk7n5ub6/T4ifuPM7wDQJEk+vf7x4u35AwceG4/zsCUiIYQIIYRkhKBzxlod1vHeu80R5OtomHc6k3k+rNfrhw4dGfRzpRSCy/O8urfKfDu1dDXbWss573a7xpgkSY4fezJN6krlt27NxgkfjYaIeHuxSxlYa6NIeO+FFM6ZgI/SO3e+qStIkKlRJLvd1aIYf+PMMx9fvVafiNfXN+jxpQbekaXDCBusrq4CQK1Wi+OaUlprvbK6lGWxNiqKonq9kSQRgNdaW2udReeQEJamtbtOLCwYqoG8GFlbKqWOH5smhKdpqo3K83wr4i8VT9vTI9zr2toaIjYajSxt6NIaY4bDPmU+TeOiKKIoHo9HShXeO0op5zwIPWt+DTHZMkJ8SLO43+83Gq29ew5QyoTg4/H4Xgx3Qd8edAh8o9EIEbMsQw+EkPlbc2VZcs6l5IyJUhnKgDJAcKF/4JxDROc8bLKi2jgUvMaYWi1ljCwszgsRTU1NKaW8t0qpqr68C8n2oIMlvLeUgvc+iiICPE0aCD5JRaH6qhxxLgeDnFIgTFtrAxQZcSAewXm0Ho33NtiYMiAUg49RSoAZpYBQ57EoC5hs7UEsvOGB0wGxMSZEvbuYfV9HDLOd88EwBw8eZIwNh0PnDBAMhxhimdZ6NBpVFqKUhtPfLArBe7xT7cKdqAdbQngIrISQoihCUQObKeJeS28jmDjnAcqRI0eyLIvjOBAyz3MhRGAnegxCKiSOsHegx+ahbTCEUkrJHct5740xBKAsSyFE2GirI1XT7soy9wVd9b0JIYTQxx9/PI5j7z0QTym11goRhcoKGGitGGOVs1ckDr+E/FL9tHHifGNysHSapuFrvV4P5nDOhUMLd7sj0AHx5l2Sw4cPE0J6vZ5zTgjOqCDAgp9RSp0znIsqcVTcCKYKaMM5IGxkcs4h5HNA4r2v1+uMMQLQarUqStyv974NPUIngHOJiEmStNtt7y2lstlsBtqFAFcZMlxUGoMQEiqRLZFrgwBoHKfOe+89McakacoY44y1Wi1rrRDifsJje9CMsdC+GAwGSZIcOXLEOQcEO50OYwJxQ58QimWpK1YES4fuh/cuTNtqOUQ0xgCzISxaaycaiRBCinjfvn2V7AmTKaV30Xob0LDhwrTSD6EqCc97Ah2DhtRaw5ZuWDW89wH01h/DNLoxkBCShBFne/furUgFmyTZqTR1aBG8cy7MiaJoPOovLsx+MX/NlDyJOknKSrPmPWrtjCmdRUBKgAFS9KS6AOQE2J2vm5bmwK3pEQSnCaVaCiF568DBvfDrmfhhtEcVECilQSIDAGNEShn8PUzw3hKKQHxIK9Xf6pfwqa6BbPQpA/WdM4zRNE3DAW47tgW90S3mnKZpaowxRhGKXNAkSUKPq4oVcE8WwC0DNjXq3dcEg+8Sgvv3798VaEJY9dgPAILM6PVWCzX23gJ4xmh4nIXogPitTnYv9LtuI2xtraWUeO8JxeGw3+v1pqendwcaCMIdFxZCxHG8tramdQHgAaAqn7z3AEgIAnhEh+gA/F3XAH7rBEKQEGatZ4xZqxmD1bXlwWD91KkndwUaACq/AQAp5USjZmzpUTMOAF4pxTkPQQW25JH7WmHLBEII4IafBX8YDvvtzuThw9s3PbYBvXVEkeh0OrVazVoN4BF8URRSys2Y+qUE+BIxXV2H5lPQBQCA6M+ePZvszBG/uty6g4NS2mg0JiYmtFHOOe9JUDno6NYG2r2W/tLIRQjxHgSPnCuDAOacP/XkmZ0ghq/kNFByZ1cAevLJp7iInMqMGY/HS5GIGKScEUa91VDp0qCcQt4BAHQUHfWWgGcUBCOSgkBHCcudN5QkjCZcEKDFH1z8dlXcPCRo2BS71SrHjx/PsqzUxeTkpFJqYWHBOUcpZFlWr9fDGxNVquOcSymllEKijEBIpMwC0YQaj0qbUZbVnXNSSin5+vraqVOn2p1OPi52ZWnYZB4AhAR+6NChZrPpnFEqVyqv1TPnzHg8TrMYAMKjlookQV0opazVIWI4ZwA8Y4RS8N6urq4KHjFGQp/yzJnTgDTNsp2A3r4ICCbXWidJcuLEic+vf4Hoxvmo0agXReGcQcQ4jj2SIEJgswgwxhhjOJebL4H4cALOubIsszQK8wlBQvDo0aNGa0opE9vHhvtrj015GRpqQV4/++yzcRIxDmtrK3v27Hn66ac6eyZD05oxUn04p1Ly8CEQEYgApXfcGqpL0CUYTcJ7QZzzEP4ppUJKxrcXcNtbGjYfCQT1PD09ffLkCWNK7+1oNLBO7du3z1pblmW73Q7WtdYGp+ScM8aOTT0Jm7p8Sy2D6/1VKbmU8vbSwp697a2P0x8edLXK1gqUc/7cc9++cuXKEyeO/fGfvDgYDG7cuNFqtaIoqtXrAFDhDoRWSqHbkNcI3vnQc6JCiPBfhRqmaXru3DnCAB0Q8igeM9/VbA15ZHZmZuroUQBA7wmlAGC0LpQKAQQ2+rl6NBqNx2NThqdHNlBZa80Yi+NYyhTA1yeSbvf22bNnhYgoFQBf21sIDzQedP1tgzT8BkB/HeNRvkz4Gxv/L0H/L/JG1d5HCpBSAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXtUlEQVR4nO16eYyd13Xf75x7v+0ts3KGy5AUd3HTZkqWrN22ZEt2G8Wt7TpOHBSJ26BxW6BLUBhFgSBAGwRJi7ZogcANnBpd4LhF4Ra1jMSyHDuVtdkWKVIUF5EUOZzhcPhm5s285Vvuvef0jzckh5TkOmmgxIDOH+99775v+d3znfs7555zSFXx0yb8Fw3gzyLvgX635D3Q75a8B/rdkvdAv1vyHuh3S94D/W7Je6DfLXkP9Lslq6B/uvYvq6CJ6C8Wx59KfprN46dLrKpesw0RGfy8NvKX02zobZegqg7G107gL48wIJBViBenL3/tq08fO3yOiJiYmCEqIkFF9epM/t80I+84otc+cNN9rulu8CUiXsI7cRqpKAghBGPM73/pf3776y+eXHjxk5/98FNPfKYZjUztGLvx2QxAEFSVlAEoiSqRQgmkAESVAGG2YFVVCqRGAWaBEhQMDT/m7ZEiULAcXZ/MW862SqCrthsja+fL/Wi2r2d/77/85isvnfvbf/Mf3nv/AULUaNTSzBqyaZoyDAhYvRPjhluaNao1IMBe/4euHenVy68dXD8WC/P97x0+/+bcRz/+wNh4M6g3dO0uAGAJgCgxQxFWzOzSqX/wxS9+/lO/eKU9/cSnf+bXfu2fjIwMLRULQ82xZq2ZRHFWT4eyoaxRS7K40WhYjsoq7+c5k4IV0I0bN0+sG10/uWHT1HpjqKjKyKRZlhARyECDtVaVajbuFTkRG8MA9fLckh1q1gXS7Ze/9S++9K2jv/9v6Lf/1i/8XYZRBXCdMOzgFRPMhfMLx189Eix/9OHHwDIxtuVTH/rVf/vav7amlpIWK77bbmUm6VTLCdVE1GuIjY1M5L0QEbMNWqmqc5WKkEGjPuTVO583szFlOFfW42EvBVmbcGoQixYA9yUPUhnhLGpQROpdHNVCqY898gnTnP/jF75x+96HR0frBL5GdFYBiFHWmdfe/FHPx/d+ZMvkOgkMhjXUq7rz7YtV8KxsFCvacSwwSiA2tlFrEBlAIAQ2LkDh0iyznBhEqhqTmKThxSeSxhQFVxHBlCbYKgQPZnWVhoINw2hRdvNOwZGte7/c7v3OF/5dqz/zqc//7K88+Zu/8Vv/mMwa8wDgGRHpD8cmvjW65efu2wwTuyAJsfooMjb3BQVRRCBjbZKKsrKIxCYhz8oI6jkQs0gIQVXgPWCMJyJVFUNGENATVVU1ZD31NCA1mQ95xNYF550zEsVUJyJyQQ0V2qs3bTa6xy9vPP/a4uGXj7/vvv3XNU0QowDxV2cKFP2Rsq2qRgXAQmtZEVuVLE4jm1m2IuKCMxSZOBLxToKIc8GRUmZTQmSYYkotWRFRdQFqhCR4S8xk2bDhLEhJpAAIEdRADRN57xLrgpSeTBTKqvKvnjz5xOMf2b1n22RzLMsyrKFFBsBgCCTv05FvjZ45ilUy4fbCRSmXVZzzhYTS+SJ4Z4lN8N51VUrn++pKVhF1Hp5VVCmIG5j4wDGRMrERGAreh1JDHsFGhIjYaBSzqdt6IxpOuOahqmSZXagWu7NvnD67eOVio+F9xIQb2QNgR4gIH8rmr/Tbr79+TgnGqANOjU21mxNNG1SoUFFxliwFIo69iuWaMZGGkpmNVKUPDv0ap7m4yvdFYCJbSaAk8WVBiAGBBqPKTAQl9FRMLVAFGBUnZRTIqfOVCIKg3LZzd78/f2BzFBa68A5rYgoLhVEPsp+cGvqToebhc6e+9txLn3ng3pmV7pF0Anse7fiiAwMEGCYYJQIi1BuAobynLEiHKM9JCtiIJWiUKgt8STAhjljtwCtpFKkI4hgUk4iJNXQ7IIuiYJ9r6BvHIYLCm35houHNW3dcmTt7+KV0397hfrN2A2glgAxE99559+TU5Obk5Pkf/Hs8cO/pdlh88xKrIdsILGRTsFFOiBOlYOJIlNUmJo4krVPcBZFAJW4OnAsRibHwTsTDGhIlIthESdg5jWNvLEXjcH1qmBAcqkJtpMFDScPpUBv63qnTx77+jO/UdMckbZ640TxUGSSscWY+9/f/2nPfPuVbZ//gm//xWb0HrgcmTZpMTkAEZksaPBkjykqCJAKnsEzNIQ0liTBBELTM2dZC6BEzub4EA2OULUIJDQpBsESV+tJy5lGRMqKUbKLGU1WpajQ59j/+0zeq40fHp0af3Dt3V41uNA8iVWUQIE985MPL7uzCy1/69T/4k5P1hm3WQmuebRYiw1KprYkwJ7FQxAYW7IhEPEoTIk8UETsh1aAAAntSq3BkU7Jg51Ug1lNkNRiCoHAQBNNjRGKZi1IBzmI4FfiUcHnucve2x/NN3SxbGlDHNdBMECICREBW8bmP//L2Ax8ZrnlV9pSqlqKOtFKwWjbECiYrGhkfxQSBKiIiJBS8lgEizGxsSogUjigVa+F8UCgJM8gkTKQqJssIXilSw6QiiUUUifPaaXFiXDzc3vtI9cBT/ZFbjM0AXhvxsa5uXphApB7gDz70BYNbYDUOaC5c1F6LPDiwURILqIcyopqyKpOqauk0eJSlphGRwoUQQdkTImIleE0Sii2yVASKIJYpSQMBNoJhWAYbcEpxRgi6comNcel6sUPozO+cnt61+4O4UZiuhrAEIbZBZWjDpp/7q08hjquZ83vKYvPKoi4vQn3o91QJcaRlgTInRIhiiqyJmDTARqzQICwOPhBZjSLxQQMTWfIgz8RWg5AynCoiTlMA6gLYssvRa9OVOc6v+GwkQ+e+oVef6nz57jjevvf9AJiv7wwtBvGgAkpKKmADLO/e/9DFN83s/MLZ+kZXLOt0p2u5XkfeAYYH/KCqg7gt1FL0e6ReyCCxPomp9EqAOkQKMMAaEaRAEI4yKXOyMYyVAGILCkqBAO13eOlcCGHvSOvJsZN37Gz2lrN1ex4HWETWgh4E9QoCmIjIqEBxajFfeW32qbvT9ZNVr5r//AOdB3dfkryjGkBBYwsjpI6EoAowcUxBEISUSaGGqXAkBEo4kMJBlWILV4rPqVaDsSRQy0gjxJYjSypatKXbGh4xj48dG2vqXNgkd/7ypz/5BOEGxKtRHl2Pw4WIlFACJ+b7vx7et+XApnDkhQztn93dvtgZeXN+yfgcJpVGDckIEkMmQdljlWAjGNayhAU4ZkbQAFVhJiZVowFo1IkZIhx8YEPw5EpBUBeiciUszSmjyfmrP+wYWf/cPe9/ZP+hL6iuxXfdpq/tIa4aNy6XZa0ed+3oMd51etfHprEt9FbiRHnn/VprivRReeoto7sieU5QKDEJMxtSqpQlqLUQJQkQr8QgouCvPTUQg1VhhQ0Fx8G53pLJW4htb7o3f36D0a0lzJkLl7wSgcON+86ralcodMAhUPS85aSJyhnti7XPLO6bXgkIbYGh5nqA0G8j9MkXpqrUi5Q9rbqad4MSEWlZinikCallZhN04DJYrJoYXqBkjIEqQZSM9Lu0shxYDVvbW0yH+WMfXXp0s7+46JaDQG/Ozthr2uVB6EdUqpYCI1BlLQpic0k2fv/Ewdhfot3eSzxalJUv+spic64ZtlAbcVUJPEQhYBfElVpGGhxYJalR2TcQJQOpqY1YWaqcgqN+jtKhfYXyJUobWpad3Q+9cvcHH0+/uSvu/3Ff+04RQYVpDfBV81ACwCACUAnyoi8i2mxwLaMkoiQ6PnTHwpWsOfs8vJPL07ta02nRhmRa9KTM0V5Q57hfUOU0rHILayBLIEN5j8WHKFIKJMLMakBEKB3AXK6gXFKjWpWSNd32uzC264Vi/0zLo9KOdwDkRlWvxqkD1hOCATyIvTdxAkhQJWNVfZVFl3bd/770+OT4d8+MlTIfbVs5TxtXTnU2+R7YIpSlUahVioOKkga1EUgIiTonRlEGjpLAjMpTnksWwQfkK+QKVYIqyh41NgQXx7PPF5dbZzcfwnh/uXqbZMOaKVz9NxDEB5BRMqtESEaglNV+hEOhoof3tmAW+yvzd2XHfum2kzW5EPKSfCGslrwGp75QceQrVE7LJahX57kq0S+59BoqTSJjLIJn1xPXRSioysFMMd2Xfuc3tn3rTpphnyJLjHoARt8J9FVxglBWwhYiliyKkpaXEAjekfpn3jz49Yt72zt2X0JUSLwhWvrswUU0akoGVd+7nCWoCMPAO3UVeSbnyJUIFUIfrsfdvqqIBK6qQEZDABvOhhCP3Df++sc2vLGxkS5S1B5uIE0NMSA3cd71bYxenUEAUFWqit6KrrQkiqn07EohMSJqZKHaugDGlpFjy28MzZ2t1WXElO3xLbRwTjstjRKCaFSnoqBaKk6IBRxBSGoxTKyGEQQKGKVKECVadQMiY3q7Rgui2rfbtz679e5uxLGlemwBVsXaLNN10NeCEGakijYbJKy1GgdIpJqXbJPgK3K5kUp7Jak7eSHjdjwZz+TJEtW3yZb9dOIlLXLElqAwrN6RjbVyFBlopaWSjYktEGtZEBMbBFVDJiCwtW9c8JcPx60DO5b2rqfC1erJkF2TOngr6GtiACNeNSBpKrU0Ti3VBSR5Tuhr6IU8hzioY+mdurL+8vIVN/GGrhtDurUWazpzYWF4k/aWTTIkYI4qFaPqJYERiAtKbCKPKAlqjKlT7KXsQuFgjp2JdnodK5fj+dly3ZYGUxYPeFjWWvI10NdHSQHxrpaQL2EjFHnodbVXoLwClyNUJErkNZCCJYmWarc2i0uxOdN67YK0ToyGwNa0TBxcYFOEokakqkp5U+OUXKkwmjU1ilB1pHTQHKGgMieOo15HN23bu2P2yKwpRzcONZOmIbo5w3qjpgUwABFIBWS0LDkv0O9rewH5CoqO+h6BVR2RJROJiaCVNkdWStqvZ3Zs6F8q8sX5aKxmH76v9sKl6NIZz1lfbMpaalkpjymDjEFvSeMIwaMqVEoS1WSIQl5M3XH4wZ8/uL21udtZUDNVs5YGBs3vCJohAJg5Lbu+KKlfSL9DeQ5XUP+KVn1SUfXMEdir64MFwVBCsNnxC7x5XNLhcnHJtbszO4a3bhm98pWVZGlBUfXVNsGqriAJiDKxlrxX5zRUYNJQwpAOb83X70SaPu+2NxrTqm6qZggSAIO3B81XPyWCxGXwAg0FeYEvUbRVAkSVGapCFhAmoxCQwJdEhixfXBwjSXWsXpbL33/98p4N0aE9u5/tPoHeBb14VE2dCLCRIhixwVgyqhIolGpqAKthdeD2hXJoouJRCrQxSyCDUsSNNr12wwhAVTMyDYYnpjLnbkfKJeRXEIShYhJSQWzBkVQFYEBBvVdWQ5aigNCgquspOjFLHLpdnNShB7Fln6YJTr+MOCMp4UOwOfsIGsgXYgxzrDZRtg+PPf/YVO/kzF1/OHqfSr4lBpigwM2aJhpksxVCgMBEwITrctdTtyPFCsplDqpk1HpECShiMkETcG5EBF5JoAhMDAKpRMMI/YX+5Otvnle6jPgZ9O/HUHODUFn5Jd/mKENRiIkJpOoRJWosNPrApukPjZ/dko6daphO8I3UbFuXAlCIgte6F7tGyQSQKhShxoVUufV9ljJA1cbQAB4CQFGM4AklURzUsfeklShQeTWJEiCOyMBmC+VGXjmjfASc4JyPi4XJaCJKZD4sk8kAUYBMpMzKUZLpremlvKy91Lvl6cVh31zeyLUdzVQhDKa1BYOrSfXrFQwoiIxJGAYUvIhD2UfoIxsyloLEWokQkYH4inxXXa5ERglSqgaAyBdKIEQSZyFd30xWbt385sJi0Z72RYF92+M7tzb/6EUHidkaEYEyKWVF58hz0abm9pfufnBxZYGsrB/2U7WIIIob/eH1jS0EOoioBTA7xkaRt5w4uC5v2IqxKQnJWHX63pHXrI1Pni4vXQAsuqHwUQ1stN8WYUgOw6oBsdVQIVjESUfXnZ2WDaOaD+Vzs2cfu2Xv/QfchTl36nwd1jPFQhT5/mTrsnFxb7Tuqh65ZdXGznrSAALYEG5eiDewBxMpATh0+zZ8781GK52oDS/BLs/NcZJeWfKn5mYObKZ1ppxzJiub6tzK7Q/q+Ba9+OrttcPB2NayXW5r0fMRSaiP6dBuXb601F9yvteNtkfbo+FM/9fM/unICh01GBMK8D1r0st7P3BlvPngxFznwowxdd/pR5WCARWA8Q48LUpMAIih4a7bDn5hxw8unD16bPZsuVzpgXvVNSKWzpVNRxc4GwpPPSWpSZbbxdPtcjmOdMsdsjJ3z8QKbzezM+2Xf1CFkBXV5ZKaNLwzS098aE84caJ6Y2Hpa6fuWBi9A5Mpzrwi84c1bmBoS3/nk7RpQ7pjvDz3H8KRF7Hj4G0PP/J3Pv0IBrWzt0TUdmDHOpiKYpD58FfO7tows3JPoz0z84FPfOzD9236vW/MnnMjl6u5ervlZ7nf00cf2tysmdrM8WWaMnHtdHv70tEfJs0ajW554NFLTY6rfueZcxeWagf76/d8w2b16tlx/5pr18bM+ZWQ/PVf/ext69Nmlv7v//PisL76hjsv7Q237dy2+x/ddc++/R++/Z7NY8O6utIEekPhb1D8lGvhnweMhqd/+J3PfrcMM4vJC1/++feHmOTbz1Lbj4Ywe2lqk8cwLVcbJ+ae3NxKk2GfDL30XGt2Om3Yyng3M3UbHdw3xq2R4fpwfiYpOmprNjFzx1u9E/3M5gt5MbZj5F/9zj83GH3xe8+UnW/v32WnZyna+jN/5RMfn6iNNGxCGPCcvG3Eb0EYsOAgMGGASF+niZXpc4de/dG43378+Pna6Ew2MlJ2lpbDOtPcG8b2kfPt7vwPzj1967rezq162/58pT3dxn6d2JGRa9FEv6Urr12qm9pWf/jRh2ppZKtD+lXlo/xQvGF7O/W/+MUvxyeO1OpbNq0bOXH5YjMZ/6Wn7t88tN76AFVPYvVmU34rewz0DgI08OXvnEZvvl4ve3NFu8j/xkO3pHeaVle/MruvDDvZFyLl0NFvdZ195dxIq9X9wH0Tn/vUxLF2+vXOPp9upXJJ6hnPH876K7Nm8vlXVh68z/ign3mk8Z8Pz0yX2yrb6O/9EPqXdi0enfd3fLf/+G8/tvfAvm1GhY0RUgsDlmvQbnLbFgqQABDQwHACuNk99892H0k29/5wtjN3du7pZ6YfuWe9in4wnP5vL9jQ2Itt98/VMDR3OE6mLr6weKVdfPjeW3bHrXvnfve5xbtpYrciXWzUkL+WqX/55SvtIn3/geZ4yB9IX/+v3z9qbn8qhN4Dt2e3RcO/e3LyV37h0S88+T6oMWCl1cL1dX+iuImnaVCAv06Eokq4MPv6f//qFy9enH329eap7sayPn5o+PymcGT2Is/PpnkROqPmzoP1HVn72IneicVJP3lwy9jyjvT0ueO9Tkv6Q0Pj28f2jyysr4dnXwkz8V1obFpHb24sXm63rO9klIUde7oP3ja5MPHw6MFP/tPH7qnFDWtudHy6io6uBhrXNU2DKs4g56uB2EB1amr/Bx/7e//yq195deoQNMNS90fHZl6fKYazKWjgZOHh7cXu9X65p2dlvBq/i2r185dWLp4vU8+58beOXrxjbFmz7Ngcz9hdGNoA+IWFTutcdzjbPLZu9MCdtUOHpvYcfPSu2x/ft2kj1A40t1afSiAwSAC9ybjfvkllMM+LKwt/9NrJbz5//Mz5+Xj2iG3nHkVUi7Ztx9T4SNaol/Fky22KYrOuTo3M5K0VVxVZM56YGI4B5cxHaSlWqmpyZGS0kVHlDWF8fHz9+o1DSaOWpPQWe/1J5B1Bi8ggv+rFtV3pXOmr4KExm0FoEZk4MTBWiSgoGUUURQpWIlIyRApE7/xgDzUg/OkR/zjQUASCBgUJQxWW1BGMQFeL3kqqCvKqyhSDhK72k1yv6DCreF3TQACAiaE3BZtXn/mTzeGdQa91RHrDClYIga/SDq+euzpyfc7A6s+b9xkQhZLyn7k76se1uPFgdQwSPCS6Cg40uIqwWnRSQBkQXT1n0MMzaP55az8ToMQw/z/9XD9O02ses9qoc02dejXns6bOBFWsDg2mN3hPa1T+5yU/BrQAWGMgGCyamzBctYg1QYJC17Tu6DsA/jOQxk8AWtfo7CdolLwZhCjobaLKPxf5v5UEEgSH728wAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAVIklEQVR4nO16eXCd13Xf75x7v+Wt2AiAACESpExtlOWIai3blBRrkjh20jZxYmfsuk2cthPPdOpJO81Ml0zbZNKmk0zT1GnaaZJx7Thum5Hs2LXa2I4j2akoRZIlWQspiaK4AiABYnl4+7fce07/+B7ARVwgDaNOpjp/AA94793vd88953e2S6qKv2zC/68BvBl5G/RbJW+DfqvkbdBvlVw30KoKhUJwnvdFB295Vb0gIMj5b0E2/7/1iHH9NE2kBAKDRAERURFRAUBkABCR9wUuBqAAFKRMoM19bhH1dQNNENpYU0WYmdgaYgCZy0VJFWRAAEQFSgolKBQEJQBCRNiasu31Ag0wFCCIgBm9fv7aqdUXXl544omTc8v9PJdtI9F77tz1Yx+4dceOGgMeykpEg50qmK6+/AVC1zv3EA9+5pnjB58+Or1t5Mnnl5994dTYeHm0HB07tba40rv9lm0f/bG7PvzBfYE1HmKIVT2RAQTgjZ9vCehiESIF+Hc++52vfOulofrYi0cWep1WORQbSLVardXKcVxh5qTX3b1r4lf+6YdGR6pKwjAXrrOp+79w0CICJgb9l88f/L3/8XS/l0Vh+p7bh9991+zUjuEoCPs9N3dm9dVja70s6Lro6MunpqaGvvif/la5FCuUQEoorHwrRnIdQBd0xsQP/K8X/sWvPzJU6vzMT97xtz96oD46NvgAQBAFk+Lp7736H3//iTQvL86f2L9/z2/80k/CCwzT1gzjoke+MRFV9bLx0nuvqg987aU7fuC3PvrJf3/s2IniLecy55z33jmXO3HOOZep6OHDx9771z7zkZ/74n0/8q+/8cgrqppJQeR+i89/M5SnUBTOrvAuY+avP/LqH3z5z7//zurnfvvn9uyZldypFzYBMzOzMWSMGjbGBM7Lbbft+dmP3XFqoT06UnvwqwcBBMQXOOK15Q2D1s1foqKwJnz52PL//pNXKrb9iY+9r1SJXabGWjARsOlVBC6s1VoWcX/nY/fumKo6DM3NL7740gIU6gGI6pZ47w2DJoBAICgTkYLclx96OfedyODuu25mMTYkJeA8AV/6FFUyxtxz545mL1GPp587DoJAFbwV6ngzoKF+4OEKIn3su2dXGp2FudP3HbhNAa8eG9FRAZwPkxdsm0iBfTdNCDiI7LHjiwoQma0Hlzdh00YLyxMA/M3vvNZtt9fXmj94/20AmHlzWVIMwuRAzudGpNg2UTEmEE+rKw0ApKLqt4jgDYdxJZCyQsnQ6lrr1ROraefc1ERt5w07AAExMCC5TcodxDxlItGN/8ZxyEZcz+d5ThCYN6C+N2PToIHHPHd4Kc1cp72+c3ZSdaApVd3M2xQAgcgUL6CDBENJJBd4BDHV6jFwUUZ7/UEXPl4c9AuvnBPNmo3W3tntBFJi3WCMCw1UVQlQBUgAKBjgRrPrlCG6bawKocsZ/3UErUxEzATI3HyjHKHT6czumQJB1RfkrRu7IwggREVmAihDvcIT0Ow5o5r088mJMWUSFAb9F8PTG0evee6bnXx8JCTOd0yOYZOVaYM6WKEM8OZTlKBkCt9cW21DNfPJbTfPEMACDA7h2vLG8+lBPNRmq5d5FySJJR7fVlVVIoUCNEisFawqUFYSAhOUSEVZ1QBYXkurVQ7j+jv2bAeEjAG2lC29GdBaWAC43c1EpNFar5RLtVqFiERIIQATFeGCwUwQVSISVRWwSlEs0uJyIuLuPXDz+Piw6kYs0i0Bf8OgCVLUSVnqyuXyoe89Vx+OKuVYASbeyC0l6aVLa51uq53BUqWe5jwR+53TQ8YwBL0sV5/XYv++u/YR4LxYw4otJdNvBjSUHRCwzJ9pJ/1sYf7QU48d+sxvvvvv/4OfPrnUOr3qzi735xZXTp5aXVpYiTUp79xlhidEZNQ14yTZOTv+gfv3xsaXI8MkX/qjr979nl+wlgXKW9TzmwFNQqIgk2S5aBoP33aDHfrCN0+eqh9u9blzbjmG77T98nK3EkYZEZ1Z17m1kM1yiViTQ6+dePLo2cjYPcPxre9613/9z7+zvPKLn//sv4XS1qvEa4Ie5OYeMBAFQ4kHPu7SXnrr7fdMz07kUe3ZR4/Zfq8S4VQziaxVwlorDwLuNNpJDoaBOCanySJ3V862699F9AMHbnr3gR9++tk/+z+PPXffPd+XO1i74QyEgWcPnnVRiXCNymVQtCkUnsjooMrAwccP/4fPPb7/jr2PPz13dv54yZTXO8nU9Gg/V3EaRXa9m9+6Z/TY6XWXeQVy8QGbJElitOojw4srqZpgteE/+IFb9r5jvLe6+MmP3XPr3qkNwJdiwAVZ7rVBD3apDIKDNzDi/e/+/sNff/ilV453J6anfS5Z48Wf+MgPHzmRP33obByFXvrWUaOf3bKnnEs0f6ZlOFRVpzxa9rNT9MT3zt0yOxTHnCSy2m2+6527aqWRuTOrP/Wj7/zIj9+pIMJ5gJctda9M5oqNvhaDRJy3oLlTS7/0a1974KuvvHJsfbgarCwvrzV6i0srh1449p7927udtF4xztNqs8WEV48sz82tekGaCcSruE5z/fhC99Y9tVJZXJ6Uw16y3jt9bI78+u4dY5974Ilv/OkhUhR9qQsVfIlmr6Lp82YkIkz85ItH//RbL3/7qaXOetMrJoaRZby4rp21hV5fdt24pysBiQHQ7+dRAJXEeYKx4tUyK5m0v7ytFo6OlOAlBwJ1pxfWuDJ6z/7JTuJmpsd73fav/vOfGKqXNg16oyuyRU1veIBXx8SnTy994YtPejP08vFGKRDDUTcvNzpUr/HMzMyN75hprXdc5jMvIgBrKbb3H7iRiERZQE7Eq1glp+HJRTq6yPOLWFoPTGmk3TePPtc58trK+nrrHbsnDz5xBJBilQGM12n1iqA3PskMo4Rf+XcPPfXi2oMPHR6KuVSvt72uNKlUiYmD7ZO12V1TvTRjFQMVOCZJUj+3uK5M4nJVVWIRB6Z+RkFgI+tNwJmyOAmtyVKfudKLh0/nSodOrHa6uTFmYAKXa/BdRdMCiPeeiL758HPfeuz42nqWps4Y02hnrSZGa/72m7dFYYUDvu+9N1erZVV1otAAiFOvh4+0cs/WhpYNRAG2xGwp864UsXoSdURERGzhyTbW+4vLLR+Wjx9fwaC3AcC9nr+vah7Kho2I++3ffdgYE4ZqDDggCG0fD265aTrzplRBkvCBu3f93U8cEM3E5cga5Nfhe5DUas7wRZIKUSFYNpbMep/BYtlkYjJx3jmXe2Y++dpCeXjbuWSj7iIQ7OvN44rBhQAvno35428dev7lM9WhMecckw2MVGIbBOFwtbRtON57Q3Tw2aWdE9V//KkDD3zlkWNHvl0OAmOMQAFOcwkr25wZCcq7RD3Bl03a8lINjDKVWSuWKvVyHFIvN61m6fRcY3113d68p8gWN8qcS5n7yhFRwcxQ//n//pRV9nnmvBjWdtckvVzQXltbmZ0ZavX6Nho+vtj6vd98ZHEtqo3dCQopNIEHVEJmT4FFrPDMLFo+18wqkb1xVyWOKEtSa20YWi9uVLOF3C6tdk4cmbv/fbNahOArdPeuCFpUmPnQq0t//syxoQqqtfDcakc0oazSD2IyWOnS4gtdtVov937m0w8urfbqlUiwXYhBhMCSikDhRSQnr9Dcs1GujG6zQ6M1l2X1Uk017XfdateLhGMjwUqjtzjXyFttonG5cnPviqBVvUC/99xJZniyvZyYIiKIZt4ziQmCgI0xijR1ictr5cCBIE6IDVSKxhyg/ry2VDWy/syKP7u66p0YQhixgJNU4ojuunNm/uxap9NfPNfcaJhcvjF5edCqSmQYfPZcc3g4dt12UOHhkUqeZTkogEIFcMxWfK7wpZCNCFgMAWTVC0TAUFUYUSViFjKWQBCDQODfe9fsvluGllf6jz49Z1WE3bPPn858pl5OnOkIiLlwwMskTFcEzcxffnz+4cONieHyQr+j3sOAjdk7WVMDVjS6ebcnnhEIWwMTsHMiHpAM1uTeswF7EjZBSIbEMhHEBBaimbNLK8tji76bOnWOIaSqPi56p+fW8kaiYxErFKQEvmS4cUXQAFabXYpLHFhjUY5du5165TMrpGycQJ2muRSNTu/BTkTUWHhiOOfViIiSGnHO23JMu3ZUmVkd0tw50dMLyYPHTobWlKIoE5LMq/YDa1ymvV6/1ZfRmD3IQhVCF1vI5UEXacqeYYzE+Yl2nmUcBWZm90gnS4+e7CYaMVsVgJmJAEmFUZhwShtfFyICmAznSd7LqO/7UK3H0fgIR4Znp6Lh4aDZVQBjsa2Vo4WVrs9Qq/u03XKtJo2MsUhRZW7JpgEIVCDbg84JzZntiYXs9JmzNrRZ5tkwjBCHKNqjbFQLilRVOZ8tkIp3zEEURSJueS0FsIT+erc0vS0shTpedyNVhZogINig3Ct1sl4/5VJIC6cX9u4aIy2869KC94oRkUHHzvZ33TAUBJG1dsf2GBRlCSsMsZKQqg46kUpQYagKQ82GgZEKE5GqipJlUysFQ/XKUKW23ndHF/Mj89nCCuVUMVHZO3L9/o3TdrQeGPZT4+WTx+f6aUKmODQWuqg3eWXzUMyMDZ/tYHqcllZ0vaPG2jCUKAx3TQ8tNrK5M504jj2EBIOG1wBvMZ+VotMAdSrq2Yoz+28d/YVP3fvdF+bPLHbvvXv3v/nMt598YWX7aLxrOiCltRXX6ttalQPrMkGj2S1NxEURQLgoO70yT0N/9Pt3P36w9bVvvCYuiePy5GhUK9kgtNbSbFRxuZxdS4IgIDIqhU432l8QFH8qQRnwAAnj+ZdWHnr4yKvHVt+3f8eH3r/rr+77+Je+efixpxYOPvNaZDh1oTGqkqy3pLF86gffv3+Q6InSxTnT5c2jgMBKU1Pjna5WQrNnIh6pWmXvXJZkae7Tm3fX9u6sk6iIELvzR7RhMwQGq2WA2Kuo886nn/3DZx59dv7BPz706JNz28aDT33izj/4rb/+0x/+KyvNdGIY48OBiChh//59O3dMUlF5vYFyCwChXI9KkQkrw82Ec0eloGRNZMjCUd5Ld45Fe3ZWHJTkkgHFRmIm5OFIUY4wXGfyXImj4dgsLHX/4S9//Qt/9NL8uSTL8S9//t5f/Wc/FJcoCm2lWsozhEHVBoEUKxH0YgK5miMCqIZxrR63+v7Mmjl+JltZT/ouM8aYkHKSTpJMjUWz0xUhDcIiAyYbkA2Kwo6YwRQws7WWmWFgrBMRa7Dc6P3ir/3JT33qvz3w0PMmwCd+/Pt279y579YZQm4tcp8pCQZDNGyJpwEIC4PK1SgMwyzJt43IiYXewoqM1IKRUjo+Ua6VLTPneb5zPB6qxfDIcy9AVAp7SdpYT3s9TXPnxDNMq02CJLb2hslKEJhmJxdBr5/Nn239q9/4zjcePXLD9rHlZmtuue9yVEo8NFQhMMnl26hXBM0wqmpMENjyLTdt//iH7w5NcPi1xS985ZnlTr7SadSrUTmgamzGJ23ZhN5oHAOAeAnKwXDFZk7yjNbaWb+XZ7l3YjLnTy/0JsfC4VJsA1ojVi/dRB959JTPTleqdnK8bCMFUC1HgEgx18OlPH21DpMSSJQI7VZ3Zmao08xeOr4Eim1o2KWddtr0umOyZsjm4pTg8+J7g5Egq0aBnx4jnqglzq828m4v7SZ6rpnnkG1htH08mhgL+pm0ui5N3Z7pWuJxeq6RJM45p0pcuODrsuqrUB5YCSxpmi6vNj/583/YaObVSqVai7y3jsWCrfFD9RAQj2L2rCJCRCLFmEIkdwCslcDYmYkSuJLn2k9yEHkEAIxBrcS1uBSXTGDoxefXJeek50NjCwYDXaaTejWeBmm7l642eqUw3jlZAczCYr/d7dsoYLZeTJr2V5rp8EjN+0S1mHnCiycFAAMmY7zPxadW4LxIEESBKddDT6xOlVVBcEysKnz4eCPNszLnvaQfl4wCg4sVeinpXblGVCKixlon7SbbJyqjQwHAQ5Xh+XPJ/HKXFUQ0NlbaOT2cdjNVJZEiNqpXEKlqEFj15KGkKpyKBMgpFZeztdZaJqbAq7L1qpymebUaTE/Vuk0yAU9ODA9oQzd/bM08is9VarbRps6yMOVj9eDGmfJIPer280rNDJUCyaTjMyixyGB6oUXaBLJk2TgBoEJErCSZipEAeUZiyQrYGhAxs/fZaN3WylG3jR2T9Z1TkyhmwgPsF8mVeZqg4nbNjN9+047llebCcn9+sdNoeq8YHQ5vmKoMxVGeaZI7FgMvDnBQpyIENsSGnMuJyJggVy9Q771XqKpm4nzinMtc7rLceyWV0IbitZv0xcld+3aSEa+Oi6kvNi/LXUvTAETJAB/4oX0Hnzw6NTMiqXKg4rMsE5/Bq0ihXSrG5Nj0GoExhkxgDNkAJnO5SkZgFVKIqidvvVUhckzWGbE2iEIbWvZwWbp377QqkTJUiVXBl+QeVwPNxkBx/4F9s7v/bG2tXauUkyTJMud8CggNpm5EZASeBcRhEcE8eYFRYrJSqlbY+PVGzwYGlKgyhKBd1pK3TLkjNuyi1OW1Snmt273jlpmbbpqkwW2HIju/1BOv1hYrukIg+ief/pF+r7my1nA+9a6vXrxXr7ChYUNs1DBRwGy9d4loxkjJ9Vy/2e+2Wu1GWIqrtRHvxDAHQQAmMkycs3hjjHPOa26strrNteUzf+9n388w3ivRoJh9PeddsdW7MRdkVQe2L708/8u//sCrR88x1AShuFw0i0uRIfbeB0y55N57VjYmKMp/FaiqV4nCSq0+kuROXFoph3maKYGZSYWD2EOJqNfuBEz/6NMf/Bsfuktk8zYDLnvp7dqTAAW85JYDiH774KEv/c+DZ86uiDe5uDi0hkVcX3zS7bT6nWXnExvVjS3HQTkM436WElHR+oCJBRGTdT5TIYYoGUPEZEslPfDed/7Nj993w9SEiDBf3QSu2VQvmE+hImQ2bhqJgkTVq5KCiVRJoEpEKgT1RFAYIuIB/6k4p96LSK4qnkVQXM4qDj4Mba1WA+BVTHEr4Kp6vNagCCCcH9848cx8wSinmDNQEXIvN7q85HAFUuT1g7cUKPxMRbBxx2VzKVVf1IhbBn3x4y7Y/QUnsDkZAYFEissgRUF+wQWKzUdcvDEZlH8QUi52srGqQFWLC0KXU/t1v2v6Vsj/3zfV30p5G/RbJW+DfqvkLyXo/wutSRJJoQjKIQAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAU80lEQVR4nO16WY9l13Xet9aezrlDjWxKphpiaAW0BGtI7AQG5Ey2BDkJDCcIHCMPAWLkIS/5L37MPzBg+8VG7NhW5ACCkygGNFC2WiRFhZObza4eqqvqDmfYe6+18nCqmtWUulliI3ICaOGibt177r3nO9/+9hoPmRn+fzP+mwbwYewnoH9c9hPQPy77Cegflz0WdMVgKGJV9PwdMwGKoYiOMGgBBFDkXA2AAqgiAlRASzagQmFmQBnyMdADVQ0GFIXU859VVRhgMFFY/eFoHjV6bHCpAF08AJiZEREAiAI8Oh5FlWzOHEQGdQ0MfImEYZCQiquNqobIIgDABOICUkMCABQABiY4AGrVkf/woC2rmXFgEBnMTGhCZCMRG5ICpVrw2cQ8NWCFMahDaeEIXKQ4FwqQDMgVzkENkQFRKCSMDBYFIU3rLQYmfDDkJ4AWqEHUxBEBDDiAS0FDAKMwOpGXXz5987Xu2rXlzm73sWvL5Z7tzALgCa7oWMXlke6e3f/ejeGtN93pqnv+Bf6nv/LiwQIOBiUwxIxdJZCBSy3BB7rCNnss6FF7Ih8owGAKMzgnIIWFgbY372x/93e/990b9OYb999992h//3DeHix3808989z15+vqbHv/zk5XV0MfxjO9d3ZLqMZmef2jH3n+4/Tv/8OnP/liXdhStbADgDpUH1oQYAr3FKAheq5QM0xaNoPJ2yf8X/7gta9+9Z1b9ze7zxxs+rpa98MwQHzylrf86//22bfffufrfz5Pi2Lek/jQ+CK5naVPfOITN998vY32xV/6R5//e0ef+cz1NkF0SOxhXobiYoD7QMxPkJAxDEq5UAHN7z7Ajb88efvts2+/sn7nnXdW64F9UK3zGdanufH784UFopPtBn2c0/4i0nzRCNtQKzN0tOV85/j+nd3DGaN+7Vtf/1//M33qZ/MXv/TCZz7dSLRI1bVuGIbGNR+e6YwNYfH6m+NLNx68eavcvNPffdAbcdNg+yA/uLMOvnabe/v7+2yL4/vdWtn0xBXO5b53zXx2vbixaoyWASyW89RQLn1MyXFz7SPXiz8bu63043PP7Hz2k8/97Z9On/iE+/j1mb+KptUyWYCNoASC2siawNoR/87v3/rTr7y72moTAwm6rgNXpjQOQ99vVZWZnQvOOWLfb0ZVnSgwO3eQzMzMTdPEGGutY8lENJvN2rZVdj5KijysrYxxNuODj/T/6jc+9w//Dua6gu7AI1uJFmBZzbF/TzdUbXCWQApAlYmVwFrx23/0zh//6Stn/e6YdRZD4jTkerY5gRUiYgYbVFVATN45Z8oTaKL3Vo+ZUxMBwAgAEZFjERGR2WLPkEvtZ2lWizmmECW1+KV/cP3f/etnvW4Fc7A6YTCMzqPFZJ7sQsHIhGggwbDeNF//ZvfO7RyaTFbymBVaxPq+lzpE50MIzpEZwRSkxuycc869F4EmSqYLMCLCxDqRA5EB3fakSW3kduiLmjSpHccgtfnj/3rvmb3FF7/I3uAhRqwCcYiXUHsmNgUAYiGDCKmTt26NpyP2ntm/f3w3sQ9hluu2Wp0tLK+TaBmGwRFPwiBnVk2cPAQ6KWR6KSLMPKEXsekDzAzrB7UYWlAMzhOcWiGWba5/8Idv/MIvfvpwBsJATCDA/GWq+SJMYzoLMyrab924m+s2NNYmqKKqE5ha8R7L5XLWLmKMzrmJPIDtkuklExFHpLWWcZRSGOrIHBm0kjWSy2Z70s4cBzcMY9uGB6e3fFgfH6c33hjVtiwJ6h2JvywOgE0BBhgqBAURbh2Vb7x0xESrB8fP7n8k8rwUMucNrgyhmjJzim1qZj6kiUWwe7jtLvMNgPDeIeeYmQADzGrLFHzQIT8gNxDXvu8dIuWuVn3l1fueBBJRYSCmzSOgYZOrro4bswroSy/de/3NDYsd3zmSmmfLxs+QZpZSirYoRaqpwIiIiIwd3HtYLxbNLuOedioziZSSh1p60+xiYWbi2bbXpmlC5Du3j2SE9GGUk5df2RbM4IAAkQiER0ATQ00FGQChGuqrL9852xir5rE7Obm9ux+W+/BtL9oBHFJk9mb2CHSCPWoPTzDpxMycc7O23d1dHh7uX7t2mOZrjmR13oSPlpFPT08Xs3YxW3an1Td24zvrN97cwKHSihwg6VF5EJyxt8YKLHQ3j+mV7zRWbp9sHsTm2q17d1ZDt9jfn+9ca+PHzNZai3M0UcvMqlrLtIOl1lprnRA/dH/OiXdtHTxK97eu29/9tP/Ys8MsdZGWKNHHMlty5SMFzXfb47NbwqKjdBv52l9sC8SPO06Q3fGj8oAKnQFGwTLmL31zdXTvtkvtyd2ja3s7ZbtFGZAH2DA/gN8VIlLVi9Xnc6btnPLL/m6yru/NabNszPmju91rrz+4dadfb12vnXlql3E2a5weNHRwcnSPa100u5vtan6w+9++evLmuy6ne3Aa7fAR0LUOjnZRnXEW8Fe+/H3zMdfZvXfvyFA40+03bubNcLi7t9hJ5pvJGQM8iYTA0zuO6H0PBhiYLXcUJaMX8kUWYznohp2TLdR7oZCaudim1uOhv2k6RCzW65658aneX8uX/+z7hmuSGY+mGhx4BmxGEUX6H3+Wb/zlKjZ0ePBcnC3vHd+bzePx8c2jm6/fufXWbOFmi2dDdJPHIPAkac/MeI/p95kpi1aQkOOc/dCHagkcgWa2SCmlWRs327N1d1JV1/kozXlv2ZzeOZVT5TIDYFzx6Pp5MGqNsRkK6gsv7rz44vzbNx7sHOzt7l+/+db3ou+KnNy+1d28/a0vPBP2lj/9YMtVUYuZGsBEMCIl8A8I45wVdaQU2DFc7YuakGffwrv5znIB4bG/f/fea4x5qR+fzz7Wb8tybr/6yy/88hfSz39u4QBjL8gO8RJog/cRoID5xz8+/tZ/+tzv/c7b//n3jk6Oy6I9cC6V4ax0crK+/eqNv/i5n/vsZnZczatUMQU7IjZTIgL/cNCJY83ZBErqPHuCOWXPi3liHmaR3nrr+92xLRonrtvbm/+zL734T76w8+Lzc48KcSAIPSBqH2WaRlgCghUEnyLzb/6bn/3nX9r/o9+nP/yTP/nGt14dh22i+ere/bdev/GLv8DtPKhZKbUO5LxnkBncpJYLu7wdx9qxdxQ8RBWFidjHdrZwUbwb9g/He7fvDLf9p//+c7/269d/9Tc+dbhgAjwqtIMLZq3HwXkEfPj7aiY1excBgHpoU0YKDUA4Wes3vnXzK1/+2n//6o3FPv7xr/382dlnjtdjv80P7ndDr8G1RASp7EgvdPc+B+I8SjVYNKnBmXcMH5vZjp/1qex/6pMnv/Kl8Fd/vvkX//Kze/tb0wWkEnk4EXNgGOAURB1o9h7ox1bjouoYUhyHUWty9s4d/1u//eqD+30e6eidMxU/S21Rcc7lnC9vvgn6ZCIy/cPM3vspysQYeZZY6+c/e/Qff/Pz1eANBFSI5w+utx5bbv2gx621qmrOWcQzM8GZmch5chdjnBLl8yTuIhZOWJ1zD99xzoUQigyO9JM/8wKh1uJCJJRC4QoV4pNqRAA49wnMDGjJVZRm86bfgtikqkCmo0Q0jqNzbuJyij4hhJTSedSsdUI/sV5rhRtCdC88/1PASEwAgQ3Qq3TqHg/6EtNsDMLZqtv0w95yNw+biTYjm0g1oxDCFMadcykl7z0AEZnIvviYqepEvKoQCAqYJJ9ExJGvWq/QQfigy5pEIiI1y+lq1W0zkakqETlPD4+WUmqtIYT5fN40jaqO4ygiIQQzNTsP+xf1AZkRwQ19Xp2upkpsyo/p0WzuRwdN56gBMLNzrhY4n8xMrTITADUxM2ZOKTVNAqyUrCoxhqZJzDSOQwgBQK3lQs2JiEopzrmu64pUGJlNUQruMc7+ffZYeUz19FTPTGGbfWznS+/dRfJJZsZu2mehlGEqEzE1QgHnXNM0IuK9DyEAJCIi1XsfY/QJ5Ji9h0NVRAaKwD3dRrycsKmCGWbmXJj6uRPBwQf2YXIpTZPe1zmYrjylNG1EIp5KgckPusBNE51nwJihWtmxQXCFFtMT+tPmDCDC1IUlVE8ueO99KaVt2+nCch6JEKPvuo6IYowT0yGEpmmIaBiGpmli0xihqhjgQ1AzZzU07bXWQ1tCYfJi7KCPw3Ml0A4X/buLmtd775kAxBiJTLVOWp/25e7urqoOw5BSWiwWfd+fnZ3FGBeLRdd1w9C3bZtSmras934oNYTQNAmGqhUAM66k6A/005ctBheieWeAEvnJx5FzMcZSaim5aZopOo7jOJ/PvfeTD5nP593QD8MQY4zJn1dfPvoIjsC0caZOwYUrebJ9sFe0i6eYODhMIMws5xyjd85NYaVt21KKiMxmsxBC13XjOLZtG2MchsF7P5vNJkfuvVfV4BvVOuYNCMElmMFAV8L8eNAGAc5dHhFAGgN7Z977WisRpZRyzmo1pZTzWGtdLpeqenJyEkLY39+fWPeBm6bJOXfddj6fLxaLMfciUoqBqmq+gKGgRyLahwFNl/IoIgAao48euQxt204OIaVERH3fT/Hv9PR0Nps9++yzm83m7OxsNpvNZrOcs0EODg7m8/lqtZr2pQ+cR93ZWS53GkyLaQZ6Ep7L9oQwrrBHvE+bQoxu7LnWCiClVGtVgg88qWI+n2+3WwCHh4dmtlqt2rZdLBbDMKzXawD7+3siul6vQwhadXdnZzlL5/pjNgD2g3naD7HHM/1ouwww7zl4ngKbQcxkInjKN7bb7TiOi8UipbRarczs4OCAmbfbbUrp4OCAiFar1dTqVVXJAqhBYVNHdTrr08ljOmRQhgprRbi+iwgMA4nmEFiECD55V0pfa13uzA3SDduQ/M7ecsj92fq0nTeLnXk/DJvNarGYzefzvu9qrW3b+mB33+qPx2jVXDWDKnqSq2B+0ka8+ICCwQ4IjmfN1BrAlBMDIKIQAvHkTGJKqe/7zWYzn8+Xy+VqtZJqi8UihNB1g6rOZrPzZall2+e/fqc3NoAMplceH3+Q9wBDGdMQ1Enb0nbTM3kRyTkzs4gMYzehL6WUUpqmmRSyWq2miLPZbJh5Z2cHQM45pbRcLtVsPegrL6/FnZeXjAS+EtWPB23vcU3nOVBNkUUs5+J9aJqm1qpWp1xUVacYvl6vRWRnZ6dpmvV6HWOzXO6KWNd1KaWUmr7vu65j72p1r762HoVAF6ejK42ZHwua6eIQAZcSt/WqS3FuRiVLSgnAMAwhBMdhs+6cC/v7h6XI6enKjFJqJ/c3VQbb7TbnPOXc3ntz7q9vDcdnFQSo4yvfTPXEMG4wMgIpjNkDNuYx59p1A4xDcOM4llKmIdBgw97e3rbvNpvN4eHh5L+JqJm1ZjaMI4za2VxENtutmTlnMcaz9fbo9vj8YThf0KctAsCqmAKVqhIDFu7f3wxDjjFNbcgY4yTrEAIzr9frpml2d3dPT0+7rpvP5znnzXqbx5JiA2Cz2RDRcrl0zrFKTMEMR7czUJkIULvaXnyCn57+GqBKqkAVvXe8KlmmNGhKP0opZjYFdudc3/ellOVyaWZnZ2dTbZtznoJLSmkYhslbS6mOYGRnJ/k8JqLiagp5EtPsK8EX0mjBmd4b8/FxCp5LFufbmGYUYtHiiVhsLLmqEJGIjmP2LqU423bj+nRNSo58GauINc2saWYiNnIbxuPWL156s1QEMpA5fWrQ50cJZIBIXa+G1WpzMQOqD93L9Do4X3OZir+pUMg5e3aTuCd9A5hcBwByqILY2L07m6PjDgaQuqsl1FfREJuBya/XZRhHKE3awDRcI28GMZ2CuSPOOeecpz7B1HmahgRmZqI55yl1IaKxWGpw+mB85eUzMKB2xSrgiaDtUk/R8emplQpTVhGDEptzzrkAYMpDzuHyOdMT62o21YYl55wz2fnQQ1WzCRGzd9/+q60xyLyhPBVoOy/XFCCQmuLoaLsZBoBFRLWaKbN3LojRw5H4w/E48N7oaCJ7GIah72utWqXWaqJG2m+xtxe/+2q/GgBju9o9TE8AbTCYGU0TUcXR7U1RA7jWqlJEipkx+QnZJA9mzjnXXLw/L4HB5/KAqFXJ45hzVlUynW4DSA3unun/fmMNgtHTuTw8UhhrKfXByRhT6+BUoFpVFeBptKKkU931sKNXSymlTLnrOQuPznPZquNZGXOtEhb+O985A0Hsaf00AZjuThCt4zhuN9nHAKNHhoXkABCRlDI1a8oF3OB9LWWq1Zl5Qjz5kForWWG0hpxH3dmPb781gNT0Ss2ax4MWB0IpxVk15tdObEv7ruvM83a9psreGqvO++hc0IE9eVbTWsmUCKpVVH1IKkW0EJlPPgTnYFyrdn2vAXpkbdpumXLufB4tJ+b3zU5/NNBwVQgxNDAPid2pbE/GYVXA1bx0dVVsM8iZoA+Jm52ojsw5IypmVXWsMpY6jIVdYpfgoporBiUWZmHmfvbctZS8SQ9Tkuq3m4CnLAIUUk0ARhYSnJ1sSu0VUkf22uqA5IMDaeEy0LjVmkeoAIAq1Dy76EPwPg/FBAwy0UnopOYJTewPDtcxQPK837phYMUW/kou7/G9PDRMAiiiMruT9QqRuPUuR6DtN6eYC7FFSuQZpIqBmBkEJasCCIxUS+JARICCGeSICKalFGn3z7adi6HZk4Ju281dSKZ6lfjyeNCCafzDDAFWG3JxF2RhMShZ7rsRp+wq0bzUUZHNzDsPYiOYZwQiwIGlVlU1EzDczHt2pZRSu1UZ7txtkRbtcjv2XAcaB6B9/3D2RwMNAkNL8Z74+GxYPejLVoazvFErI85O2AUNCc75MoppqVW812n+4H1lrlMX/XwS4Mhs6l6riOQs+/FBWR1q2mI8Cy555tMj/ehuMvpg1E+6QVb8qJoCoR/rN7+b7z7Iw1n2c869HN8/4qCCRLRbxiGEzlRijFPvuWmaGH0ILoTQzuKFK6zr9XocRwBE1M7bjy4WcW/gAuF6urGf+QgOD1vQeb38oUAbhHpY66CgrmIBqEcBHNSjVkQBkimkwscK9e/7OkhABCrQqWVM5/GKHIBK7LWCO+QdRAxAU4BQzPxTgH549ou8Aper3ae2x8F63006P/y7V8FxOQe6yo/+37Yrgf5/zf7mafsQ9hPQPy77Cegfl/0fYbQLGpke+5oAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x60>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAIAAAC1nk4lAAATCUlEQVR4nL2aW4xm2XXX/2vtyznnu1Z9VV19m+nJeDKe8SUa22RGM44cMwZxS0CgKA8BXnnhBZ55ghfEA0IgEUUoLwQECEWICIJASUgkMomcENtjy/bcx3Pprq6urq9u3+Vc9l5r8XCq257u6ZttvFX66pM+nX1+Z+///q911t5kZniklgXO9V8NpjAFQBQ6gQMcMqDgAJABXW5jUIIDBYAUUAAwD7qr456E6O5f7mz0yNCAqmoWZubb9KpLxx4WQc4AhabOgoNzrgMcxGHZ1ZFcGSKANqfSh58ctMIIZx2bKJmBCMTC6HGRAbYcqAUa6Far6si8437sARCSaSB+pPv+SNAwqKmYknMEAsCAmrqaEAgeRgCUAKjCrHUOAEFDUhKAGYGNQPhJQmcFkzIyLJsagQxEZHAGibBQd7vfeu2NV/4k3Ti6OJqMvvLi45962m9NBFDJwXkATdeWsfoJQitAAEEAALcnff/kYGc8S9/b/Z//9j/O337vuWc+PZttXLu++7Xf/ZMXf+mvfeHv/HV6YmcFEc0D8pHcg5X744QGRKRt29IH5oBVc/LBtfn1G1/7/T8KgvXefP7hLhFtXtixYXFYLy/Pu7m17omdz7z80s+89Pzw0nl4Bj/CsvsxQC+7poqlA1b7h29+/Vuv//GfXf3uW6v50aiLddu0kp2PzjkVkaSkthjlktyIwgDOFXHj6Ss/8wsvf/Yv/Jyvwv8PaF2nNoQyGEEAQnZYQKfZeNn+wX/4L3/2P/4gzZfr9RrRx/GoUIhI13Vd1zGR956ZzczDRJWDd8Gv63rRrItBtbW19eKXv/Tzf/tvpIvTxtmII+UMxwJ15H946CQdMzvyMKgIAAU5z3uvvv6r/+yfH7197WIxLpWKWC3Wq0zmQ3DMZpZzNjNPDMDMiMzMjElV29SlnH0Rq6raX53Y5vBX/sHf++Iv/uWmbWJwt1z/wa5y78dyzAoYwMjeESwIvfvKN371H/2TdlFvxGoUy/pk0Syb4XBY13XKQjF6750PmsX6pioQIjKxpEKGQVGyd8gyLgfvv3v1P//LX5+Ww2d//gVzwaBImUJ8IPQ9H4vAJIYuq2oGFKQHp//t3/wGH9aXhhvtYnWyXIxnG7EMOWc2mOac2pxalUQmt//MTEREhNQciA1O4Y0IeGr7oj9Y/vt/8WuuyWoKMNGdYfLRoAEDM7wnZoNE4Hd/67ff+ca3L26d39+7ORqNXAz7x4fqOSMXozLGSEQiYlkAEJEjDs4XMTpmJvLOEdC2bdu2IrI4WqxOV5txcO2Nd37jX/960D5QPdS6vCe0A8ERHABEIzle/vf/9JuDUNSSQlmwCwCathVGNR4dLA699z10J1lEzMwI5M6UDcAANRORbKqE0XRC3p2s1hvD8e/85m+9+dVXoRDJPxI0AQa0kE5yEH7tD//0aPeGOlp0zXRr1jQNAWWI1z+4ulgvtnd2RFXNDDCzpNLmlFTMzLI4EIAeF8HBcVI5Pj1ZIfN0wD7sDCb/7l/9GhIsPNg6cL+FKJodGTkmgeCV//V7l86dP5kf5k5XsTg33eSESVENLpw/OV14ZoEZm2cGoKomagYlds6FEJBTV9fJxHmfTeu6Ze9OmvV8fzmthu3h/ObR/O1vfPPKi8/9SCOdHYdOSzHHruua/esHw7U9u3m5mlSr9WJ9cjwOwYk1KWNQHeS2RFGiCBZJPaknBBVuG+na3HRZ2LnRkGJRJ2k78a5IeTVicrB9XTXTqk7d11/5I2eqqneQmFnXdQ830gC8AyjltDw6Xp4uKtWmba9sX1oNxl3T3kzrKgYPl9f1QOWo6F8GiIhAMBgZzEwDRMRaY2PNRjmZWc5SDgfWptIHA6ETNOnm3g0HzppvswJwzhFRjB/xwQdrSESObs7XJ4uRC63mk/c+GE1HmaztVqAi5DwW2SyHVARm9s4xs+tjlpqZZZfrul42bS1dTZairhiJ2m0/tcQVs5kG72jo59f2LWf/UVmrKvOdcrgnNN36V4SwOjm1lGM5bHK6cGFHRLBaFI4fn84ujaclUcVsokTknXMgMpCZqkJNg4hYK9qaHqVut15cPT2eN8ta6qhuWA5MOgfyZZjP5ymlGLyZ3c5JmPlu7vuOtKmqee9ODw6dGADzvDyeDzl8duv8E1s7A4ZJrpv6YHGavVGfVhNBjQyqysDKdQG+gosULnC4EDc+Oxt3av/7cI/axID3vm3bJFIfa1N3vix6WffC6Ll/8DHuB82AqRo7AFe/9z5lbdu2cfbEeLxVVJ/cPr/J4fDGXiepmo3jzrYzAGBDj/79uXJsojml3HZQC3BjH4johZ968tqH1/YWSyud984MXdO+/q3vvvDyS3zLgnArDXxYaADGRESS8rtvvoUsTdN0lbtSjoaxzM3qSM0Ni0kYGVtaNQMOfb8/+AkgHde+jL4sU1VlWJe7tq6bpvnp6cXp1jmoNrnJTGVRLZrT3/mvv/3cF79QFMVtYdyGfih5GIydM3C9Wl+/tsuiQpKVrlTT8dbmabM+ODkqy3JSsks6ieWKb3kHEQDBWcpUbW/WJK1JZ4lgleNRKEfg+sNrT1563Kpy/4N39k5OYzlBk772f766t7e3tbU1Go3uM5r39Gk2l6AErZf15imnc2NX2FfGs9HGtK7rerHc2ZhtTzaoM++isgsmXoSzUQdOLiQfEkchlZOcGlUoD6WYJj8kFyq4dhJ21/uzwH9356kNtu/4o+i8rrrXvv7N0XBUp05hTIx+iG/VKh4AfSZJQ9s0bd1omyofNwaDNnXSp9eqmnLOZ5kG0Pff30QBJTYyI3FOHcwpfEuhdmEdy1U1COwAFhEO/sJ0FhQASh+LEAG4M7c33BL3w0HfauvFsl0ttemmsZqNJiklEWFmNvTpRq88u9UVQQnKpAwQGyw4C4xgRqK2Bi99XMQywpOadokIV7bPjTrNpp5RlSUAor4a9YjQfeoDQ71aW8pOdFTEsQ8KEzszTjI45wAYkeL2WjEigNRIDTAmc+YhwTJLIkkmCrBTAEipbVL32HhjhigmuW6j831Uug/l/X2aAaS2i8zmtPKBbgnDEUONPAXnswpgRM5gZErcV2tYCWoQJ2xKpmWvF0IAe5AzZudFukVaT93oUjE80JNm2TbLFYzIYDAmAuDuqkXdTx7943apYWbPLgaXUyu4pQdRzUJE/fT1/tjrRBlC1MF3HDs2gbLl0vIYeWxSaSpzJmMjCiG00hZil8uxMmmWqx98+H2C3j2Z8ZCWd9vK27YFADb2TiwbCIBzzkRFhIjMDEwE9BoxghJl8gleiEjFREjUkaqRgkQ0iwZFVimKmGpF3Ux9TCTO0VtvvAkzZu4RTJXuyj0ePNIppWxZVeFgTGpmTP17Cp15sfUh97ZJKziDE1EHRxogHuJMSMRaycvUHjeNqnY5wbExaZciuDPx3u9+eBVqtyWRPu5d5t7QgtIFMJ596unVRuUXbbnWxBwBp9CsRKzM7H0oYkrt2pZlZz65Ncc0Hh6SND5w5w+DOEOplAKnyDFb2UqWbqE1M6d1UyKsTRcsXhWa5u9e0+NlVhNAVGKIXdviozWd+/m0wQB472OMm5ubVVX1Dt2//xndmg01ACMp5wFGND6tXbOaNPXWYoFhG1SgSTWTiFM452KMw7LyzhGRI2JmZiYiIxBRWzfXr+0yvp8LOOfu8Lz7QYspgKIoqlhszWaDsjLR28oxuhWpzaBWE406tNGOXbd9nKZGq1EedauBJiYxFpiwiiMOIVRF6b2/TXa2MAA4rtfrN777GjOpKhMDcN6rfQT73j5N6ANdGWP0oYqFA/Ue1A9zPzZiqqoEuE7qSegsex+vX9y4ujlgLo+Wi5EakwopqTkxhRnBgzxxH5h6AhE5y5uTvPXa6wBc751moIdOmHBW9Edf5sqSO8nRuT6IGJExmZKZmSiBYulP0vL48OjC05+hl76wWi02j6V49S3XHSghs3llE2SSs4kkkiwZfW3bskpWBVNk9/733kM2HwmAiRD7O+oh93OPfvqO5oeSs4iIKc4CB8gxeQc+8w8Ap1LPxJ07t1Vc3l6s5atXr/3f1cHEVUi2hi0ddTARFTMhYygZNIukrKqq2o80mAahuHFt9/DGPgGwjy+r3q/u4YgA7F69llJyzpF3mc6KysbEzLhdi1HbcdMP0rI9PK7e3JtVgy9//vN/bueCnWcDtcw1uBPKYp1KJiEo+pRLFYCaqaqYElER4+HB/MP3P4DBVPv87qEXIsAgS3k+n4uIL2KIMcn3J5eYbxszgHUrMytmG5uHV6/xn762fbw8rm+sTq4xR2HXOU4GEUvQfFbVQa/p29/7bj3xerE82N83PUuVDGc+9mDoDiBmMn7326+dn223Xbdsa1/G5J0nrp0uvUQxS3lNEl08qGov3k69bG7eWOzmP3xl8uo7q2UjnNdRBwmz5NeeT9mcZO9pKfVWNVhKIyLCOLB24KPjwFVIqW1PTsnAajCDWcRH8ul7v7mIkmOofPHlL39Qfef4228QkeZsRqbqmI25F6LzDsCFegTUbdGSX2+1PF77LrsTrobS7cCp0t6Erl/ZlNxWe+tymQbDweH+gXNuMBisTuvT1XI0mgyoktXi0888G2MEIcMCEd21EXZP6H5PNXv62a98aStOf++Nt2KMtO6EWHOORI64r0M758VsYYtgIqq50wSsVBZB9wrLda60qDgk2JUw0eOT82uNGhaWweRcWDeNMZkjZu5W9cWN2ezyY5ceuwyGOPIEuisDuXfVtLdk7zAqd566ssit856y9qXRPtHrndU5JyLr4akUyjxau/M3ws5BNc5ORnm5kK5rmgW65QDT0bgQ9+7Afv9KbHKqqsrMFqtlHI+UnYhsb2w+fvmx0Wj09DOfVFP2t2KhPpymYcg5Z1gH7aBUhDYnJRj3ZfKkkjwjeiayJN1G6wvxDegUthajmkanbjYnNxmRIbHqtJhujCaDqhyNh9tbLngVQBTsjSkzRsPJk5euNM6e+vSzYWvW5NTjpZTYPZymATjvM4TBSeX8+fP1/tFGEbMJHPfOWhIzs5garFrNslPh9VAWJfygHF/d2nmnOl/l/WcO8nguQ0n16vXV7ny4ufE5d2HNXkxDKFTycb3a2N4K4/H8xj4/ufniX3oZJszs+vLLXZtC94amfiLIAZuT6XA4FJ1TCLnpnHMO1NfBAOScC6JuGNja0rKnNA6RJoNuazLfcJ+5nsfTGJu2pNQcHTQx11tMMxbJIYSuEyPUqaUQzCw33Ut/5eXJ0z/VpqaIJQFQ8yHccWbhfiMtKsxkqmEyaeumUO0zjeAcM6tZL2s1JeKV2/et1SkvGTXk3On66dNu07oqRFm2b+sxCn62Ky/msPfOzeadmzLwhXNd14WyWqtc3X1fpht/8/mf+6u/8stw4H5jzgBReNd0bRmLB0MrizcHAwhgnT11sV2c1PPVILNFL0021bUSJBdmVLhBW5nRe3K86rqnpVp2J0daV+wpE4IPbqDk22KwH/KptUPnNhpbkbXRD40+zGvaGP75z73wpX/6D80TYP0WOggIDsAPEt8Puk88upR98Fzw5198/r35YhCOj67vm0rKOYLLWLlQtCklswEXBbnHmRe5nWgRiCx3btmEjZEU4YnWS6ajkTjV2YrZ2VrTSQlrJJ6fPpbKeu/Gp770s5Px4I7g97Ht3sFFlYid94kQCVs//Yn57JtumfI0OudcNnSyFhPJTSQr4tL54IujarBcLmlej71Lk1Eae5KQPUX2WWyJVDCGhWtzosJphdAENxtvHWIZBk88/xkoyD94g+ue0NKJLzwYBqw1DYeD4aXze+/tDoQrH9kxOTHD2rqWkV1omjZOYrx47oJsT+VGWLdrT6uYZzLounRY8VrzzgJFUSxjXp6uylE5aFwOXjXnk9UnP/3M1uMX4QQfjdiPBu1jNFU1kGdiB4/Ln/vs7lvfo5v7tSqpVGVRDcccXGOpIxnbjJsUa4rRI8Y6d8w8s+Ik2jqnA2YeVdsbw+nm1AWxGwM9Ws4aa4aMVWpT99xXXgS7FcnwR4EGEzoLgTOggDnQlYuXnn/uZPcmmEVE5Cypmo02zk0G63Hk71yzm4uudOuIPKy2i/KJY30LdS7oYuIYx3plCxvTy7WMYvm+vq+azOW6bopPXD730nNIye462PRo0AI4Zig8ozWpiQbR7zz3qfaVV6vBQETWx6fN0akullWbphxWzYK7lhxCLIbBJ6cO1nA6H8ebwYUO4uikTot6jlVS0uoTV9ZHi+rmcV3qk3/rL4bL52A8/LgIfffJkHueQsgAt8LOQXOOXgDJ3YDD8ubeaDyGc3a6aPbm67251HWM0XdJYMtp6cnPDlpnuhizmfpWR6PJ0Tg0bJstNalrKtoaj9Nxd2O+H7769q7vXvjHfz+DAO9bQ3HnQnwE6Hu1H+Ikzse2PjD1NYk+63r4ax9qW/eOmz3qJQ/s7VH7fGToH2O7XUm7e6fwARf+uKb7h2g/9Nmr/we3CGGz51L3NwAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAYaUlEQVR4nO16W7AmV3Xet9beuy//5dzmzFWj0YyuCCEBBgwEGwguMDFOsJ34JUWVq3DsKpw8uFJ2HvLkPCRxuWySGMdJsJ3CDhVsY2LZgDFgbrIEWAiwQCA0GjS6jeZ6Zs75r91777VWHvqcM+eMGCEhFeUHdnX91fX/f3d/vfrb3/rW2k1mhhdmKFpuy0kZB1agsVGdFyyAMkAZLkVYob05o54CNcDf+5Wex6FXjCRWAqmIBSZA3QQAEQ0cIjlYzeghJ4eMfppw+3wu5V8gyEBwUZRCQdL85q9/6ALSr7zzHx3bd/PETY36DGTAExWWQNx/fsF6wSI9hZbCPJu967c+sHdp8As/+5Zf++OHTl9oBlYOs/oMywbvQeXMAkn4BwGac5sDfvl/3C2X8EvvetsdN+//2Ttu/eXf+auTFwTCoFz7DNImkyOGPL9rvUCYUbf8X37/Uw8//NB/fNe/bNhzO37bjx198YHD7/mjP5mN8swxAAhKRwUUHJ/PtV64iXh6vPi+3/75n3nj8qGyRgNeErT//I3X7v/bz9Gnv1AAKQGgSEjQ6On5XOoFA33pj3737bdc//a3HKvFCAUc1rK79baDv3Lz/tEnP8LIFAKIPFBEX+j3l9MZwGwuaA1zZEQAcYz1lu96wL3m9lJKYYOg4ekeTy4leuvr7O+P69eOe6DlicMcBRrOyAZDzMkAGLr9Z0ma5wyaNaMXnIjmWhhmG+D+5OH7Lj74lXzuKeTWAsO4yn1D2bowGeX9G5f83Xc30hY2yAlICPAzJCEUPpAaFMhSuFA8OwzPWaczPIAieqnhkApbVMXpD31x/W3/Wm943cOXBo+M5s3aRjCq+v2qN9i3+Or0U2859uTaAWMSeNSNtc6mpV9hs9xGXxTGRs5pTMwez4Lu9FzTeIs5aQ1GkVvM+esjPhObx87ymXPf2PjCvfTle4uzJzXMNzyNMaiHh8Itr1p+w4/2+9cv7gtvXpHlQ+UeX8AnRAfHULNAM2QGV2BKivDdH/5zBo2cR973kJ98jD6+wU9efGR4z+fnn/vo8Ny5sLxPh3uzq2rlRaOm2ZjJ/LyP5elTGPanN1w/O/ZivOTVb7rtth9/UcUENjhGFoMjg7GZA+NZ6MpzB90CZbr7jHzuIYuf/eTKJ97fmq299I5T174q1P1c9qZE83am7bxyutiv63Ue44I99fhrvv3o8rfv1Xrw1Ze99tg7f/Gdrz9YAA4ICsxblCUcGkmV/+7C8j1EGo9O0+987J7+nR8sT5166BVv02tuO9/M9w2kGPSYCp2LV4YasUBTrAd65vxT5jjK0mB6wyMnr3nga2flwRt/7l3v+KWfTw6SpSIHAxjCcM8CwnMG3Sh+7y/ufuC9f8JHbr14x8tqzXE0WywHmkvuM7lIKbmyapgdl4h5Pr64MZsViQZ9Wre45pYOMN/+4BdH99+955W3/tvf+40ZUAKlAYDQ8wSdMfdthUAtt+W01H7kaUb/Lz9z/5//5p+uvOJHZjdd6ybzum1pUCUji2pbA4D3HkCMcXLxIhG54J1zxgRjcuycm8f22IfeU/7wy//db/37QaFTKkuCS5Gehe5dFbQaGDkTc8tctpN56Nf6d/ee+u//+X/O77h19brbyjGpkyYIFCkZGwAQEQAzIyJVbZpG2qYsy7IsOXhmJjgxFZH5qYcq7NfP/6/Db/2xX/vVfyMFSgBIwHfn9FX1xQgg822OJSzZIPDJtcn73vP+VK8MDx9rompsp3muIrWxL6sO7uaxZqoqIiLiihCqMlSl956ZiU0ltc0suirt2Tf4J7944mOf+fU7P1M2mEgD1e+K+JlAEyxphvMKIFSi+K/v/v1LOay88Q2DkQuX2lnfJ7LKuI3ZkjhiBkFNs2gWEyWDZ+e8B5GoxpTm8/l0Op3NZm3bDvYeacPFSVqsXvfPPvXb7/nolx8ZMEXFs5ljzwQ6JI4eIYkCd37m49++99tLP/TytVZyBldFmxrX5JRlpJGbJCJ5a3Qx7kjCzKqac5acU0pt21qWwvnRbKyTDc+TS4MjK/tv+oPf+E+n27LwZfegvlfQChSh1RzYzSI+/YcfOHDdLSP2fpqnrDNKBEApTprCqHEppdTB7a7aMUQ7luScU8o5W06aokgyE6Q5NUmRZxtnF25/E6bzP/yDP96uDZ4Z99VzZtY5YcgFHO6791770oOnJGKmtfdZk8W2X1Tol0bOJ21TY7uHbo+UJabcxjifxRhV1cxSSqzmdbDm5gerpfNujOWX3/eRv7wwSs8c4+8G2nEFbgDV/JH3/9lBC6Gs106fHc9GdVX0vI/r49QkXe5NSBbzpmhsR7aLupl1/M4xpTZqFuec954YJapJSXVe3PBjnrE7eoAvFB/80PueF+jsiCIy5g8/de7EJz473LNo9Z45j0aji7lt4FicBdLQtqXjCWmOM2gkS2SJkUkicovc5hxFEpG54F3wzAyAyWkViqJQN3UjphQ3ZmO65tDpD344gYRILG/iMJiZYZeqPMNEzFAUCJ/667uwcfrc9bf7cnFhcTWpzdoYRY1dUps3MSZRo2xIalG0zRJFxaAgsAM7MSTRbFDibhNQSskxmkujhrKpUra0d+/xk+e+9IUvOYCZzUQVINBONX1m0AKDR6H2N399z3KvXDv60no43L//xl49kGxtk0SRxXJWMwKY2IMcyMEYxgoWo+3NyBGcKWUxURB7aF6/sMY5+34BUUdVu7K3Xj36+c/eRQaoKcxoK8C2C+fVI22FeT1+/4nHv/7NPfuuPZWQ8sy5sG91pQxOc7QUmSx49o5Ms2mGCUwYSiYmSXPMsSGTbuu+V0ndluYtM5aWljhp0zTUr129GJf2nzz+CAyqSmQgVoM9rd9w1colAI3w7/6/j+9de2xw+DWXzI5kl6anTJCamYiwdyEEH4KK5mbekRWAbkmHiZqZZTIzIzDzdpI3M1aEstyIbUihHg5Sr+hZuU6uOX02RfgyqCWQbpFjF0Geodxq739g7c8/9cV3lCkvHrDhAjfu4rmHN8ZkZt77oiiKonDBA0gpEdG23pFhG1zO2XvvvZeUk2QzY2bnHBmPxlOmPMzmFoJCZ2sXhfXJixuPnz5/9NheGMOU4MAENewg9lVBq9qffeSvFp86e8Pqwb9duXYhlJpy09TOGzOTY/Le2GcBEYWiTiqbITR0NwAzmBWhDCEwc84ZIuSdcw6AzOf1cGFYhdGFMUYb4m1jNPMXzk8Ux08+cd2xvUyOTDe9F+/i8VVBnxvHOz9x5+ulCUvXnTtw09GicHvDML+e7WLOuWkaETFCzhlAVVVGRESONh9nl7pVtaqqLnt7rwu9Xq/XizlPJpPKuWp1X5FlsLJfzj7x+GMnUh0WNHHZe+Ls2SahH4iIoDBAcSVoRTQ4B4JwFmhhhRju+eoTvB6P1Pr1O/7pwC2eGp2ZHn+cqpuP3biXHPcG/SQWc4KXHNNk1hBtPnfnXJdimNl7nzQlESFU/UE9GOSUm9nMRPqr1wTv5u04Ty9Omma4sroo6cTCkZX2iS+f5p+RiwOsWGDw1JSIe7s4nQFXOGyad0YWODjCiZOTpVLPHHrxqTpwvOAqCweW3GjjzBkZDAb94aAoihCCiOSQRSSltvNJqootS83MKSUzK8u6C/l8OvPOLS8vT2ZNbGUyGkk7i22LHHulP3L06Pihtcl07cLZuHoEJGidFdTn3aH2zkwJRlCzACfgTJCYn3jsgesWW7nph4r+omkDG15XHpmuTNfnoxgjplMXIzM7F7pJGYJLKXUQu1N3cuGcK8sylBURxRidc8SYzWaxmaU2zqdTkwSzFHNu5v1eXaxc++TXv3pq/PoXmWZhuLLrP+0cTJkd1JkyOzIwhQicPf3E2lOPHF28hVduH8Jny+O2baJpv1lZWqiqopuqAIjMTDRH51wIoaqquq7ruq6qqiiKDvHmzBMBUJbBEU0mozSfzSYjk8SwEEIIoYlpPJnygQMbDx1/4KEHYSwFDI4UT0vjTCKymSkF3lBAR3//zeLx+3jppqdceCpdiDOrjM/4aWgiEZGZ5pRSKynlGHOMKaUs0SDs4AN3m/PkPBXe55zb+SzHtplNR+sXR6P1FBuoQCU4NrMYIzMz83w+n+S0uLr/E+9978QsYV4Jg1R5N+js0DjbjFsGMryIe+DEv3joCa+VrJ+n8XpDftjOefytc/N2Op40TdM5zJxj285TalUVOSEnS1HaZuc2GW3k2EhqUzuX1EqOsZ23s+lkMumUR3KK8ybnyAxmtlmrh4+M7rnvo5/9ZAEPhbIw7crcHoCHgyoYFkBiQO6Pp+tanslpqnl56iPPbnji5E+e+vQHDr321MLhqlf3hoO66oMppZTaqKrz8XpnTbc53cm2L8qq3wu+VFV2ADS1TTObw6gsy5yzmYXCOVM4X/a9ZFxK/LKbbvrTd/+3n37TWxDbFMrSduVE7zO8I2RYIck5OCqgoeSPpScXz54oDhxSkGla9fKTk3P/O+lwOGTvCud9YB/KoihyKFS1X/A2Yu99l19EhEPZkVsJEtvpdOqIl5cXHRdlWc7nc5h69nE2jamty8qFsI967sbDzef+5pvHL73sloECuAK0eQCMYGU0OIxcKqIN9l07euWPfuvz//ea3s2zPcM0at5y/uRdvaO0cqjs1SmllCQI4MiM2IfAIYbCRFQEgDB3k88BwTlmVpPYtDEl8qEqC++9Zck5w9SZShtVldi1OYciT8qljfiSRb5r1jxq9HIfgWKX5rHZ1j0QAxbAzXRWHzn4r37hV3s333jqwj3NPN9YnlvND91/8GY7fCyE0DVics4iaas9I8y8rR5lWXrvu0TDzKq5k8IQQlmWzgVVJaKY03w+n7dNjDFtj2nLsVkPGN94fV0sk32HRognAAYigmcICrhp0uq2G19eL//j6uBds3ZjefXHLzzYn+WHX/yipQH5XBJRzNolavahk7NOkp1zXZtGO66Y5Ry7AgxqztMWbUygWVJWISL2nlUZRCA2XxONe2Vzy+1kfXT+1HYVApdb2EYAwxl81cee1aeOj66xhaWD+/YP5Ce+cv5zg6OP7jl8WCv1FMiBN5PIFZ9dCDs2byvM9gW3vwRg0pXu6pwj21Q0ZvahFwpXON4YHpqMBArPKVOx0yR5AFkyM4jZCKTo9YbR6Wg8mzmaruxfBN29fOCDywtBuA0UBF2vSETEFFCzzd5aJ2HbN3DZqXYuimA7vieDI8B5BjQroMxcFEXLYOQq8iiXG+N1cwfIoHSFnzYok2fqZqga2CFBeLZuTdPW5RpW3vuiH57qZKmd5Wnksu/YsXdG0LzZL+iQde6/A73pToGuOFBVMrDjLt4ikifjzX967qhvpGYmZMlsQbgfKZQZBGS6wox6GMwxuhLHsXmwIYDKqY2ToOgPm/Fa1etxHGf0xpUVtrMjszkPtwK8szbZYsWWchNMHQBTUkGczlVVSbuZ3ZULIuIGfQ+KLMNe2Lu/JgDs/G7J486wAoAoAAU0pQK8b5haG+d2NTsldi7XFGc2SB1fu87G9nzruHGZCVu4scPudbHvPKBzbnlhsa4qqOYYJaVuHjOzT4qMDWtd7ZeXSxiMHV9hmCxolQmZETxh5jFjFzDlabH0jZvfvIdT4znESZvg6qXkS1ZxBjIGGGAixyCCEjkzUoVZVwy4DnFiIe2HXLJxS6NWm1mRfvrC1966/o2juegvH8k+NzF6XaySz4V5XzSenYSDtV9eWWwSFBm0q/PEEJiHeBiMpWBUM5dGfb0gYsMBerUQM9EglCGpb1uAxUxhZqaAqibJMXW1lqjmbjPb/IZlbnYppvGGzpCWD+dL/+HLX1ij3tjwc6c+/Pb274rVZapclAsXWDu5JDYi6vWqylfeA09r7XmAATUAxCCvGWpTH2xtlsrBUuOLnBs248KjTWUowGwqKio7fDMAMnQVrZmBLpuyOq3MC6o5VsLzXnzHN7/9yvgVd/722y49eaFofurECdmb71y5jVV77kIP+9QSEdRsYVA5ckRgMPFuw0QOMPZmAhjDEwZpGB9+4rFHzzFKi7koPEFnmhpKAgp5W7O2tLmbbvlp7QlSAFk2IqqCG7F+0c4/vzw4Ub8GUnx2aXEkS8H3zg+tXOqJlP01ynmD0COYJh0O6q5JYyDaXQV4keQogIjIgGzg9nx6z7s/eOrIjUXVn8wzdUxQreuaneWm3ewBEKuqiHaNRpgHdHsiAjBjAK33So0hD8S5tv/hAy9ZnPWz3/AWxBvratWklE8VWepYPVaOFyMDSVWXlvtk1HEAu2eid86JdnqUPSdQgWuqjWMH19qWe0vIahZJ1KEYUJhP1mGsWws1nTIEZiI2MoDMpBPP7kbNDFgdNGcal2o7q1g4dFE3ipNuNGjDY8BA5Mk0buumn+owL+JiHABmJo7c3tUFJjbLoCtbBh5gJXiA2MFIACW84Sde+fhHHpzP2kAgJsBL0vF4ujFeizHmmFJqoZmZvS+8K+D4cqbRvNNVQ473m3Sul2KRl5oV4sw4g9mhOelKnk97GgJLUUZfl4ZxMV5KA5A6V+xZXiDASBmA0q7CNgOBFKowUvYg9KBvfvG1X7m//dZDj08ltZqVKIKFxA0HxcaGs+zMmYKZmUmklWik7ZYwS1c7beY5m86Wj+zXRltEZtQzx9fX3pfEEqZDkXlvIZOr40YzCAfmveRcl2CrulAFTMHAFWncd8LXtY03uUigcrhgF2djc54tWS7hrPCgWUiDpZyzy9lMHcjMWJMXNSx0nkQt01aTSTVrWKyZjHpUozAzK5g598mTGS3BuCImIiqKXsSUpbAUJRA3p0+NXnHTHhGXCYTWdUt2W/T4ziNJbmJeWFloZ9n5QkhVExOZEpFjR6pZzQzG5M2ZMZla55lAampkIGJiAlFXtXeJvuONwRwFeCZiAGbKIGby5EqEOD+/vFKrKMAE8G5PfVXQbTsv6wquJO/LomcmKWtROZLchdCky+HSPTkiEsmdNSXd9CfOObiuVUbbib37c86ZmNm5zW4qGdTMpE2qqqtL5Q1HDzAHkGZNhrCztL0q6Lqg4bA/EXWhLopCc4I670pybGYiTlhIM9R1UFRSZzEACEQJRGTcmVLqYnz57ERFqBTS3UC3CiMiqgbyNp7cfse1C0OnBoJ51t1tj6s31a87tCpxygTvvYnm1BqkM0k555xjzlGzdOYpxphSVBUz7WonVSNigLaXbrsKYHuAtDNWojnl2PGKnGcfKidvfPXLSlK7ytrcVSN9y5G9nGdFtShtTCmqtC5AcjRL3eogNgVOVdVUSY1gIqIpCSyEwLwj0zxtaEpExESac1Rl9r4IIYR5zjcfXHzlbTc6qDFMAbgs8M+GHtfuHbz01hu++uj6xvpaIeTKkCG5ZZN4+e7NaMvaqaQUJasAcBzYoCkrwWHTqWJH2MyMaVMfVRVg88LMQi6L3PGSY8MKmimRemYYX/HiylVB9zx+5LWvuvdbf7GxdqEwv7SyOG8baX2K006GjS6bZiJimIiYagghlJ7gRMREZQvlFRVDcJZS6irIEErmSmLKWcZNc/TIKgRd554BzYBPOwXkO4DuHmmEv+0o3nTHvv/z4JeePD9qRyt5OkrNZJamzjHzZhnL7ItQh1CKL81UcpPTXCQTcVEUoahgOefc1X9dZUlEIYRGqaqKvvOiWaeph2r//v379qzsHfhbDu8TDzbxMIDJs+2WvKu/7xEvcTG4OE733f+t4yceSe28593CsFbKReGrqvCBYSxiKYkKylAzwxEIGYBzzvnCe89kZtaB7jpPXYeE2AfP3ntmMJH3XJZlFYpUDEsPy8okzlFXauyutp7hzRpJMIMrAIAAE5DCFLadmXZ0fbpz8Fb/ygxGmwdu//od9hVmYN4BSaWz51stJFFxzils52tkV+W0cZAMD6jCYKoIIYgKbVK5k9iuCCdTogDbDIIR03b7bTskO2NjZo66KMJMzTY9LYE1tWB2HAComPMOUFVhvsyQq0Y6AgwQNKdYhAKAggVwl4V+e4cN5jdXsa3LJluR75YxLwdpe18t72jgMmx70U0BwLyKEXWlJmy3zbsqaLHMxLSJjE1gRuy2aohuwQ1dJ2tHJHdQ7/LDf/rYJulOzgAAks6DL3dmvW4lcufRV+e0AoCIusCbJ9WOr4rLseyiYgAUZgSmXT17BjI2Wzmdb9r9I9S61Hj5J7cFN+fo/eabY6q7bv4Z3stTYPM1+CQpOOc2g1sAsK3gEKj7J3Vr7tQd2Vm8rrzZHerNxs1OH3L5imYGcjHmovCAqinDbc6RnUdcHfQ/3PHCvV7/fRw/AP39Gj8A/f0aPwD9/Rr/HwzxAHEEsH4RAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAARfElEQVR4nO16TXNkyXXdOfdm5ntVKKDRPT1NkR7qyxYpW3KEFnaEw154LW+88S/x33F47Z1XXmnBhSO8cYQsi0FZokTKIsWPUU/PoAFU1XsvM++9XjwAjW4SZIcHHknhuYFFFaJe1slTJ+9nMiLw983kbxvA/419CfqLsi9Bf1H2Jegvyh4N9Dv+Pm7//l/Yo4Emeffa3Vtv5vZYi79jjymPO7Jbs+m4zFN1f8Tl39gjyyMieu+11lpra63W/q5sIj5/4vCYTK8K6d3NjNQI1lofcf07S4+1EBkAV9wkVQWAma+83lf857dHdnkRoapJC8kIkPxZMXz+DTwmaHd3dxEREXePCBF5FBG/Y495EEWE1Na9u4soyd57bRHB9QPufkPz5/Mqj+mn3yGVJMmVcjyqrB9f0xFvQiGJO9DAPYl/PvyPCPqNfEmSILEy7bcx5rHIfuSIuPK6CgO31N4n+1Hscb0HwnnfAL/DvX7mUch+RO+BOyXcYr6h/NHJfkzQ9w/cO4x+QfI4ri7AgfBuM9ARC/zggcC9fPkGjEfEUnuL6E6DUosZGDowwYSerd2t2C2Wu6fd3b1jXTcANEQ3a8v6bu7oNqPdx/ZzwuyN9QkiIVKRGSgBExyB0zUwxO1uuYrVa+2Hw0QVSMo5K6Mtc1K96ouq7jY7kaSAGbICAG8DTLx5wR6ePVMANoMHVJEYiADv0ftgwtTTJgUO1kNjS6IDs+lWOxCIoAcIMEAARKIkanF3ODro4a1KJ1I6YXfvzAkqLuz0ACNixE1klDsGQDWFAvSs1sGOhMYURHkfpmdgdMA9UpvrccMBWpqkfC8CB+AOEZCYjrXWCnhKaSxJBOGdpE3obpJT3oxQGGBArIu/WWglM0BCLlFPIAWyxqAFIVXye4Huy1XKZ3+9x3eu2g9eX+c0Ho79GMI+kzTSAmbm7qqacz44I4KIUtJYyp2zOw8rgl32Z4Ocqe/Uz0o+HYZFlpzzqFkBBcKdcBILMfQEYEpowBmA7hCHpF8OGubfPsh/+tPP/vilTy0n5WzzeDJiIZOC2qxX6womUVXd7YRkWF8zu1qbQ8xs0Z312do8KCR8LEUdIlJ4WbQMpYyaNaBhOcmQ0zf+wfDPd/jtYUHyhtE6RwVQwfLLQX8y4z/84f/6rjzfbl+0fZ/bYXda9q8+PZQzzSnI2ltEJNGshEdGZFEzI9QspsWYiln4ZtPNej1sTtKQ5WQ7TtO0HKeGoXez5vCIMEEMRcax9O7ffCH/Ytf+zVefDUQUVIBuRfQO24MH8T//FD88+TrSrr6eznbDy/3SfHM2foS+V1dHqJGUrWZFmPelBDK9BREd3hSapDNy/XTMyg23gxKSG6Y92z7Onm6r1S7uIlRQLA2aS/pI9I+O9Y9evpZ+9m8/Sm7XqmOqGSN+OejjBPb5Sc4XmqZX/XwYUvNLR01ZFSSMCZAOAdyIYtojLLIFnMqtBClQ61sIlHDNV1dXmodjLOl8W1Ob+zSe5kRPqhZxcjIE8XLys6SbfP5fLvD7v3lR5MkES6PfDykPgv7mi/n3h6fnEctZPjhsX4/XSx1G2yMkDLa419DG6Og97KKeAbBAa611s3AAjn5MgwBJPBcuecxpOM4pDxlAP9FxUAmIYOmWUnS3OaWXJWI4nR0v+9OPiIHRFPlehH0Q9L98ks+d9Wr/+vuvTkfqcvXkwxeWezxPgBNEKCLx9kQE59VFuXsAIhRJAKKJhFOI6IBCYZU6wDrcKQKzpqruIQkR0hP+5HD4wd7+9G/aJ/vnH51CNBZqvoftwYP4amrzZ6+GAcdXLy+Or69efvobv/t7Z0+/ppZBj7CARGj3iHCKqeY134gICdymSqaJAAQwb6qKkGaWc+ZNnwRmJklVRZVO5KWhGDB++4Ap4Z9tmuDAOMf7MF3kuD35ymuR/7bZ/e/pp7/9a9/4NT33KfJWk0rSJAyEIBx0kGGJBAgEwNvaxOjFARDhoWsalVxEwvtEKElSHE1FAVfYMm4HAyqe1GX2sE0EJNlbSB9k+j9+Et/94Sv08XX2Z2X3/VcXOvv5155xvtyWtCkYQ3JwS80SSt9oExFVFRFNFBFdF28wM+pNnVtKWVOkMdMsSKaUaq3DqGPOhLPIaWrPUX6y4AM5/PrJxiHh0Dce72Gmh8v5Rxqnw9Z7/YdV//tlT6Lz4bhMZTjJYlxaax2SwCSg2zHdloC2MrpWX5syHpdO9VLKNNWzs2TN27zsTsfDYQpiHPW4b6c7Pd9Rk84Hn60+D8tp8+9/k3ChwgL3MD8MmroZYtH9hX81Lj6ZuKvP2/Pri+V8tA1CXObW52rZNskYlOYNa54JkhQJAOE80ap+cMem7GjHcw7GdrTDxtl9yjmf5ELOu8AOweaRcR1YZFiIr+zE3TuspAqc3GF7MJ/+2F1ywZbDp+Py9Fm6LNWuylMyp9DSkKeInuAlmuLY/dhrBz2yVbGqresSqaosXSG7kNPjRMp2Ovac89Pz3dFqUJaKy2vLJx9+NtnF0UNHCflQylX3f/IEqYtQCmCxuY/t4dS0O0KIFEjTtJCiqiEZ4r27R4AiWHUZAHJKndak2xCA0COZbNLQfanePKg5CaLBF/NxSE/H7VHq9dWxR0gec06AT/M8bopV5gh5uKB8ELSZRUg3WvOL6RrCUornEn2urRuCVAdrtyAEXFoRRfNu1gBTkpTWRUXC1R2iyZSt1m4GGTbQkoYk5qLWKVqOS5+n/tUxMSLsJk1cpSp8SxEPgg7v7nRKEIvXzcluGNMCa+v5ogTEgW50uKp+hOXD7e5pHqUtCprqtfl1XTZb+kYtQBVVXWoD/LR41+uT09Npo93l0I6SVKIr2MLgZDAiSIkACcf7HcQkRiYV1VFFy5PNNqPv6wQkJlWkZmHdHViX/km2WetrD7ajIMAyUw6p/8qEnHNQrPeIINQjptq+pvpsm3pOS7fr2pRpHDabpN9pVVXUV2EIgPiZ0c2DoLebrB3Ww72NElkpzQVBEYq2oHtYBMkQBuB2/vIqftyn3kWIxEjCIZ/+8Xw9DEKKmZEOlQi69+9ofdZnBoLegwIrwTTbICbQIHvvYEKA4Dvu4kHQAvXevEdtNmzCrMEja3bA3Ky7WcAD1NUjix0hTJl53CoZrXpt3nwYswhEQCCiJ0ki0lprwcPSBmXK2G4Hs5bpMKsmSu8mc+0PwXsQdJ1qq0iSk2jJsZi629rocvNa3UJijdrmQTRlliwtfOqhKqkg6wJXl9ZdCYFEhKScVRliXdriZES1QYgOLUlDq4RIRsDC39T874KOmzxh7cGt/7XwS0/czGWK5v3g43mPGhzCLq32Q346yEdP8s5jZvzJp9On7flJfDo9waQ2uG8tzFiF1IHaRMSdFiEqFl28p4xCI6O691AsGMu2ee1SVQbIIingOw+neHh6J5w8GFwWVfOUQrfqjYePY/5r6y9rD8PJk/KPn2Zd/L/+eLlo0+9+ePTx4/3mw+V6GI9njtOXSS+3Sbbal6swj1szs25hDkBlLS4pANaBWHNzpPC3OlXvK4/1mY6FEXBFGpZ5j5BN0iean7tuy/XVHn922L7Stq1Dja+fa7taDnNU15PsOrLU4ySKJyFTBMFYhe8wepckSVQ8J1FBa2ZmLQwUSXB3Cj1ueoIr/EDwXm56ry6/t62ISD5vgC7DZd9G698Y/NkWT3Q8OVv+6lKf9/bvPvJLT9KXUeWvwvOz1JfhR9fHPztMPH9aPM1eDxvdxV2dACcQZASrbxISBYn0MAsLgblYEhUJAwT0eEAIDx5Ej23BNEnde/pIym+la+a2t/SXnxxKbK5dro+2Za5Gz9ojH6Yf/d72N76Wti8R37fDSZdTKZEErUZEwENkFYMbFrNCd9ekyElJd4c5avNCdRHcNAzt1l2/pZM3oO8fRJJL3y71aFG30n79tBTan4d97zjTX/yr8fV3pvqtT8fnSWpdKvybiR88O/+Dl68qR5Hds9q4UTrks9dxugkGApQghCQ9IqJZZDMVIZFUO6Jb771bzgqG4MY1IX5W1z+HaZKIKNKWmqjyLB9e7Ma/eZ3+wtNV0xfp8uPrT39nSC+e6kHyRny3uXZJaf76t+yTj3351fFsuNxfnGC/TbuzTe/h4reTAReQSgY91MCIUAYgBpfwCLbak5IqQvKB2cyD8vhgOHwsWXFyhjoyf3cvl5F+VcbWehtPp82HaX/8FX19qOXV8cMx15/o9amyV2s62wle6DBdL13QBXRC1j4uA1SqqK4hnXQg1tariISwuRVPAH7ByCDdbeZOGxEh4FmMU9PdydRyfHt/bLvN7shPri8/2Ina6f98ffG962W7nEyaX8vVV2r/5gc7y6VVpkXddD/I3Oy0Y5ZQ1RRy8xWyFgpuYSopi4o6xVOW6Fyap6EsdTCtZVjoOUJNscC39w7lg346pRrai/eTJabP9m2a29LrJje4gRAtpeScNXFQHYeSYPVwjb6MQyZR6wIgVBSUwFo+Aqi1124W6L4evnAHgqqqqhLIcy0BAy/asjCgoo7SlveSxyi108YoT9P24JeFKfU6JViPKWpEJHdgobFoK6KZUbxvUhmUCIN5EnX3nIRkeDcHAELdonULYbeo5gRFmClOV4msmgQq0juCuial6a22xy/Q9FictYOg5pPtSSnPF5jO26w05ojd2j2NNmqcpmToT7a7DK11dq/DuCEZtWYy59zMp7p0C82FFO8Wgdpckyayu0R3AKWUo9TihuZb6OhoDlGQb2WnD4L++sl2JA6Gn3o9DihRz0uSpOoAPRl2olqQDA4U+L72NG597pd1vzbuwz1KpjfAh5zMzJba6yIpp5R6mFn0Fpa0W/TeUkrDkOfovTvChyGBQII7QH+vIuB5knPVi9mD3dRlmbe+VYslIip6p1IiQUK8+2S2N9v0dr20vZuUIbpFRD7ZlIjWzczKkFX1OC+9NaqrJiDc0S3cjeEQGzA8SaNV7PvcCmdmQrIAlvA+fY9dWp5nebWf2ibT47C0PSAdkbWvPyjRLRywkHC99nScWrewkkUUzVLAe2URCQ/nOmpJQigjjCEqSmhrnURSWmBpNbug+pjsPA+cDxjG8Ey8X424G/zZkL0u3AzqcN1cRVIPeps7bfHuNmuHBHvyIMrgrUGFWTswQrNyPy9iODs7S1qurq72+wOAkgcRqS3WdpSZiYAlAZhrO2aeurzY7v7pizLIBPPFeyrpvjwenrl0/8OfXn3rx8f/sddXPgp021tpx88qoAmAB5ubOYJwYGKWcMLFu5olmpJZ2Zd6ktLZWK4vLqZm6fTplaulUSWBkVJKQoGTMZQ8juVfx/f+0bOz33l+9uGp5uKS0yAD365sf8Ecsc+T//DKfnBZf3g1fXI4zL0647qlCEaEOQyBoCRV1WfRlZKVRSKpjElL0iz6FJ9l4ZOTrbXWHVGGi6WH5H0qAJQUEYRFWEmplPTVs/Fc9Ll4obFAhzFRaO8H+gpzAkqX5IBJC5qoJYyYcTNmBQCKqGZVXQDiZoy2Thdvky/02lK+cbRBtACIDODu8krYeo8IYKUUAK0j3JOEJAGi3x9uPQx6/a/1SpiqggKIO0C5ywrWR9czYmz3DsubKzbC3LuD6o4QisC9J016+zjvfx+BmIAEEJSgrGMLekDe5CIPy6M6VFbG1uyQcMCxtk9uvuYWp4eHkKTcorhbNTpC3nQBCERDBLT8nGtC62wcCkis82e6rkkV3gTFB0Ev2CcMgrwGo8A6Bje753DkBgZxNyN/OzWLQEOovBXQCAQi4ebG5C1uuXlL4vZi1g0D0SKcMvxy0FgH/wEPuqiBFW6IJ7cn4ubHvZPK3b2lt4EHGsG7qT1vdkf5GW97s+uVI0LuXiMsepL3YNoNcqMmowOR8e6vtC7gNzt4N/+9nX17AtYZOm7Qrh9HgLydiq8JN95dygn3SPr29OIXMf131/7/vqn+RdqXoL8o+xL0F2V/L0H/H7ZXz34C2smNAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAh5klEQVR4nK2bd5Bd133ff6fc+t59vW1vWOxi0QsJEARAEiLBYlGiHCtjy3Ek94xcJhNPMvb4n8wkGUeTzNgzcTKeUbHk2FalaElsokixgSBAdGBRF9vL6/W+9247JX8sBYO0AIFgzh+7Z96ce8/n/uZ32u98f0hKCR+xSAkIgZQSIQQAQgDGd2rPGMMY41sa3Xz23sode7tNWe/uZ8RCSn6HxlJKSqkQAgA4577v33z2ngv66JYW658qhLhpPCEYxvQOz9xq2o9pZgC4U08/t/iep2oaCMT8QFVVAAAspRACxE2mD+H6vm+aJudcCKEoihCCEPJxoO/F0lJKhN7vlTFGKb71l39ZOJeEoPWRwJigFK/X77l8ZEsDwNmz5+v1pu8xVVUl8EgkrCjEdf1b29y0BUKEc95oNBBCpmkyxvbs2ROPR+8d+R4sXSgVf/LKa0IAxsQ0Tc5Zt9tutupOp/sh3PV6NtszMjIipSSEOI5TLpdHR0cPHNj/cTz7I1t6ZW2tUq9Z4Zjv+I4XaJric9ZxHPRB1pv1ZrO5uLjoeV4QBKqqIoSmp6d37NgRChn3zH17SwsJGAGABBACQHJCEEi+uLJq6oZCMYAMAmaa4YXF5e9877vtLiGEYIzXX4gQCCGEEFOT/Y88dAgkVwgOPN8PGEKkb3DADEd+9oXr/YDrurqu3s0sfHtoCYDe/w/vV8Xy0sIPf/RC27Zdt2uoGkIokc5gRAWgVrPEOeecAwCllFAkhGCMReM5lRK71QoCz+s6WFEBkbGxsc985jOEEM/zdF2Hn82DQRAoivILoe/kHpzz9blJCODMVxRSqzWsUGRwYEAllFJqGEY8nrxy7Vq1Wu+iqCQSCGCMEaUcIAgCT/h+uXzkyJF6tVYqlRRFadmdlXyhUKlTQgFA19Ug8BRFQQjbtm1Z1i8kviM0gvW1QwpBMOYACBFApNmxy/WqYJxS2ul0fJ+l0umDBw/2ZHsVRdE0TVVVRcE3ffWnb7/9gx+94HmeYYQ67W7ICrs+77iB57qarge+rygK55wQsCyLMUbpLx5mt21xc5RwzjHGqqr6vu/7PlVVqmuMCd/3FdNiyFEM8/rs3OyNM0IAf7/I9ccRQl1ficVTrVZL0YyIGgKAqKFKRJvNTkbXEaaA0M3heDfEcAeflgAgJUKSM8Y5X15Zq9ebpXLZYb7v+wKwEIIxXigU0okEIWQln/c8z/eYlBJjjBBZH4j9vTkWCCah3emGw2HLspxON5VKcadjt+u7d+86cGAfen81xUHAFeUXL5Z3+jLGmKKQVqu1sLBQrtR8n3EBmUTS7jpSAJcCAEufKYoSNg0WE77v+z5DCKH3P0kIIQCr4YjheH40ljT0EALRm8kCgEs1l/F/+uGPipXiv3rm05wxSrFC72p5v717gKSUAsiVlZW5ublsrjeVCjeadkg3KFakBM9nCCEt2+u63XQqKUIJxpgQAAAICMZYVTVFUXjXFiClQIqmqlRRFRIJm4Lxmt3tGxxoNuvvvnvikYcOJuMJ13V1Tf9Y0AH4iIMKmm+DaSaIHtIMNeJTPaqHpO533UjID1tJnynVVtlK4wGaqBZWR4eH5uaXc339KwvzWyaHyvm8sWWsVKpZZjJsxDiXXuCGLKPttDGrJIY2T7Ye+emPv/ne6ZePPPo5leggmkB+8Qp/W2iNq0BRl7GyW4xHtXRY9aTKjWxITwSsHUpqsXikVFwywgjK3sw73Ik3Fmo+n5nBwMxCyQ5CF1mHNGrhgkhFsK41AtnGqtKb6/E9qWF9GcL9MewPRi8PTkxfazx5OACkMBK9m5F4+zYSAQg/sBUFG6EIQiZGkrGWiqLRKC8W5k9dcs9ds69Vg6oMcSMdXPdxJJWm7u8e2WnXqy+dnsnFenZvP+S1CgWHzi8T7LVGzPZU3wpCIj44aAH4gkdS5ifu2/Xaqz+uN4JYXAHuADHuHdqHQAXB61XR4UomKzQNeeUIKudrxelj7OgZe6bCbDBpKKNbxFC68RABi6iq9fKl64BIK5q57vqdG4t92b5suL6jnzkinGepH62UY9DZCcue46pGKGKwDX7Pcawvr5VDiSGF3NXu7bbQmILgwHylN91jqILJNkaoXmHffvU810Zv1Mlcs6PFjfFcnHVqY/FoqdaN6Z4BGBlhLRz18ossJBbaqNi9ohuRi3VrzMKbM2RyPFnwEj+ZKw2q0U676bgNKz2248FH28V5OhnxaPxuRuJtoSkgBtpy3QmCroWk78u3Tix/49tv2W7ut75435UXvr13Yrxa60b8pUC2Wvl630Act6/0aNgrtYx2eJspm4VLoFuBknVr3MVK1Oh97QqT3eLkWPTR3WMzS5VvvnR203h2XwrSCePqpQKm993lnvMOuzyQGM6ePR+JaHa7+/fff/0npwqePlBZnVF0bc+eg+2WPdinRPRafzKCfa1ot1ykd3yBqOIK2g6IipghuqpoRS2V6lTNDrdIMpHoH41bVmCbUfXUhUpCd3J4ac/GyXLTGRrrTRom0j7GhsnD4NUL2M1XbPNrz50+er2tZCYcr/3Q4Yevnj0ZFwtbx9VkbvBGOXy0RJoQUJ4uu4Rwr4+0OXgNlEQSZ6Ab4PGFkq2hprl8ZiRtmXZPx9vc1LOC+ZIbO7aOrMx31mwHt6t2XiQnNt+VpQPpU6kAAPAmUNNjCqUAwAKgQXV+/lr5r/7xnRfWghjFOapsGM9cXV7ZNWBOjm44U87PtrICOsh2vVaJNGymgKHx1lKFcx4dSLkuJgwJM4Qtjcejkma17uy45oRpX2ZLUhk90ihVfn2CjeXol1/vDATTjx3aGk4PAwCTgBEgwTDCIAAI5gC3LpWISR8LBSEA5HEhMdIBQRDYRLEuv/f2V7763Leuqb0p1cHhA5vHLp19+8ih3V4sdmympZh9repVVu2GA9mXRaF4qtquUCEyhlQUZbHmYlWLqJFWt95t2pUyd/Ww3t/rBlLrFCZTyNKtqcd+JR6SSj04cij3d69WtpJLk8NxGsu2O53llcWDBx7CQBDGQgJHoNxyxEFS+gAKSAAkvMDXqA4AINqVWufr/+drC3Tjaq29kG/u6Een5pZ+7eknl+v16QoOlCD/3oUkXzz4wC93Am9lubywYre9Om+LXZNKOBx+/d2SlbUwU7NpmuixeiKJmXM/LrRVbfgAirNGvvpwRoYGYsnt/3ZDzElQJZKN/vS7zz/zcJ+hSkSIzwJVNzeMT3U7vhlSf3YguQnNPUBqwAFTQEKA5BgkY+73nnv5L7763o7776/azdpaieD6088cPLmizLcN6U6z+fzBvo1btzmvHS+88k6dhLChRHxhp7TeWv4HYcMk1mEH1bmvYKaiiIiEm3tGUJ/Zf2GxfiK/NrjpM4XFNzclwhNbR/o3H1hda/7RwcFGOPbDl9471FvauX1zIIJ8odI3OJ7N5RgTCoVbj2EUAAECBlIFhDGWzAOiXL629K1XzlVl5O3jp+7bOdwzlonmxmfz9aLXC/UZpVL8pfsPXrhwrnwmttZczqQlFxsY7VAkPNbJ9MQQQl3uYi3QNY0zHsEgOtUa33XqYvng/j49qpx778exvbuv58vGpXdqPPzQ3v1HZ5sCLSzXu80kXcxXh/rTGJCmaV4AmoLhZ5Ggm9BKwH2FqgAAXCCC7a77/KvvvrcsUjqj8f5WcSE5PqnoytVSXDTzoeLq4UOb3n7j2sWlVjjU8BrnItZOF3HJNKBEIqNcDwshrHRICgmgc1nx6ytO98Zlr7ej9j778qlPP3Rw197ImxdPy2z8lL1x2+U3rlO5Gh2Jt93f+dS2F37w8tXZxQe2Dj165BOAVS5ACkAiAKrdhMYAILEEEBjWD7Pi9LlLb564LIXiCG9IbwdaangwejzP1AB1lq49efjg86/MXyjPqiaPkh6DDNnBipAqAp8Q0uF2NDmW7tnU8ZuKrjHuhPVM0a8YyZ6IqkSCbi664fsvHzNzw3tHkiHHralmZY1du3o0ChbJDevMjw7vsVlo+trCyvy82+4QBBjDh+JRWAggiAAI3+WAIHCc986cXy22IgRymWilWj44mTldA8W0irNznzyw5603TixUuzJOQLFaXc6VzUKisL+MkGzaLY5YuRbYXeJLv9PpCB74jqfEEr62yWOKFvVtzuJW9PQ/vTYy1BcC2ucUF0PxIO/a13+6Vlj9n3/74otvnpmeXVvNV77/7D9dOH/2ZpzqA+4hKRApOVIEYQDOylL19Xfnat0gFcEsCHrSmp/oXVsQLH99k3oDPOXdlSCs6GoLBX6VYddzVc16uAnVQSOxa3PWYyUA0CElhGi4FYHp3GpVEw8qVPNgSRdaiKc8aTSs5enFpZh/nnWjNLtvtq35hfdWmwjnxfYhr63T1aqfS9nfefbY8Ggikxn3iKLdCg0AwvdBU1SFgkDnpq9gRT944KHpa7PUl9mBoZVWV8dm13VzQ2NmdGgIv8iDtE1zXihtIZ4x2NLqQgWp+59M7nuwt9OKqxAyDSYF8uREl9vt750ulle6moYM0Wj7MeoqwSJ3zlqhXx3b8XCt47xwcS0SiklpObUCdkLjE5v6Jw59/Utf2jQUxUicOnnpqae2MGDarbMHBhDrQRnBpeufvzJbanVJ2LUsbSCqJvsGZwtuZWXxvuH+dtD8m7/7yUCohwV2x613vUjHWf43v7ZxeGDrN344e+bMmbOnrw0PjnDfxoIJCbbPzGja9XzTiDlOIAE0Krifr+Xnk+H4iWOXB4YS9+8bSM8tNzttzEUqLUnCeu4H379//8FGM1hYXk1Ho9evLj71GKyv0je3SRSBIIrCAJjvte323GpltdSoVFujY0Mm4Wv1NjPSMaWeMMgPTlxzZORaB3pDiaGour0n3LDj56ev/Mc//J1PHXnwP/z3r7z5pnN1uhTgqhWKOF1mhrS1/CINaYHTSUcjG4f7YlHcssurMbVa9ZJacq7QnGjbo9n4laWGQCmD2afOnSSiefn013OpSKHc6k0FudwYKIDBBdBvRhowgACEAUBVSKVcWyrWu4HUVa3dqEsZaLGs3eXSbSgIO4GKgPSmMlsOjD7xuQMP7d3zyU/8Su/kvv/77EuJUPZL/+n3H3lAlaJihvs6qMOURrvdChkCvOaBvSNPPTk5MKzk+rMTW3bt/cQj6Y0Z13WJGqnU3Z6YwYXnCFUVQSyium2mGPGW7QXcmNjYv2Pr1Fq+QuEDcWQsQUqgAIAxKeaL9ZaHqJGIhIGxaG+m7Um7UOvLRuptZ2m5mojwz+6Oq8x68c3Z41fPLZaWy3byH1+4/Jdf/l8vPffKwo0LD9zXLx1H2Cissw1j0VZVPryjl3je9PTyctlR4sl8o7O8XI1oUTNCVSwWFpvRsKIr1EWi67KQjoBjgyJAbGWlZjfKkYh66er5b3ztq7duoSmSwNetzkWj1ux6QkokfI8SHJhau82MgGuUL5camXTfzon4ar594srV7NimhWqdsVCt06Xh8NELJcqvCRkuLZ+d6EtevZJXVCmZls7kOG/OXQvUcE+SBqXCnNthXkcEHVUzOG07rmMYphKipC39AFSNelpEmxjOjG3cfeytZ3UF9470twIsO831K7L12CIFRAImKUWAEGPMcTxBQCM4EByFwrylIMcd6M9evDqNBOJe4eXVjt/1o8sLiLZrVej68W5VKmHDzBhSa4Dd1HHx889MnD7vnJ1uZyac8zeW3a4WZrVqZR65UyFrS36l7EGLOU2d6i4KVasVFHDVUgQoCLq53rgZYtms5Tge83wAoSiKrsTW47EYY4QQBoF16XsgACuN1srBPQ/87tO72536aBZpLi/RkNSc2tl3n9o5PpjpVNvUzNeY7S6szutozWqXqzPXK4WLzUorIeSlBVJqVet+qetWrbDn6zHP7hhB7MC++OR4plyox+LhlcXrjdWLD24cGbB6feQ++UCiUzkncElvp0VAWVBdvrRy9MLKN587FlPSldpifrZcL8/nG3OM+Qi9H17EEq3PJQIATNMqFNaWi9V031CdKToWqNtwPB/06PXVWq2LEmEzu9GiES3V0990ysXWUjydiqSjRs6zSd2KE+b0SZycX66V8ovjo02Fqz6szcx2Z1fopq2fvXKjqIZsK5V558ylfH2JaObxEzMbNj6omUnXryuEYYxVnXNhl25MO24jHk/2jIwlkxldC6/b+H2fFgiIQiggALDCyYWF1y/n87l0SjU0ygJLOp1QMpTJXLxUKNuQiCQnt2ztGao120GjDBgsSaIbk9r2DRtPXD7WbrDhXhP07OVrczqsDA708r5sNNJ7Zb6CwnJk02bwU8XSTCLd72Lbba11HaVpc4ZyviiGLCLB77rMDZpD46PRTZPNmWMdJ1hbXLoxOz8/t0QpXYeWUmIAAAQEsAiCVDIbi5kM62o4EjBJQYYorTq47sr+XLbjw6Wra6m4QJzX6lq07wEttdlj0VQ07Tqzy7M9CSOSyIhOoKQG9mYye0sLuFxr9eWULVtG+4c2VuqdqS27e3MjqoE9hgSOtzt+biDTdHi17SsqIogSrE9MTG7etGVq4wQmrK9vvOV0Mj25L37xi5TSm3etFIOQgCgggWUkGk/F9YUCcjutkKZUKw09MQhGbKW6tKUvpWIodODV18oPP947tIEVK1LTjPBm1rWLr/207naCQ/vdofGNSE8YSsQpcN9bfvHE27OXgrGdQwOpSNf3yuV8KrY12+seP322XLcIciNR38c+qHoQOAhoqWID6wZEyYZjyXikWGwVq7W9+7apinnrVQxFAAwIlUAojkQiiSiIJY+3vVCkt2I7mX6aTJqV/JJBWV9CaTtw6vJSvnx+7/Ydvblwq52vzBlvHL/skHjWaKRj/WsrIYRDhsUcx0goY2NjpT/7zcfXiv5Xv3E0krNiKaVZL1RuzNaXZIDCYY309oUWinmiGhjbmJOAqRD4c1du5DF94kBmabXWfOvooYfuv/UMgBCiIDEgkByA8lQmuXNqsCDIVEadrTkB5wloaVytY8MR/paR9KvvXrt/Z2rP5i3f/9ZZn6Ql5dJhusUwWdq2PVMt0xu1RiokOmslPTmSz9vY7F6eee9XP/MH1bzzP/76WQ+5Aba79lu9UYTV3VFTy8QSR9+7zkncCAun3O4bGktacuPk+InX3ohGZciMJjJpBkADibR/3p1i4AIApAQOkob0vp5ENKxbGur4olCqqU5pMGPReM+V+aXxoewTjzw4lfGp46uRuJP17IRtJLLUJ7vHQvFYKprK1dq40jxdrd3wRaTeWhxJj/3D1y48/91Tv/UbB/7o3z+BQ3UaZtnU1lYRpqYS/bn44swq801VD8fi2srygusFW7aNbN8+noiHhkd7SpXa1NRmBAr6YLAdSS493lUVFXEKPJhdmv3j//zXp2b83GBqMKHHEE4devTYjaZYKcSXX9r34IG/fSnvM0XiwLKQ7/hY0KEMzkVa5aaxUJ4BFtZleXLr4NwKrTY8k9KeTLTbLfy3P/vzTzyc/ou//OGXn1vARtls9iX7ynFSmV4M4Q37A97KoJWEllVi5sO7+q6uOgsnXtnVA5N79/z6F35HEQwh9dbjOAYJhBAOEjAAIalUat/u7XEDOrZQFbi4VBzy81MpIzvQdyOyGRMrnhBEa4Ro2+w0VL8LGi47QcehshW4FRalSQ202lrFxFHqaYag4RjudPU//69funaj+Cd/+GtTOenX1BKUx7Zsx8mdXjanMPdQdpG6bssK9/b2Tk3taa1dmxhLP/LEY7/5+d8OPIGwCugDB1sMIAgmcn2VQTIajTyyf89QUnG6bHrmxuP7py5Ozz+aFVWGMpM73pl3n9q33cTSlVbdDenQ2TvaycTthhbfcWjgs7/1TKSnP7vhvi7NKMnU0PbeZ75wwAz1a7q3vDT3hd/7qx+/8+ojD29gVWP/wZzwvZNzdRkbk3jN6aA9hw+ObRjYlBDH3jk5FsebxtKPPPU0SBJSqATg4H0QGnEAjIAIAAkSENq6cWT/zuFUOv6vn/xEvh6sra2dmy8/tTGiS1YLD+Yb3acPHzIpNDHVk6En7h/ePZxeLQWx1IArfDORjmc2T24/DGaIhNVGJ1ioNUsLfjYmF/Orv/8nz337xZ8+8yujA2b62JkZMzWUwu2dk9EVGC4HsClNP/2pTzYaazvG0o8e2L9crINk0uswCRiUD0JjuCm+QBhAkmgs8snHHtw9pHJpnL5ayE1tO3H5Sipo7U5hYoVPNL2laulzj2/bMtCJJLU3T1fnZhRSV84fXe5NpDcM6mP92qE9wzsm4ht6+q6/V5vPt2KpYV1J7d+3NaInctkJX3Gef3Ma9281JN6WswMbHji8N6eEdFn73z86vWVTLhbSejIDnisvXDiDNI4RfChQigEABCIAGAIAEByBxNu2b35yR+I7L70OSLmer27oDX33+dcfGO8dsYK+oclFN3702srjD45/7sguqcTfvLCMVHTx2tqbx84gGtIM4+rV65iaa8XW5evLMsAdxV8sRwd7+j/9WDqmp187UbO2bNelN5HzaShJ+7YqAp64f2Ksf7xZWx1I0qntu0vlemDXM5kUYMICH30wHI2YDIikACDBQYgypiAAQgO7UPwvX/3WP7xRjKPCwMate0dHTl+/+ktPPn3hWvmGYzbaNpt/c8hob9998Ox87cbyatDEy+UVVWRHs9roeOaNEwuCIIOyeDTQjYH7d+85c/rv11bLofR+qz8nFLItJWk4iGW3FVslA8V3DiJWLO5/cLxTXDSj2asXzh24b9fQph0cAQEBct0N/hmaE4lBAkAHsCqlIgAAfCLVc5eP/eVXXplt0Kf2b3/33JXB4dTi2ZmnPv3YTJefWQmAx/38ksGWcgkaMi2fBR0Xdct8OFuc3Nz78mttRoy+XggFtAl8Pt9sdB29b4jpuQgPtqWDruyu6ckHh8wHe3rKVvzNt27sz7Qf3p3sH9pc44pXW+oJqxAe8BBojAN1AUK3zNN3kE5A4+ixd7/1wwsksfMnx06MjKbTERVVK9nJyLZt+9483boR6L7niOIq79bC2ONCJC1cL6x22n5/37AncMXhvkvcuEWiUUQiJpE70/Ws5pf9tNGTmGvJIb/9uUf2vTN3fTjMJnQ3unFrLpG4uVz/fLA7QDd9J6oYF868V6g3/+abr0zPOZLQ3l5zeGTz2+8c3dqXe/zwoXZIz7c7C2uiQYcCu8BZF1ib2zVd0YEaLQ9Cqd4uiF7DUZiTRrAh5NS8TjU+5CjWI309lumdbPilwtoXxqi07ZYa/8zjD0hE7x26C2AANFbXrlw9oyRzX/32628cu/ipzzx9+drcC68vg2CjY5H79m4d7wmN9iQLttr0Sd3xa4y6oOgIqdwlwlXBtULcaJeNcLLGdGLGIdK7UitnwvZIOv741JaX3vppxNJ++/D+7zz37XB//+M7dlArfGdiuMOdCxLg+V0zrLsuJr73e59/tC+tBY63Z2Lk1Z9cn9o+sGfv6OW57sJsbag/r8TSG02S0PiEFaaqojG36zOumq16xSAh1rNtzXFlTBGe/1Ca7YiF317lpfLy86/mf+O+gZiBTs6W3r66+u+2jiph424uEm8LbSABusKJisMxLRQC2T2yf2d5xf3yiy8mze5v/NJ9ZlxZKNfLjGupZNtj352x901m22XP99qbe2OrTbdCQn3ZPVmFJyIxO79cYkHU1EbiVAVyKl97tH88EvO5hVg0uTB90uRBT3QUwAMw7x0aoA0sIgjQsFqultKRdDZhxvXqH37+cO2Xk1cuz5cda6Ve3jA8tHcsXZhd9uJaT5iUNavaouFwOKdHqNA10ezS2OGkvX9k9OvHi76Dj18vjKfgs5uFBUGrW41MPLiysFJbvpTU3VRvWgBDd6FEvYMcSPO5IBQbCm60PGzpjbZDFBiImqP9oRQkiJnmrOHyqqEP2zSUjIkd432z+armVg9vnlpsBi9dLii6wN3uUhOiojOGm/eNphXRGtkwko6Z52dnEETdmpu/fmNuNr9n12YuOpKGyM8bYx8Sw93+HpFrRGMYvP5kbvXyqtdtkpDaDnTsW+kefdcDm7xity8xZUXNt09e2zWRbTX87splLhPYys3la003GIlrWahNRiPLvj3VS4Z9d2hjCkLDvm0zFsMtrnFvrrF8rDhbrrZ7e8aIqoEXwMe5/KTAkcAIG7EUZmpQblZTSooK0fGa3VLihu+buiGp2Wnx0Q0jVFPbVjMSSQ81GpGI0e12hkMklUrl887IaO76y+eLUUMxBi7NFzBIHviJmH253DA0nTcbhenrCImBkWEpAKk/X1nzIYe5LfR6AEpKqShKIpHI5/O6rhNC6vW6pmm+61bLNc/zAKFas4Ex1TStOzvXbrcppZ7nEUI0TWu32++dPCkxOXrsHcf3IlYMgwiFTFVR6radyWSuTE8vLc5vndo8MDCAMJJCIPSLxYS3hV4XiQEAxri/v79YLLquyzl3HKdYLAeuxxjzPM/zgtVCPp1OG6a5uLgYBEEQBOtvWI++scCJRGII00Bw3/fXtX6aplKQp+dn283W5MYNf/xHf4AQAinRnSXvd2npdaHchg0bpJT5fH5hYSGQIgiaImDr8lHGWKvVMk2z3W6VSwWMse/7iqJIKRljmqYRKQiSGPF6o15nVcuypJQtKVNRc+fWKcuynnjiCcYYxgBApJR3Iz697Yp4U4h+iw5SYIxffvUn169etW2bB4wx0el2bdue3Dw13N/TbrfXNd2apt0Mchqaadv2yZMnK5WKYRgSYSGE6wWbJob+9E//FN2ib+dc3qUY/PYiFYwZYwCwriIGAM/zVFUlSDZqVdd1QUqMKCUomYipFG8cH6eUEkIQQoQQzvl6KoDT9S5dvDjY39uTTmGMBUhCFKIovX05hEjg+5TSda8ghHApyMfxafgXekRN0zDGmXRycmI8FAp1WramGaYVJoSsrq1979kfrHvFemNCyPo3tzudRDx+5LFHKIJWs0koZYw1Gq1UrgcQoQq+GaETwPBdEN8JWgixrrtcn9jXnZsxlkokjlcrjVoVBFBqLy8vJhKJZrMRTaSllDdFm4ZhrHtL3AzFYpFzFy+4nbauKo7jROPxVsvesmM351IIoShEgEQI4btOBfnISnUm+MWLF9djmKqqUko558ePHz/+7qn1BlLK9Xeu/w0C7/HHH7///vs9z2s0GqZplstlz/OefOLIR+r31vKRleqSi/nZuZmZGU3TfN93XTccDhuGMToy9C/zLgAAIbm6svSNy9Occ9M0HccRQhw5cu/E9wKtKMrg4KDneaZpep6XTCZd111aWup07PUGt65e6971wAMPxONx27bX5xaM8f79+z8O9Ed3Dz/wfb9UKjHGXNfVdV1KaVkWF8GHoNcrhJBut7ueSEQIkVKqqjo4NHRvyUz3CA0SAt8nhGBCpBAIIUBICnH7NBcQnOP1mf5nFSkEumMG0v9n6JuyfcdxDMNYT8rCGN8ug2s9aWc9P0BV1Y+fA3Uv0HALN/xsnb81j+tDxfM8TftnCQHn/P0bqrvbZvzc8pGhb7YWUiCEEPxis3Eu10ckIWg9JUoIIPfODP8P5ESJILBgJpQAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAANb0lEQVR4nO1ayY4kS1Y9dzBzj4jMGhE0SCDeUy8QiN9AQnwuv8CCFSxYwGNQI+hBTfWrqhzCw83sDiw8h8jqejQCKRFSnkUozMLM/Ngd7F67HpSZ+P8G/r8m8D/BC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp54JmJhFlJogAOMJgDFZQAIAEwAABjAAQGUIKIJCOIKRAaaudPJRQiIBtSIIemkDcPQWZSaD77wAA2YYYGZACpIOzQGAEg83QB9KU6QCQnBEUBCEkEBvbDXzHAEBuLUYCBJBtcxHsso17mHUHS2YCA5nIBG+DAsyPIxOPBSPuggIQ7mgYQAlylDPStp4gLFrvOG1DE1m2PT0+PoBMBN91cgKEpDua53Z2LvGHBQhPQIlNu3T2QwBiADBodWGCAilIQgrK2VzPzEihQBrg4UosxAoC4m4Hdw/lBCdWQBgFCGSAEiAHy6axrzDks32c98c966e7wWaYDsBBgDKQYczn5hGZAAhxRpEBoGQi7zqRJNvyAgtIgnjTQ1gQgoXSNxuNM6EnQKBNf5RPhEpAPqoEibs934L3yAlEjgjmh8XkbG6zLAICcnRiAtH9dAYTmEB3BozcDNNBuiaYUe953WnlqcwyEbizXbrryc3viSiSH/yQn0xsQMAYELAaA3CBE+ojacsUAJEAQOSExcGCQzaAOmhAMlPhlZKR4eX70T92A9OeaUfMoBSipNiQRER+3zx/2NajzCICHSLCCffBRFWViOCxk4pIEA/BtWPY8rbkZQXo8GhAkg6iTED4JvHXf/8vf/Ov/+bT/Ee/98312v7jZv289kBeTuXdRX09T7/4ZD89Hn++HEfmpcgeJBkG6nNxd7d0JECR6Z4jfJoUgBBlprtHBDOrqhCrKjx6OyFyKsIgs84zSwqzrOanm+sfSf7FH//4z/70mzPrgHaiCibahO1/+d3HX14dlwl/9ZO/XRi/O7+6iXUqMqV+0PTF95UpOB1jvYmZv8/wsh9Zrz9fTeCSxFUaZ/dQEU2a4aN7MrXRt4N1WRYRKZNOdSe1jmGtNXNPRMAl6TBffLz6NKuw8z+M0+Wbn//5n3xzfjwpn7Xc3ZGesa79XSkjRoMv5KtZWY9dZDZ5d3j789vrn11/VvJ3LjX52vuRyoh2qLOCxuqhLFONyOPabgWtNc8Yw1W11trM+rLMXnVYnnh09wympAjzXmsVG448je6rW/bT6F8EbiXchS0wjZ4ioqqjeY/RRpeEc5qPdly6Csv+777/91cy/3491Kqf1tuP3j4fm/CMAl8WYdZSiMiHESBEgzCIEtxitN5RShZZV0OjwgrmE6VHFIDdvftp3Fps3pMD4cjbtfXIeuatCiAziDiBboNYS5nQ+lGMA5L0NtUjVylQMo0//JXZ3D/EerO4Udb9/nKaXGS9WlYfc5mllGR2d4rUaQ7vxAImiViWhU9NRAjCLDrVLAWZPgYjhahKWcaQddVdFaJSipK6u5nV+hhclHGXGwSwjj7CPcLdRWkvc4AziYJKKcxYbPzj6yE5ZMRF5/f7txNVozy29Z+GlanqPDU371lU4X5qqxC7JycVLgLpayulMCDE7GQZ0YeNISTCUoR3WZW4knIaEUFImSctT8wjkXwfbSMTTA4CSVktOH6FwcwZvRZ640QjD/vXNAYqrkt+mPm03r6X8ju7+YNZJ2IVhoQPeIwxRGSeZ6zoNlR1P+9aa0JJhIywvqZoJSnTTpDkPoaBUKTWWiUlAPdO+SSbAKCZDtJIJIFZCGJm7u6ITLklU0gCKSxQzXDdncDNDRA5ES/5qZxOOt7vD/9xvLE+wFJUMTw9RMgzkmBmRMRKbADAzCQEQIh3RTLTrA8fnpZMSTB3VSXJCIBpeEzy6IzKxNuxD+YkWPi6rutqn3dZ4av5JWv0aJK3ESvZ0sauqpKY1qsWdnkx2bIPid7SzXpbuk1cL6bdYF7XtXsQ0UAgnBkgklKUCMJEDMCHtdHHaEEhVUTEIk/L0WstKGAikXwaMzlBwBBiwpCYoh3f7C/e7GQ3zLPv0uS42K68H0VBOw/2tV1/yuNN8fX1HHtpEwWG3wA877s5iFBoGSeP4WYY3k8re8awtLzYX87TnkgnLUCu/cSapFnmCWAY0SCesScdliNOEyvNl0RPSCuBANoyl4eIJbUIoCMX4djx2+CRYy30mvavTdZZ1rBcT5PM73W2SU/eP3265lIpU4jZMz1AxLVkYnu/ul011t6EOCKSIxNbHlJKYVYlJiIGncaSht2rV1XCjv10Ork75DEm6vkOIsLdM5OZsyMiD0xXaDr8xnvx+VQrMREYAWuDKFF9UN76kDo5MiML8awFih4jCJ5Z5omZY5iZiQgx511uicxsNohEhFQ1IjgxlRpt3NzcKFlNJSIzQ30kzRm4P/SQieFhHuYegZudXpR5R0wCFLlwHVVPVUZizvpqOlDRK2+L2SQ7nWdiIUAyOEMIRGThw22e58PhQEQRUUqZ5xnCEeGBCLQ2eu8xLDMjorWmqtM0pUfvfXNWPMW5pCmQEZFIImpCnRMqk0zVoQ4M1+SjNWu9hExzYU5qGcw87w6CaZoygoZ7H633jnABJec93L33HgR3N/PNNgCICDMTESI983Q6zVHevXuHbH7sY4wvbfohy84tdUQmAaJLidL9WJHTvtzanPk5+/uO2u3W/KO3Q8ob5QvIkfgqbJ88hhNCGaRctqtPukhZ1zWGKYuytNO68eZkEdVJNbOUIiBKOEUp5bbf2tr2LFXCzCJCnwr7TtIZgOAue0SOcKLclynqpKAj+353eR0fx2hv5v3ip6MNCwcwFe3JGHl7vFnakhS16CQ6TdMsyuEopZ1W89zPszIv6zrcmHnSSVXLPJn1wtJaQ3rvvXCptUYfx+NxxahQkfO0FAA0E0R3lwgicvfmttpAi3x/SBJc9194+/F84ODv19sf7d8Xx35wZYqCEzxC9g59/bq0YjGG9eOyrOs6zTsI12kiIiREZCpVVU+jNxu11mTaDN0iW2uEiGGDUS7K/s3BWbwfs/nmr08lTUAyFB4xGZrYZxwirOz6hePDhw83b3e/lfu4Wt7xxU+1na5uXiu/fzWtw8aQMZXbMXre7m3qY7XWijLPJRzBREB2O8w7qaW7fz5+bq0Vlt1ux4zjuhyPvtvtjuvp1NZpmpKYSCzcico0K2e3JZCkT206kRQEgbKSqEd45Gl0qtG8W1hfVyKbSQYTJv7lsYt1SQx3LjOBjAmkxFprpYjMdLNkqiLJsis1icjT3SgS5gOeEYf9JXsigOEYrkk7rVBYs956D+4WnB3u1r33vjureygjQRQZ2+UzQFQrmxH1jJhZEaQZymrIIjwuLsba+zADF9EiUoKUVJl0mgCMtVmmkqgqwEqIDBBVFqqTgtxdiI99SSQrO4eRO0eLnpkHnTN7VW2jW7QJmpnn9YMzR8wkou3CTkQkhfsaaTNJCYanMNxMunJQzUJViblMNSJ6X9jHqFxKUWJnnrRM07Tf7dx9PR4dycyiRYirlmAhorolTMwA6pRRgkUysyQFeFeqN/cIIop8WnwANCIYzMyJnEpVluxdMtakDFQGp1jYCTghx/BD3KVswTHSmJnJpiKXhwstxcx7mZoNVZ2S1m5hgwjMSnAkE5IJzDQHwh0+zKxmqqoIkzC0Uo6Z2VKcS6GihSFPjzzirbAIRuyKXlS9amPPelOljeg+atDqnclNGIiEEcxHtjCKIlWIEsrj+spZu1skhVlLb5nLcluViSilSNFIcncAzGyVrQ/K9GHMrFxibVJ07j7G7U0sPZLFXSJdfDSU/ZmkwUJAOBCz6sR0+vSxiDp8+Fhvj7taj30Nplqn9LhOK5DCkkncRhAdl5swq4FIJEmdJ2ZOD1DEunYiIhJVUwVgCQCFZZHtlkVhLiIk3G1IKW+irn41BmeRUklKXpa3b/b7J5IOJAexMJBzBbl9+NlPEZiKmtnVp4/7Wm7WxZCH+RBrb28OYskD3kxKqZOu65o2oDksPDHvdwBaa8jw3hQUBBbhUkEcEUTErFNkW1dKxDARIZXhttvvrxOD1zqI56oFdb5ov/0KFtvFcAP5MFbBfdHrn3/yk++++25d19WltdZaw31W+ZAAPrjsluJs/Q/1LtxXkrZE96FzW+f8c1tHRLbcY8Msycy11lIKgN1u9+233377zR+cR0XKSGzXIWEmDmCYl/ttRID51+qaZ8j7wrN8mYrd/fRF0fEB93W4L/vT72Z9EbzPx9B5hNxYjnBVkfvM/YcJP6X4NNI+TPyh/t8I9+0UBu5l97jIpsGtEciHcjGlP5HSk0L508vxV4fhLEn/GjZz+vV1zEJVcW9jm818MfdR0plpZszMIuZWRPGMeKDxVVXEk0o1Hg/OhwF3q2BztccXJT/8vG3dPHO534wvRj7ogwkPHs/MX1HIg6S3c2B7abQ5NdGXWSx+bcf/G/yQaN39PIH+4ly6m3Ju0+fvpsKdmR8t+MFA/2thftWC//vyB3Cn4a9wfVzv5f/Tz4QX0s+FF9LPhRfSz4UX0s+FF9LPhRfSz4UX0s+F/wRjFnscL9rXQwAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAY5ElEQVR4nJV7Wa9lx3Xet1ZV7b3PcKceOUhsUhIlKpZMmjKsmE7gGA4kG4kyKEAcIEEA+yHIS4I8BHn1T8h7AiQPAZIXB0mQlwhBlISSEVM0xUE0JVFNsslmD7f79u177xn2ULXWykPtfc653c3uVuHcc/fZ41ervlpjbTKNAAAGAcZGAKDoGwMAyAACDEJoAQEYcAABZGADCEr9+QQ4KCwCEQRDELAHwQABYABACQ6AGrzAAV6Hx+XbPrz59abxZ54+7M83HZCBbH2UN7oKAHD5n4Jz14gAymcpyAOaZUKwfDbn7jwSMkBrSYP7G9wvafQCAm0AM8AyDoAggA1ACHBDf9Kws+9kHjSCQRUKGAOUH6wMAPzZshuaBwDih4i5R0zaozQACjOQwhQAWAEwWMAMtx49AwzEfTdWgtWMEAwwZ8HDYAqTXgS9rB4CehDVZltd1O8m7aVvDOMeNwBIP9xQAhMYCAAcfC92wDEMifKeodeKlQQYYI808EtXvHoo6GHE7DPP0TVfaNUpBgzkwPkE3rjc1v8JMBABpgDnbWc9nVZ3N3hi7e/+OJxWM/3M8dDTusQAZ/nZ/d0VUIMpdJAsOzgHhgICUOZ46q/O3YAHQYZpgNVZw/ejQSdby+g0dAVAp1WCgQV8TycF61mYb+IBN8zF3O9+XmoaVB6BGMT5Wgzd+eVV3r1wAcCMVNXMwOTZKaDQOnUOZfB0coJqCmN0wKe3sOxSOfIXz6LIM88QGAJ4oCBYxNR7WERXIwQkA7GjQOTMrfv8OO2BklYApkpERGQDbfOhVheeKyBkW5GATw7w7/7j//zk5kGYTLbP7jzxxMUnLp49d2Zne1r4gBvX5fDOnQnVz54ff+Mr5wuJ45JgKz3rQB4ENdhjqTsA8JsDvXkBsQegMMmznqACta703KZZ8HuHx3GyU3TAn76+/3/+7P3nvvYSdnaOnL95rZFrHxWBTdKy7ra3nolNPdu/fGnPP/WF339yEkqAI8jE2s7MuKrgiEkhHYQRRo9UeaSDpDcQ9+Q0IGUBbFBb0TLcsuVQ8se38e//0/cP2+qg1pmG8bmLxda0sySQUBCpNk0E75wc3MFif7eoX3p279LZ8Hd+98XdgGBwGGaiRVACBASgAj2QtBugzTY01IbMVUHcK9T8nSdNp/CM1vAn/+317//wrfGZSw1vabWzv4g82Q6TCYUAMjMhqKmLrWeNx/sfXro4euZc+fFP33h6Z/T7v/vbv/r8me0RCoAVJWXT2XaLWTE99xkz7X7Q92hpAjZ0gg2gI9AAr787+5P//N+pmN48mC+Sf+K5F3hr707d1UKJOfiCmVWSU5S+APynVz7YnfqXv/5Fh9knH7x3cmt/d1yd39l75ddf/o1f2zs/BkUEw1aRAAHCo+lh+iCrQjBDtN65yDp3tsTBEv/1//78rfeviWJ79+zhyWLeRS7H1e7eeHd3VndtFx1xwY5EKSmrtXXj2M7sjbo4296pbt++dXBw54Uvf/Xw9mFJdHF362tfeurlF7afO4cSMEkT538pL2+wF6QAlLxRT4mjGr/46OjHb7/zkw9vzsOTsTiztbM7b5rjbl5HufTMxRu39kdbE2epIPFk01AWhUtt1zXL0SRcv3H1c0897/y4Gm8LjuG3OjedXNhansw+vHP86e13fvh6+8yFyV9++YVvfnWXgaLX1uuptbIMlF2Gnh668r8SqDFoRBlR1sD+Av/2P7x28+48McqdM42V5EYppRjjzs7Oq3/6w+9+97sfXvkIwGQy0STOufNnzjrmo8O7dV1/ev3aM898bnd39+Dwzt7ezhtvvPHMc1/o2sTsxuOxpSSp8SSpWTLJ03vhn//By+cLjAGSlh0DLqI38Q5wiLDkN1zijNuABGgHCMq54NUfHV09TOXuJQ58krqymqSUIsyPKg7h3LlzN27cOLt3ZnZ0PDs8OpkdBedZZW9vzxeOOoDt1t07Qry9e6YaT9hXKphsTc1ghFaFfRkmE6m6etHcXC5/8ObB3/jmOa8YOQcRMKlxdgtWZsQrlPuwZYXdAyAEBa7fwo/f/kk0d2Znt2WrZzMwgz17IkcK+/ylS4dHR+cuXDAzOIbjwI7Yi0IU80U9Wy5OFvPYSVEUURJ7ZwRmZnZRBMzkHDkXyiIlVW1fe/vdl770154/C4MnUsAKRrfWyLSyIHBraRPgFEwo54J33v14Vqfdc09Fo1aUfEhqLviiKGKMdRt39vaIqGkaMFfj0fb2tojM5/O6a0XkeD47f/48ERWhSirNyeL8+fN7e3ttijEJM5dlqbCma41QjqqJ8/PbB2+8d+XZv/qstjItyNqaKufXXiQD3lt2aYgHBx8gDwQBDg7x5l/8AmFaTncOm9iSiXHlXEziiuALiEgb097Z84u6DiEYsQJtjIu6LopiPB6fPX9uZ2eLiFJSAGY23dnm4GNTE7ERnPcEizEayDsW5urcUz9+/9orv/bs56YOZkSAiSMI2AABM5gVsDxPs+owhoXM6xu35ndOGnFla0jkKJRG7ELZdV2XYlGOymo8Xyx8EYxAjsn5VjSajqfT7TN70+3t7d09JW7bNqUksHI8MmBZ10QUQlCYwsg5XxRlWQrs8HiB0c6tpbzzwZFm8YWgyxlMeJh0sqHGE5BAmgMZAZYdfnb5mh/ttupaY/hA7NmHpOqLysh1kozJFeWybp0v6qZTM1FVo3I0JvbLpq3bRlUFBsdqNp5MvPdmVlSlCz4HF0QEgL0jx63Y0VJ5fO6nV/bvJiQAxMwAEiHREI/wgHtFjr438xZ/8f41LrZahRIl06bpYLxcLre2tqqqWszrrut2dnaWbZOnYDme+LIwJgOiigGjyRhERVU670/ms7Ztm65dNvV8Ps9wnXNm1sYupRRCqEaTu4uu2r5wcNJevho7oG0jyhKmm/BYYACaugYUKlnMdcJ7v0itldX2XqOY1w0zS+pgUhVlXddR0mgyJua268qqApHzvm4aMIWy6CSxd9Vk3MYopj6Eo5Pjn77/8//1v79/+aMPBaaElFJRFMwcY4Qag0xUVZd1x+Vk/6S9/OlhC1A5HYJu5ewzA96MiKisAiBwAUBnII9ffHwz+RHgxcg5ahfzuFhOww4cDc2ITjsJpJaTPdzPDyOIajLdPXvmxRdfFJHJZFKWparGLhGRmZEZA6nrCOLIS7KTeTPeOvfB9Tt39WLBcPCOEqAEYbAB7MEAE7GmlEO3aLjb4GdXrpsfJ/Jg8kzLkyPqWm/myNhlOjARERuxgQbjDxibsSmpkiqBmOu2adp2NB5v7+ywczFGVXVEnpnMyMCg2HZNXTsyVum6rhhtXztcvH1ZaqDWMLgbSjkqY4KoASA2ZJvu8O7PcbxIkQtlV1Rlapt2drwVnIvdWmEyHCPLHP18UmJj5rzHzACrphUHrwQzMzMRUVUHcs4xKBMjEFtM0nRsKMgKpk6h5fYP3nhvCUiAIWTQDsnlgWQjwMh5Mc3e4Zvvvu8m262yMfuiaJYn3WI2hrbHR4jRUiSVDNQRciqEGYARgZmYs4E1Iqqbhpir8ShUZVEUVVWVZcnMnp2JOgMDse26pkUStO3EGUuXFH68e/n63Z9cQwRiLygBxCFxn0PJbhNTAq4f4ur+7dF0NxorMTOnrpN6vrx79+6NaxLblJKqkgmgK4JnsmSF4JwbdrKIZMFHSV3XiQipQY0MmhKDrEt3bt0+PjiMbRebumTEeuF8Ec1pufXaO59GIPWKI2t2Yc7JK/IGU6Dp8P9+9H6npuzIeXYBwLgqNDbXP/rg4Pr12LWSOtGoqgwwjBjE2Z1gR+YZ7JCJTmxbW1u+LFYsMjNmLopCRFJKAOq6/vSTqzdv3GjrpqvrgpKzpKrJXLVz4YOr++9eidIb8JyIU6YhsVM3FlHOGvzorfc0jGplKysLI0MYTbZN3fXr145P7moSETHRzNG1d5iZvaFccquXy3o277ronA/jETOnlCR10CiSiKhrm6P9qycH12NbxxjN+XI8aWPyReFCmMf05k8/iICgBAIIMGUAsWtT4qLaEuC/fO+1VO7x1lm3faaWUAtFni5qd/FzzybH1WTU1Y031zVxOa9hTMSS1PtgBvJeiaIYjE3JorFhxDzyRUFBErWi6tgTkNqki5gWbZd2p5On98KFLSXEw/mioaIh70IQ6bz3wY9+/O6Hh4oFkGgCBBCzdk01Kr3jusXVG/GjK58KsZGbL2bMYKDwxe7umdnx8XhSLhbHxCYxaUwmaqopqoiISM4kmfUObi94A5k6A4wVLMQ57ceG0aiM2h0dH8Zu+be+/dtP7Y2uXblcVUWYTFBUwlgul/Vicebs+XK89WdvHKQ+Je8A5qQCoGlSWWIUuKtPgjYTF7eDjtFgMePmyHWzyonUx3vbkzL4FR1VNauw9VR+cFsnj4ygxEocVcqyLIri+PDO13/ly9/6nb9ycO0Dp51zbl53BJ5Ot1OSxWKhqrPZbG3GDFyMRgCqkYfhzsG+NLM4O/Dx6GwZt2hRdIeVnNjyzqUL23dufPSlZ58clVllwnufzatnZtBm2pSGdD4R9WniIRtvYAMZWI3APJmMu3aJ1HznW1+rsGxnt0tHDOuaxjGmk3HpmKBZw65wM8BN24gIDL/6wlP/6l/802/8yrP7H7y9uPH+01u4OEo038dyv9CTnUrP740d9xqAmXOab2VNaAjsMwHoVCVCV4eFWImr0bhp2+ViNi7c2KULE/zmi8/Pbn40v7N/bme6PQraLjjWpK12bVcvN+/FIHjvnXNsxoZLF4q/++3f/ON/+YcvPLVjJ5/Wty5/6cnxV57eef0H/+PzF7e/+etfl9SqavYXs0HOynitSU7xRAHbLHoosYGVqE0ynW7XdS2pPbNVBuAP/8Hf9t0Rd8fx5PbJ/ieYH465C2lJ3YJTs65+AN6ALDDv+qTz3gg7W/jH333p1l386M9/9uqrr9az49/6xlf+6B/9wyee3/vem58aCu89gJSSd8zMSZUcZxkPU3GgR07tGtg2E+kc2ziajJ07MZLpiCvgW7/13DvvvvK9P3/t6S9+/dLTT5aFu/7JhxRnLz3/zN/7zm/4Vb7Y2ItYKAqIwpmk5Fwx9VhE7AToCH/wey/8/d974fKHR09f3N2e4Gc3oRKdJ8/OE0eNTOScSzpQdpUZvKdKRYZTRTKEarSslwacO7tXefYAAf/sj/7mB5/8m8XdKx/f+fDM7s6lC2e//Tvf+eoXywnB9Zl8BeBdFjAzoM4xkMh4GliA8xNEhWN87Qu7+ZGTMofPTkQQY2aziDBzTmQOlq/3DdTUZS/ELIc1nJ1AsxRjDmzbu+248g6J4ace//qP/8msgQmqCtMRfJ8IRXAZMQG4Pwdl2Vo6Ygemgb7rOoPBzFSVBumSgWAwy260mRHBBs/a0NvczBCCwowtu7BKRKrati0mROBgvFdgwoAihF5duP5vFWqpv69ANMhJBaQMdSjWaUiDWlJVVbWUmPnUtFMzzjy2oZBgSt5gMDIYqToitnVd1NjFpIvFAmemgDoQjLwbSlyqsASidUk0x5MbIh7S8Lk6CAWBTYFE8JyTqANCVd0kbfZDciQyDFfeT0YwYxgx9VeSwvqBIGLXih6fzNWmTAw2dDGHJTAAAlUwg9a1JEMu760fP9QeSWEGo9V86quFG+OiuvZLVQYVbQDBaP3LwEagnNgicSCn0CE0c1zGpHdnC8t1MwDOE9m6uOtWHl1/Q+3DmIGwq5oA5W6RKfVhGfpKDBGcI3ZEup52UFUb4pcVp3vQRqYEIyYjA5mQGYwUSi6Qd2I8X7RCvs8NOAYAE5iCByNouWjOmQMepkNx91R9iYgYBOqnQO6i5P3MeXauNlSVnLNBgeQNNojBmC0rFDMy6xcuQKEGB++CgpZNp8Nkihk6OYDZhNkBSJocWNGrBF7Rd2NAH9yorwD2IUm/gV7Sq9Ms50OBXGEiqJko+ioZkA+CTBnKzAZfq5MVO60XEDkC5zUP7F2xcj0IYLD2ywLoVDFPJQHKDJhpjKr96gbnnKp2XUdEOQBpmo7Jm+XhIyPOfoYRGwEaCWIE7eFrAglxEUjaWqUrJ5Orh3WXc+ltWxH8UMLgviDKfSw7fPzAC76n9khkyIPIHHwwggI+e0uOyTERQU1VmR0RZQuysVyDe6lDDGRmBjMywCivSVBzrKZKLrSaUh5JsmwiHjzUm7febKsatXMOgIlsHnXuXkN9n7Lr95j10SsZ84MIlz0tVQ0hxCg9bdyjlyBgkPSaLg8mNCFGwIEdABIRgoHZBe8H7QEmMxsq3+u8B2CG4cDQo1xVY3Jm5r3PU0IV7nHqtcMilc883Gs0gRgcIwRkw6sqCviiDwhUexVE2lvEzwZ9akwAMPveU7CHIbkP9AOaZnXbc5SRtacSjAlGImoqKSWS5OCwQY/NlnGfBj0QjCAihMrMQlEAYAYeDzffT+uN52VdyEZ9MezoGI5D8GVRVESu61JTd5KMyGXtAbAZsTEpUU6SWb+obOPWDICIUkrkWETKsswzFA/q+QNB37cFAH3Qlx26vKducefuEkyuCCEE51xUiTEmFR5Ml62J0f80M8v5U7Xe6zAjNbBTBRGJagg9zXB63n9W8/cMB63LjJRiJHLMHIE2oSxx5ZOrXdeV01JEnHnr2rppQln0a0JWouztvoGMwEwwg8AMxj2pTVJy3td1HUIZY4usA1boHwH6QS1XS5m5D8ysLyQtm1aJmYnJsQvwzoA+JuDsdTyAkr3GICYbtkGrMRSRumu7xwH7cNC5sXO9w2bwDAFmJ4uUhETMzHtXlqWZZV4SOSLi7CJtrOTLFsd6VWI0LCHIoA0mInVdL1to8cuBvofPmcQG9N63Uu8tHc9nSUrruk5SoRKKwsw4YxrcutU3BtC5I2RqRAbdBM1ghdVN07aw8Pgq7yGrNfun9hsCNE3n3BTg2Ensal8kIipoyHtQ/pAN8VVe3QYDtLfhMDPttYmqOkc5JRmlXzX3eKDvk809XciDbYAokohzzhVFl1KMMcaY6UFELoRVTIA1aAVZH9jCuFfTBpgpiUjhaRWzPZ6UM+iHn2u29loNRC7G6IlGo5FzLkrK1bScTN8EPWQ8bDVU1lv5NTdyioc5p7nvfdxDQee1hIRVpU5WKydNzbI/Ds1rE9jPF0svGkIg59B1UZIpFFIoiK131PpYM6OAgciiA4gU2muPXEcimIM50yGCBOjRK8YYKkDqCdB/sluWQEImsesALDs4hzDe9dXWyWzRtJHYj0aTne3d4AoGp04kiiY1sWGhJxlYyAsIlqAtJ2UhMxOQWTmp9pqTI23mFbtUSxLAhceTNBTmVmEjVh2Okb2D48IVLeADDpa4e3RSFHvJkWnSSN67wrlyUgFV0zRAv2aXTE3NAIGp80YKjayqYgAJQYhAwQeeTkI67paLu2XhhNBJLPyj7Yu/3/fIXeUQsrhSSo14LnF7X5azo3Jrh63h2JlwGgJbDIxaJ3n7rA0pq5pBkqkoFGAxVXixrp7XFbeVa32pYYycMDYoPWrh1anDtLnfCGJQ8t77AAe0de2ZYoytiBrgvQ8FhWDOCdGibRdtO+/aZYp10kasM4pwbXIx+U581BA1JPOCoHDleMvIKXtXVq261956bwE0RvooxNj0p+mBSoeHKgRw5fLPr1y9cu7FFzTsROLouDXuJHVtilF9sUVElqu45PqkNQcRR8YgMVJHRkRGDkwn886HPeLYdJrS6K33b/71V/5SoCCPsYD6wQ4TAyAHR1lLd511oKriL37+ydvLO4mjMhdFUVTj6aTkaQmm5XIpOf1FAITIiAhGasrGDpJrpAQiggKBpfCIi3mcH49AFZwDFktsjR8p6P6dgH5VsK3X7ytBYCYxumKSgATMEj7ax6tvXz6JWC6bpmlilJhSjClKGo+mAlNQ78oaK4GNrTNWkBmZMrKk2YiTqiMdebm4Vz6541956ctffXYSNiPjxwc9CDu7G0gx+jCKigiA0RiynDpBJzCFGFJCFKQIySvADXk25cfHBk6zyjey7E2xEUIAGZ44j70R2hOc24LVNVUB/JlxySbovCyVN5MeK9CZLDJocQIKw6rsi+HtmM1EGzZU5+boYSNwXt8aCABZgrWwCGLwCHiE1vOnVcbQlfUvRl/gRZ+AzXdf9zrjzREUu9WFBBh5MkFn617QoGT7YGNY6ShAtoXc+zoPbfcHpJtJm3X+b8hl5d9p1bPNvm1KMTcBDDEv7NIeq8eG4DHAX30/TuvXT9O9j8MDiGUbmdX78G2C5lOH8ssOyJW6Taz3P+Mxofv7Xr1Y71jNy+FHfldgnTDijWs2cawCTQeQrdjCa1Lj9MYmzAfbi9OgVzBPC/t0R3rEAiPcl2ijvtjygJbzgT1cyj7N6oYbs3mYBo/BZyDXEU+d95npknWd5n7fYH1FPzqnO08bn/6CNLwGARDndKzA45d/ZUSHVb0PaXrKyp4a4g0a24Nn84A7u+5p0Idm0OGFF3aP4Xv8f4v4aTRb5QZGAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "Vo_1V653g6nK"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/examples/python_bindings/notebooks/clipcpp_demo.ipynb
+++ b/examples/python_bindings/notebooks/clipcpp_demo.ipynb
@@ -1,2115 +1,38 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "collapsed_sections": [
-        "D3MQHKeixw4b"
-      ],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "4ae67bba152f4240adbe501402f70e8e": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_7c5d5c25159343e2ad0756ec6346bc6d",
-              "IPY_MODEL_7525713bf9434a8e83ccdd1bc94792a8",
-              "IPY_MODEL_746a421cfd89487585007264cc316536"
-            ],
-            "layout": "IPY_MODEL_8d4f2cea3f02404ea5aed908d6e7ac38"
-          }
-        },
-        "7c5d5c25159343e2ad0756ec6346bc6d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_b1d89c5c59ab4c169ba53e5b01602590",
-            "placeholder": "​",
-            "style": "IPY_MODEL_ef1c0a8257434468bb70636ac049035a",
-            "value": "Downloading readme: 100%"
-          }
-        },
-        "7525713bf9434a8e83ccdd1bc94792a8": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_023c6c4ed3b446188eeaaa8151649fd2",
-            "max": 867,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_6e9e8d05043a4b1cb30af96f34ab2d97",
-            "value": 867
-          }
-        },
-        "746a421cfd89487585007264cc316536": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_1b763c56ae2d46829e53e18cbd6ae7ef",
-            "placeholder": "​",
-            "style": "IPY_MODEL_5abc9e4f2eb6438e86dd127f9f96d08a",
-            "value": " 867/867 [00:00&lt;00:00, 22.6kB/s]"
-          }
-        },
-        "8d4f2cea3f02404ea5aed908d6e7ac38": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "b1d89c5c59ab4c169ba53e5b01602590": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "ef1c0a8257434468bb70636ac049035a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "023c6c4ed3b446188eeaaa8151649fd2": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "6e9e8d05043a4b1cb30af96f34ab2d97": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "1b763c56ae2d46829e53e18cbd6ae7ef": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "5abc9e4f2eb6438e86dd127f9f96d08a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "eca90f32fc9248769e710913f60b9b7c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_6d1630037e604e83b8b37b13221c0113",
-              "IPY_MODEL_2701f0097b2e40f58d3d2933c40f5ad1",
-              "IPY_MODEL_fc6e9db41ffa469d8c968afe968f8333"
-            ],
-            "layout": "IPY_MODEL_68711a15d3454c6da258d61210b6fff5"
-          }
-        },
-        "6d1630037e604e83b8b37b13221c0113": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_f5f4d0cc28d64341b290eef632dfd6c6",
-            "placeholder": "​",
-            "style": "IPY_MODEL_4a81afcd4c2e4b9e9973600c21a6a03f",
-            "value": "Downloading data files: 100%"
-          }
-        },
-        "2701f0097b2e40f58d3d2933c40f5ad1": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_fcd94e1dc1bb41e2a9e26e9eff76c540",
-            "max": 1,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_d0596dc4deb247a8b3af85c619adec7d",
-            "value": 1
-          }
-        },
-        "fc6e9db41ffa469d8c968afe968f8333": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_6857472d8e4b4dd68278597963525e1a",
-            "placeholder": "​",
-            "style": "IPY_MODEL_61e755addc4c4fe6920be4081155c766",
-            "value": " 1/1 [00:11&lt;00:00, 11.52s/it]"
-          }
-        },
-        "68711a15d3454c6da258d61210b6fff5": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "f5f4d0cc28d64341b290eef632dfd6c6": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "4a81afcd4c2e4b9e9973600c21a6a03f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "fcd94e1dc1bb41e2a9e26e9eff76c540": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "d0596dc4deb247a8b3af85c619adec7d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "6857472d8e4b4dd68278597963525e1a": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "61e755addc4c4fe6920be4081155c766": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "6632fa54917a4a66949ac64be2405eae": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_252bc9f78759418c91bcc7a162fed88f",
-              "IPY_MODEL_74e10b36274d45adb9ddf63f10824b86",
-              "IPY_MODEL_974691f61e5846efaa42e118cd87ff72"
-            ],
-            "layout": "IPY_MODEL_989e22e99798474089ed8c55d9adf74f"
-          }
-        },
-        "252bc9f78759418c91bcc7a162fed88f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_020b30456ac04d02b0d511a9780e0169",
-            "placeholder": "​",
-            "style": "IPY_MODEL_9b88d8521b964d829c0ff02e53983197",
-            "value": "Downloading data: 100%"
-          }
-        },
-        "74e10b36274d45adb9ddf63f10824b86": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_3088b25b28d843888b3ed4443a43cd4a",
-            "max": 136091680,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_2b76a7691c33466a908d23d8c5698867",
-            "value": 136091680
-          }
-        },
-        "974691f61e5846efaa42e118cd87ff72": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_f9e253e85ff942b4b7025fa80bcd43c9",
-            "placeholder": "​",
-            "style": "IPY_MODEL_109cf29003f8412ba5d9ea731f95ec3f",
-            "value": " 136M/136M [00:05&lt;00:00, 24.3MB/s]"
-          }
-        },
-        "989e22e99798474089ed8c55d9adf74f": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "020b30456ac04d02b0d511a9780e0169": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "9b88d8521b964d829c0ff02e53983197": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "3088b25b28d843888b3ed4443a43cd4a": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "2b76a7691c33466a908d23d8c5698867": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "f9e253e85ff942b4b7025fa80bcd43c9": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "109cf29003f8412ba5d9ea731f95ec3f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "a58c4bf3ff87443bb130154914fd6d30": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_d59eb2b6f7a34c828cb732a8ac86febf",
-              "IPY_MODEL_8233eea0e1404d59960253f136c7c098",
-              "IPY_MODEL_f8a61b8bab194518a303bd620c244186"
-            ],
-            "layout": "IPY_MODEL_f598bcca46204914b14767473fefd867"
-          }
-        },
-        "d59eb2b6f7a34c828cb732a8ac86febf": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_412e57470bae42609ff839adf0e2f802",
-            "placeholder": "​",
-            "style": "IPY_MODEL_41ad3ca4daa74aa494de4d4b56d166fb",
-            "value": "Downloading data: 100%"
-          }
-        },
-        "8233eea0e1404d59960253f136c7c098": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_2242e5ca5f5943efb9d6cc6158954c8e",
-            "max": 135404761,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_f27f0685c73944b794af96df74fd36bc",
-            "value": 135404761
-          }
-        },
-        "f8a61b8bab194518a303bd620c244186": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_13e4be26528b4d1dbb5f3a8be1458635",
-            "placeholder": "​",
-            "style": "IPY_MODEL_7486b22826a74aae85071f33f0fc3a17",
-            "value": " 135M/135M [00:06&lt;00:00, 31.3MB/s]"
-          }
-        },
-        "f598bcca46204914b14767473fefd867": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "412e57470bae42609ff839adf0e2f802": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "41ad3ca4daa74aa494de4d4b56d166fb": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "2242e5ca5f5943efb9d6cc6158954c8e": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "f27f0685c73944b794af96df74fd36bc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "13e4be26528b4d1dbb5f3a8be1458635": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "7486b22826a74aae85071f33f0fc3a17": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "1a4295168897427eb269166acf54b014": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_165cd045e8f144ecb7d0c3901964259e",
-              "IPY_MODEL_1f5e7e234d544e5e8637b67f876d7397",
-              "IPY_MODEL_be7fceea155642f5b983df24bdd7ca3f"
-            ],
-            "layout": "IPY_MODEL_c892d6a91ccd41b9b2a34831dd566555"
-          }
-        },
-        "165cd045e8f144ecb7d0c3901964259e": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_6997b6fb2bac419d85adc36f415587ea",
-            "placeholder": "​",
-            "style": "IPY_MODEL_648fc8fc6c804aae9faf02f09a64e2b4",
-            "value": "Extracting data files: 100%"
-          }
-        },
-        "1f5e7e234d544e5e8637b67f876d7397": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_a1670f5b5fc3434985acbe1f5cb61f0e",
-            "max": 1,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_8739d5ebc54a41529741cc43b91ade67",
-            "value": 1
-          }
-        },
-        "be7fceea155642f5b983df24bdd7ca3f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_7607d0df712a45499051e8ab1e7a1cc3",
-            "placeholder": "​",
-            "style": "IPY_MODEL_c50b5960a4614bdd9ce3c940e3207a35",
-            "value": " 1/1 [00:00&lt;00:00, 11.84it/s]"
-          }
-        },
-        "c892d6a91ccd41b9b2a34831dd566555": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "6997b6fb2bac419d85adc36f415587ea": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "648fc8fc6c804aae9faf02f09a64e2b4": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "a1670f5b5fc3434985acbe1f5cb61f0e": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "8739d5ebc54a41529741cc43b91ade67": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "7607d0df712a45499051e8ab1e7a1cc3": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "c50b5960a4614bdd9ce3c940e3207a35": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "dfc716ebacef49e1aeb4de6a22303aa2": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_d0e7e6ae228e4eca92d1c29bd51e281d",
-              "IPY_MODEL_00618ab3c8064ead9c5e36c36f15b9f5",
-              "IPY_MODEL_4482e1cbf57c4a64886843cf0945ceac"
-            ],
-            "layout": "IPY_MODEL_9e8b1fba499b4333b460022371ec51cd"
-          }
-        },
-        "d0e7e6ae228e4eca92d1c29bd51e281d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_da665853f8144b7caa80a54034499bc9",
-            "placeholder": "​",
-            "style": "IPY_MODEL_58a9d43ad9654e39aa3a022b6c7bcfcf",
-            "value": "Generating train split: 100%"
-          }
-        },
-        "00618ab3c8064ead9c5e36c36f15b9f5": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_ba3cab9e1105440299aaecf75b533468",
-            "max": 44072,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_1a8d331fc5944af788491ae42cc2631d",
-            "value": 44072
-          }
-        },
-        "4482e1cbf57c4a64886843cf0945ceac": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_31dcc7dd63af4947a793f9adc4a43846",
-            "placeholder": "​",
-            "style": "IPY_MODEL_40bbfc78bd494552ba6f9a17ea1aa9bf",
-            "value": " 44072/44072 [00:04&lt;00:00, 8122.41 examples/s]"
-          }
-        },
-        "9e8b1fba499b4333b460022371ec51cd": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "da665853f8144b7caa80a54034499bc9": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "58a9d43ad9654e39aa3a022b6c7bcfcf": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "ba3cab9e1105440299aaecf75b533468": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "1a8d331fc5944af788491ae42cc2631d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "31dcc7dd63af4947a793f9adc4a43846": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "40bbfc78bd494552ba6f9a17ea1aa9bf": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        }
-      }
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/Yossef-Dawoad/clip.cpp/blob/add_colab_notebook_example/examples/python_bindings/notebooks/clipcpp_demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/Yossef-Dawoad/clip.cpp/blob/add_colab_notebook_example/examples/python_bindings/notebooks/clipcpp_demo.ipynb\" target=\"_blank\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Downloading an image from internet"
-      ],
       "metadata": {
         "id": "tqrOHxcPxfyj"
-      }
+      },
+      "source": [
+        "## Downloading an image from internet"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!wget https://i.imgur.com/8H7XCH0.jpg -O cat.jpg"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "oOaE1AmDyth_",
-        "outputId": "e32b635b-af09-4aa0-ca86-654a7e731d56",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "oOaE1AmDyth_",
+        "outputId": "e32b635b-af09-4aa0-ca86-654a7e731d56"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "--2023-09-13 19:58:43--  https://i.imgur.com/8H7XCH0.jpg\n",
             "Resolving i.imgur.com (i.imgur.com)... 146.75.92.193\n",
@@ -2124,14 +47,14 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "!wget https://i.imgur.com/8H7XCH0.jpg -O cat.jpg"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "from IPython.display import Image\n",
-        "Image('cat.jpg')"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -2140,47 +63,47 @@
         "id": "Y9Q6bhVA2L01",
         "outputId": "abfccda4-eca6-4be3-d88c-f66823849bab"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "image/jpeg": "/9j/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAGGAiADASIAAhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAABAUCAwYBAAf/xABHEAACAQMCAwUFBwIFAgUDBAMBAgMABBESIQUxQRMiUWHwcYGRodEGFDKxweHxI0IHFVJi0jOiFiRygpJDssIXNERTJWNz/8QAGgEAAwEBAQEAAAAAAAAAAAAAAQIDAAQFBv/EACgRAAICAgICAwADAQADAQAAAAABAhEDIRIxBEETIlEUMmFxBTNCUv/aAAwDAQACEQMRAD8A+ocW40kaHvDlXzXj3GjMXVW29tD8Q4vPdFhrYDOcH9frSaWJ5Gy3M/H+fKvIX6z0+SiqQHLMzserZ9eutUkHTzxz2A9fCjRb45bn2VE25GOR36+vnT2D5ELtw3MEgZ39cqKjyB3ix9et6mLVmfrkeNXfdmGMZxjp6+VZyD8hFXIxzz6+dTMmRhj7ue30qz7q6gbGuizkOefvpLQflQLK4weh8+vrxqh3JbcmmDWTMPZmq/uRG59CnTQryWLJGBFDO+pueenjTeSyIzz9/r50NJw/G4z5U6mhbFpLDn+dQZvAn2YpkbBj0qL2BycZPmeVMsiBYqBO4ztipBiDsfZTIcNY+Rz0FEQ8I1MccwcUfkQOQoycGpByDjl7KcDhR5FcV7/KySDvnkD4+vGj8oLFBZsE8ia5k5HMY+dPF4Sc7Bs56VenBCRnSTny9bUPlRuVGdBbGMHbbP51fFGxG25I61o4/s+7EnR76Ptfs42QNPlSPOjc0ZiOF8jAJolbVxjPwFbKH7PADB3oyL7PKWxpz86R54g+RGANsx20+yuixkOe4c4r6rafZGI96Rd6MP2Wt9Oy77nlU35cfQ6Xs+NvZSrgaTz6c6Ga3ZeYORX2G4+zKdU7o8qU3n2XhYbJvTLykzPR8raI68j51S8bliBua+gS/ZkK4YjOPGqB9mVeTlnOTt0FP/IQFK3Rh1hdm1MMUYkWCNuVa9fs6hXU+ABuSak3DLO1t+2OWbIVR1ZqV50Xjjk/RlRE5OdsGpLBNKe5G7GtcnD4lTW6LgdMUVbRYmlTs1jiVRkkcqT+QvRVYH7MbHwq5Zc6GA5AY3+FSl4TNCQrRlm6gb+6ta3dZhE++dyOZ8s12OMKT2smJW/sU7j96C8lmfjL9MU3DZgdJRi/kK4nDrhjkxn219Bfh7mIRKW1vzwvL14VTHw6KA4lJLcmJO1N/KaAvGT9mSteBz3A2TCjxFGf5G6g9ptp/wBW3xrYQSK7Na2aZI/Ew/t/eg7yze4kP9Xs4VP4s95vGpvyZDrx4mXk4Yqg6CD51S9n0Ix7PXyrTpw5FVSkLyEjujwGeZNQvrW2tk/8w6l2/EqEbn2/rRj5L9iywfhknsPAd318qqa1KYwKezzRuF0DC9AKGEBfoQAeZ5VaOdMhLDJCtYsbYx0xUzEpG4z7qYtahD5daisSatI5Z5inWREuMlugB4uVQaMgY59d6ZtbkrlRt7Kpa35j9NqPJA5itoznGABzqHZE7nFMTCRzFUtFpfFDkCUwNY21AdPOutETt6zRPZYBOnA57CrFjwNwK3Mn8gIEwNxtVgjXOPLrRKxYBIQee9SCciBv5UOYyyIhCTEwI5frWp4PxHs2Xw5cqzfZ4OQMHriiYXMfPao5KYedn1Gw4oCow3TpT624kGX8Q233NfKLTiZix3ts+NNoONsoB1493r4VxTgzfIn2fU47tG61aJlI5181j+0bL/ePw+Prar//ABSwX8Xxpakhfqz6H26eNRa5jA5ivnrfatwMZ6+vfVf/AIpbHecY8qP3DUD6C17GOoqv/MI8Z1Dlmvnz/aRXGdfz2/jzqiX7QZOA/nud/wCanwkG4I38vF41JGoUDNxxFYLq8ueN/wBKwEvGDj8fw+f8UE/FWbfWffv/ACKb4WxPkXo+jHjSn8JGT5+vhUP80VtwRjGTvnb6V8+XibFzlvLHr86Ng4hlgNWd9vb9fzofEMswrW3GfHw29fCovbLpA6DbyolCp659/r41xsHxz88/Wr/IyDyME+7DV4kH51H7tkgHl0AHr4UXpAHlz91dRVOQ2NvP18aPyMX5GDi0UDkDt691SW23GTjrv8qIAOdPPfl5+vjVkajnkc8+vpQ+Rm+QrW1Axn1+9Wi1BUch7vXwq5cDbpjr4fSrM7c8Y8/h/NJ8jB8gIbYDI0jHr1mqpbYeG/X20cfDr5evlUHUN4fD1tTLKwrILHt11d0ezb18Koa3TV3Rv126frTVotWSfePyqhosOf19bUyy2N8tC0wAcga4LXXtzPKmRgyMDn5evlUlh3ycYrfKD5gFbNdPIHb3YoqG1XJyPj6+dEhPjn176IRR7/XrFH5RflBRZam9/hvn61bHw9dth4Db18KNQDT6O3r4VaPM+3Pr50/yGWQGWxQb7ev0omK0TOdPrpVoB67n9frV6d316+FSlMPM7HaoeQ+Xr4UZFbKF5AfT9ajF0zy8T6+dFxnbcb5+f1qTmI5nEgXOw9dP5prYWajc748qBjIDdKd2pAXH5VOci2J2y8RgDGBXdIqYIqqSVUI3pFI6VbIyImk6thSi9EEIOph7qpv+NArphPNse4UiurlpphHIxLsRtnfflVIpnXj8dy3ItvLmLTlRzXI9eFKppy0ngq+XM0dFbm6cu/diUYXzFVXNqzMixIQreWcb/wA1TZ048WOL6FLF7mZk16IhzP50TFbJcSxTKp7JF0RA79Satv7YWwWNsHxHLboKb2cMEdpGHI1EagBthdtvjTIeX6CW1sdDh8E7M2F7q+AH1oOaAoxghiIfGok9CeuPGtCEM6kQxqoB758PAeZ8qpu4wkbtCwLtzZt9Rx+WPhWehU7ZmprUmPs0ZhjZmHj66VZacJMVs7rH3jvrY/rV9rZ/e7hRLK628f4wv93jv+taSZYJIE0DEX9oHh4iilqwyluhPHDJBCDLIDIwzt09dKT8SleVvu1vkaSVL45t63NF8cu3kxDaJJrZsal3J8h1oyw4bClqsCRNJdacs+dlz4mtV7BdAPCoHt4TDEgJbdzjn7a9MpVi8zMFB9g8h+9PYrNY42iEikse+x29frXOIRJBEHbSiqM6sb5P5Vq9s3JdIzst7MVEcMTDcaRnr5+dVxWYlw1++uTGNER50UljJcKDChCj8WroPOrTZtAhU4JPXGB686HKjcUDrZ8ND5KDtMAED61RMtnFIWZQZcZCl/0/Wuy2dw0p7Z+zjH9ifjb39KJslitoz2MCIx/E77lvXhWX+sP/AATyWtzdMuVEEf8A/Y3M+QHjVYto0Vvu6rIBzcnZaZXEvbSBXk7QD/SuBj6V6USOgSKBIVxpyRk1uT9BcV7EghYyHMiqPHVtU3ijYfjBbyom5tERdtOcbud2J8PKl8jrC2dWTzOBk4q0cno483j89xOSQjlihmi72f3q+GcTA6gMHxq8xAtjBP1rObPIyqUHTAGhAPWvCHcDn0o1o8dflXhFsTj9dqHMhzBVi93uqXZ0YI9jt7ia8It+XWsph5gmjA5beZqJXVzyPX50YUwo8/L18KiUwdhtW5jLIwYKc5G46VLU42DZ9tXsu29V6duW/rNDkNzOCRwy9ff1qSynYZPuqI2GknmK8Rt9T8P5ohUyRZjg5yPPlj6VMZdTk7jb19arQdORzirFGACDt69YrDLIRbKsCDv69Yqsk8uY8qIIGCT69eNQIAbf0aFm5A2p98+/Pr514k7DfPQZxv8AWrynl8PXyqpl0jVjbnyyMfSjYlnFYnA9evKrUdvHHr8vyqjAyc8uoqTnQxA5eJ8fXxrV7NyGy58fgPj/ABXcg8qgGGk4Px39e2u6upbJ9evOuYjZYCMYI610c+vr1yqCtnb9PXwroxjmBTUCyQIzsfp/FXIfEn3+vnVI9p5+vfUw2D093r5UGYvB8T1+f1rofzz7PXyqkNt69YqWefhkdfXxpTF2Vxz/AI9dagTk5BOevtqsscdf3+tc1ZH0FCjEidtufs9fCoZB2z7/AC/UV4tsQfLn6+deB235536b/oaKNZ3pn459fOug6agGydj69dK6TjbbYevXSiZkwQSB+Xh191Wq2NqGLYbwJ9ejUw+c0UKGK4A6gjf151NJMHb168KCEmFz0+Ix9KksoI3I9/r501jJjFZNs7cvl9KuR/Xr86WCbBHt9e+pifB+X1/ikY3IcJLgjx9nx/irluBgYO2Pbt6+FJFuTnPT2+vjVn3vHM9c+vP86nTFch4twAdz4ev3ptb3yhFBO/KsetyS2N/XOmFtKxGdW2PXurVZfApSlo1R4iqg77eVZ+fjEsplZDyGAa9E/bSLnONG4/T96rjtU7CQ9Gf600Y0e5gwqP8AYVJMSodgQvr51C1c3fEFOTqkcKMeGRn/ALQabzcODxyRIg7649xpVwwPDxKeZsBQMR+QG35DnTx09na2nH6jm4Jj4jHbxYIxkDwXkKvltAmCDiNANx18fpQ9gHuL2WViQ34RmnjWyyoi6tlxnbnVKvo5pS49mQ4lC0t6rsHMY7zAD8R6L7T+VWWZkup2VHXbmRyz9PKnc9h2haQMeoXbOkevW1Drbx2NuQmzyc89OlJ0yikmg63AS0OkM6xju/7z+9AujqGll0tI4wuDsmf1NGcPZnlwR+Ad3pz6nzpj90iYlTgjctjrjp7KrVo53Pg9mahtMsAWwm7Njwou4m14ggbs4Ih/WkP9o8B62q7iS9kpKEITgr9aWW8hjykAzpOpnY7Bvf1/OlT9Mr/ZciC2kbzbHSnh5e31mnraYYWjijOfZtn61zh9iiIsgfvDcEjGTUb+XsI2VVDYQgk7D4+sU1UiblylQrjkxcuhQHfZmHXrgUR/lEEshmca5M5Jc6gM+Xj50O6CIE6grHn3snPtoqxllXcPsT72P6eyhBjzTq0SlaKBirlwVGyqaTy31vAzSMFQ8v8AU30pveoiRlHZUdhnYdPZ6xWflt4knR+xBI/ubvY/fzoOxo7JK095GXhtlVCMdozHlS1rW7jkK/eBjqI05e/9adzXsyDTHEx0nBYsq4PvqtJJo2DNAMtsveZ/bgn8qCoNvoWpZiOQu7SKSeg1Mf0FFSvbdisUdtI+RuXBY+/n8K81xFPMziKR237xwEbf8qi7f7RHkZYBsH+fOhtDUmJbyxF1qXsJcY2AkCigU4UqS6Wgu/aV17+HlWvtkAXU0cu2/IZPx/Khbq80jWySRKNizRbfvTJ0IzKtGsDYMZj322xRkeGTIO2Kt4lcwyRa7URy5G/+qk0M1wkpzCUPSitnH5PirJG0NSB1rmCDjfn78/WuoxkX/psD19fpXeQ9Y/ilPCnFwlTOjOPpUQOeeWPlXc+XxPrfzrmdTbePMevlWAe2Od6ixA/P317I5nn69Yrx5Egjl7sfSiayl138jUdhtkVbo2xj4+ufnUW+eenr5URkys522PP2b/WokA+fmB6+FSBHjt+n0rh659u/1ohs6o7o9nt9fpV2MqDn4n18aqXG3P8AX+fzruvG+w68s+vZWCXEYHXPz/muFFwO8PL14VDXtp6Yweu3rrXi+SMZ+PX60DWcbOo5GPb6+dUse97+ecejVjP1xvn1/FUMw0n+aKNZ1snbkfZ8f4qvO/IE/p9PyrxYnO/tzUSx1AY3J9/80xhumoYz7PX0qWcevW1VKSF8fXrepBjj31zindRDADHPfPh9fOrQxBHXrtVAbkD69eFeDYGevnTGLwxBxsfdUix/n186o1e31+v511c7bjw/j6UGAIyduv6n18a8G8CMeQ9fCqi2Rz6e7+K7k4/f18aUJcDqG5GP0rp2wevt3/mqlYkdf3+tSzkfljwoGOlsE+vXsrsfeA3ztjb1uKgBz6+3186mgwN9yT19bH86YCLGAHs5+XrzrhTBxv6/WvYywO+fL18q8eY5Yx8qwzKyvgfh6+VcwBzqxgSB4+fr51HGCTWEOFuuf0NdBG3j5evlUCMetv4qQyV5ke3186JiYbPhj410nc+vXtrqjHx9e+ub/L1/FAx0H4nw8a9r89uY9eFRwTv0/SppGWfHPesZK2XwszrgjZfXOm8ULQ6ixymPmfyoG0Tsm3B/FjHr8qYxyPI3ZsNOSM0JHv8Ag+PwjyZOCbsGCopY4JyN9h0plbRg2UaE5OsjPiOf60ohniguOxcjWVYrvvkZyPhTPhkms95STrbblvyox2dk1Wwt1bJKk5Zdj4Uo7JTxVozsFVS2fZsB7+lP2j1MkYwMjAPr2UsnQNxSR9GrszhR54wD86ZxJwnugcR/dp8KdGofhPMCnVnG7w4kbY/iPmayt2lyLprhs9nqOkewfnmtbw/As41YbkchWx9hzpqKZCVNL61OIo1OPM9aR3VxJ95UuqpltgeYH8fnWjkXSwXA7NQGJPLb9KzPE0lv5gyDEAYksRgtjl+tDIqF8d2x9w6JTDrXrv7+lNFCgkEABR3vIeFJOETvJGFK6COlPHwkG4znfA3zV4P6nPnTU6EfEZEmZiV/pLuznbHlj9KDs4kup1cxnQozGp5DzPjRF86RxJbpDqIOTq/CPaev1qy2kU4CtqbmTy/ipf8A0XjqGhnojgTSBqY9796CuikMJkmRh4JjejIpMNkj5c6EuohcTBjuw5D9TVpdEYXexRcrrn0JbAMBq05/CD1x+lVSySpIlvGVMhxluZHrxpr92+5wtIArXDHctk7/AFoS2tGMjuRpnl5lV3Udf4qXHejojPROOyhjjV5y8jodR697z8/lUbsCK0ZuwYzMAcjb3ftRixFEIRNCjYuRgt5DyqqKFHnR7lstnKJzCnpnxNHvQvL2ILXhs9xM0t0MJzCYzhfPoB86ZXM1rCrRxhZCAMxxjOfaf1o+9WQkJGj9mpyXIyfd50luYLjt9cIKL/b3ggx12559taq0h1LkL7uW+Gf/ACEiL+Adnsc0NFC0jFpZJGOebdPYBRtykzIcW88rsukkS9OgU9fb0r1rFHFAwkt2HLU0hLEe2g0UUidtG8aB0uZjEfxdpgj60NfyWzRv2jh1U45fn5+dUJHJFKTDPmLJ0aV5e7xqt+F3FzP3XCyHlltIPuP5UKs2uxV93tJpsW34z/amxzVN2kkOAihseA5e0VoT9nhbIryjsph/er6gfaPCgRb9tdCGWaPA5PnBzTAdMUw3zv3Xi8sj186KDFl1cj8Dn60fd28VuVVNLPz2PP3fpQTSBz+DT5c/Q/Kg9nleX4sa5RRHHl7hUGOOu2PXurzHAxke/wBfOqi2+/PPvz+hrHl0Tzt69e+vat/H3VSWxgjz5evlUkYEHbp691MaiwHby9esVW24wa9kb9K4Cc7eNYCIELnPQV4Hbbn5evlXTjyxjn66VWTj3+Pr50QnS3T1/FQ1b7nBHj6+deLFt8c6gz4IPuomLu02543qsydNhtVLtkDfAI38KiSfj5+t61GstaXPX1661Evk46Z6+udUB9+ePZ6+VeJ7uPLHryo0ay3UM8xnz9fKo6sDIH8VUSB5+ZNc1efI+vfRoI+Vs/6gelTGM77ioAbeyrANzuefj63rkETOHffr69ZqWnLZ393rnXdOVGOXl6+Vdx3emPPlj6UbGsioBGAdvIdKmAQOuPXrNd04O+fX614DPTfy9fKg2JZw/i6/lXc+Xy9fCp4x66V7A8NvM+vjS2ayHMeVSFSIO/Pn7N/rXCNvL2evhWs1nUz5+757fpVq7j9B65VWOW/z9fOpg8zjfPz/AENFGslkeWPXy866Nz1z4+uv51AH2+6pFuYznb166UyGs43L1691R8yf4r2okk4Pr1zroG+d/X60QFbKfA868p2+nr5VYV26cseX8VDHvPn9f1oMBNT7h5V4nJ9evfXOQ8fb6/mvDn69e6hYESB39evrRljF2s2CRpAz7vpQ0cZbpt6xTmKzNta632ZgV9vrxopnZ4mGU8iKZZDLb612ZCFY+PnVltdiR0KYzgZzt3vrS8TlO2hGWXmCPb62qdraM/fXUM94eG3OpN7Pqo40kMLi1y8Fwq4IkxnT+HpRfDpXW9IKkBlGx6ePuq8qZETlp2O/UeutWy2ub2ExgEoSTjz/AGJpkmuiMpJqmM4p9UqY8CaDgy/E7oAfgYAE9MjNd+8RRzuq94xrvj5VdbqqOwCglt2bxx41dM5araFssQmuZJMMIIVKqDtnzHl+1N7RzpXVkEbYqTQgqGCgsTsPGl8d4BxAwA5wDlhsAfCh/VjXzjQ2lPaDQdlPPzpTewu0mtABFp04A5DpgUxjPaYB/Dy5865doexLgADOQW+VNJWicHxlQNwmDsGKknUTk55486Zzsxzgnljfp4n20vtX7MBnJZvZiiMuVPaOApOwzufGtF6oXIrlbFU6Ga4VWzoH9ijz6+HsqNm5WdgwOfIfAez50XxCdbSJVjQiRwcKvP25/WgbJJyC8i9mM59p/U0lVItF3EbpJoGtyMk7D2dfZ51baplDJuNW+W6f7qCDu0ywRRd0jMsp5ewUVc4Nqy6gEx15H9qtfshJXorllW5kAV8Ivh19eFS3jRuyYKMbuaEso9TkkaRzGKPngyozqP8AtFJF3seSUXxFUJkeV9DPLvjLt+E+HlTABlcHC8t25b+X0qqLAkCdkEjA2A5VOaVFYDLbn8QXUPL+aKRpMrRca2BVgf7jn9fyqhLJHkYupZiNye8asliYOuQ7BB+J2ycjr5GurKQjA6gB1Lafbj6VvYy6ISQW0al3LAfhAc7A/EChJJoLSFpezSFRnBI5+wD8q9LJMX7tizqf7tQbHwzQl4s9xIu9xBg7qGwPy+dBsaKFd5cxXcgYPy5AMMn3eFRi4Va30eqWWRcYYZOkg+Jptc2MrWf9krA9O6w8d+vspa8NxHZF5rbTz/C2+nrt+lBaZW7WgG7N5aM0ELzSJj+9Q2Pf4/nQMMEMsrfe2eNhuEKAg+zNPLeJRbMEjyeYIbO3TO9IuJrMkxfSZEUguo2I9eNMa9HJIFTU0cutRvpJ9fGrQ0EsOdR1fixnB/mupbW15AslrMNZ2aKTbB8vpUl4YAmmdGVSM6huP4pf+ksitC58asA593x/iqGfPl89v1H5UXc27W5Ckg5/uDZoI8/P4b/X86KPn8sXGVNESxGcZ8fX1qavjbr19tVk4Pt6gevhUA2Bjb1+lMSsI305Jx7vXwqOvC8tuo9fnUVkOSD+fw/mvczsfZt6+FAB4sud84z699RJ8/LaoEb9D51BlwfrWRrJlgBt18vW1VOc56e/9a6Sff7d6g34fl6+lOjWQBJPM1HPt5VPGF5fL1tUGTDZojI9nI2Hr11rhLZ/evDIO3wFebfp0rGoizH35qIkwu+nFeIznu/T+POoFTnYtz9e+igGmB22Bzn2ejUl5eXh5VEfhyQK6OfT4+vjXEhS4c99z459fGugY/Dmq1znw9nr5VJT5A+3l/FExYBnAx7/AC9dKmN+p95z69tQHdOfjk+vjUl2ION87Y29GkYp056+vXjXQM/t8/4r2M49evZUwu3IH3+vjSmPDkeWMe7+PyrhTb96mFJz45+dSCbDbxO3r5VrDoqEZ5DOfXrFcCHAPTy8PL6USFwMEfHw+le0tvnn5+P186awA+Nj4dfD+POvY38fb41cYz68fXxqOjHnRTNZALnl8vXyqQGB5fpXcfH16Bruknx9frT8hkyJXHtzz5H151HR6G3r2VesDE7D9fXsptacI+8RZO2ocufr20rdlceGWToTR2rscKCdvlTKHgkzt+Hpjf186e2drBZoupcup3J+X81OTiUSuY0/FjbA+NZJez0sH/j9XIHjsLe0iXtO8VOc49b/AJ0PNcRyqQ5xpBwB+XsrvELh3jCDAZhnl68aW8LtjedsJMgjfBPwoOXo9fFgjCNonw6yjm4n2OCf6e7dOf7/ACrUJZxW0KkbBht5nes1wiZjx2aJS2oQZH/uPP8A7a1UmPu6/wC0bDpyqkUuNsXNKXKjPJMDfQxQaljjwmB4DnTlJFjZjgKSME0saAwydtnOOePOpzRtJpXWccyRzz4VLkx3BMMtAqhnKgtI2SfLpRelD3VBHUnxoBZFj2YA7bAcjRmpXjyTg45U6eiU47sruL9bbnJg4wM9PrSl4QLqOVGXURuz81HTSo/OuvwWK4neQ3UhY/8Ab5+2iYrCMR9j2rghdORzFFW9BSjEOt7lGQCNtYXbOavuT2sSqSvPcgcvZ9KTWiRWs4tw5KgHG2RTZyFjBBA6Z9fnVFdE5RSlaKoXQ3GAQxHhv/NMlVAdR7zAbEjlSUzLDKJHKhm/CBtn2CmsDs4GCBnqfzo436Fyx9gt86RR9rMhLE4VEGon2/ShVf8ApmSc6WI/DjZR4Dxo+8bEbMmlT/cxOAPf09tJe0TtFy3aSEHHgW9o5e2mlRobQ2ttJEgDAoAN85J8vZXLuAzyKXUsF2UBvnXeG5EYJVC3XSMfKiboqhHTVsRj5+daStC3UjlpCAMgY28MVdcL/TwoPmPEeZoOMsrZaQ+X71c8ihf+py6k0INJAknysF0Kk7uGPg2cEZoC6l1SqxhaRs43bA9w8asnEb5xI7P/ALfniq4QkcZLKiEDcKdZPt+tG/wol7K5Zo8qHkZlXmFQbDyHh5VcLuNYwgmcKNtP4vXt6VGO4EoISJdWQNTsNXs25VSbMNKSxJUHkxBGeuwx+9azUEpOMuBlH8VYZ9/garMrAZR1bqAyn3jI/KgruG7JDdlpjU93sdy3kBvt+VVz3EscJJjMYJ21nDL4DBH/AHUvQaD24hM0RA0tvsyvnHt8vOll9dztausyhAvQDI8jj9aoteHpdP3rfJO/aIQj/I4z+dHzcLkaNVjc3CLyQ7Hz2P5VthVICivjJGEikhMi+I7N/bg9aDt5kkmZ7mPUgbSTpzjPQ+VXcT4cGiDRJ2UnNkc5B8x62oWwhuHEvbIrFRuy7Hy1fWsOmRaGO1u5Ee3HZOe667hais72Mja5v6ernn6143PZTaXV1cZABHx99Qjt7a7Ur2gQnkp5fxQ/6BnplS5h7SLdSDuv0/Sk0qMjaTt9P1FNJLJrfWquo0nffn68aVyai52/u556/X86yPK86Frl7KSCCTUBz2+no/nUzqxsMez18q5z8CP0pjyURJ37vr14V3lvt5+H8VIrg4PXn6/WvAYGRnn78/WsEjjO56VHp1znG3r5VPA/t5cvd66VwplTk+eDvWMVYxj6dK9p272+POrCDkk+jXmHe5593remCinGGA5EV5hhtvy9fCrjHleQx8v4qJTxPnz69K1oogfSCTtt511hy2BI8fXOrSu+1QljJA3Pu3o2YHIxVZI5fxir9OdyB7PXSvMp3HP20bFZoFB6g5+efrXtP7eyrQvXbH6fSvAbnb5+t64hWiIXIOfXv/WrEBBzvnPzqSrvy9euldC4HTTj5UQHiVJ5KPZ8/wCK90/fNc055gevXOpadxyzn176VgOgb58/H18auUbAdeXn/PlVSry9evZVwXA6evXOkMTUAjpjHu/irFUnp8T6+NdjX4/A/wA0THDn2es/xWoKi2UqmOm/r51LTsMfL18qL7HI93Xw+lQeLxHtz+v1rBcWgUrjOcaf0qDR9Mb+vWaK0EDGOXxz9agY874HhitZOnYKE3GBvv6/aiobbUwyMD5Y+lFQWZK62Hd26/D+aJ7QRZQIWIGoDrmmVno+N4M8m2St7JCy5OlhjY8/XnTX/wDbwkxDOMkgczQuteyYt+NdwQOXrwq5HzFqyCp04PkelOtHrY8EcfQt4rcNAYmXJV2WP4mgeKK1ncpJHh9snPLFE8RBub2GAtlRKrfA+t6jek3VzdIFJWNNOw5tilatHdB01ZLhlwb+FmbkAASef80wNoLRSsS4Dx8wOXLalPB4fuFncd0hQof2g09tLlL+1TS+ogc+pqiRObaeuhBYwdhxSWcZPaKFznwPL2b09upTHa6mO472PDfaqZ7TsdZQddj4Hwoe/kJ4Y2M9o4XBFJuthdSaZTdX8hg1JozjOfz2r1hxFZlC6DgjbAOKHLQzWZQOAVXBfmT68at4Wn3aQkHC5zuN8/Wh7KUuL0FmZozj7qxUtjcbUclwpjAaMjPVahcduyh49BbGMAb/AAq1Yn0KxDbfixT0yMpJrYC7GO5yDpU8yen7VXPxGAXQhMZ1sMqwOM1bcqJ42k15VT3vP140FKLCa37GZoyxOVzzPs8K0dSM6asou7ia0lEvaFmdsaV5DzPn8qd2MsdwiOcFiPn+lAzcNs7i2CyK7YXukNg491WcNEETGGMNpXbBfV69tVVpitpx0EXUiq+VEYJIwSM5Hh7KKilYYDNjlVU0JZlPZsQDnvNj0a7JgoCCpGOimlapg01QXJJGU3JyeuP08aCMpbZAq42OjvHHn9KMQgw5KqRjrvQwyshVYwif7e5v51VE0iPD5Jo7h0f/AKDAENrOR5cqYzSRLt3dQxsTjf11oGJmS5UFgEz1xz8vOiZoYLiEpMNSDlgfLzFOJJbspZ3eTvMcDfA2qOBKQcDA6Zz6FUTuIFYJAzIvgcHyr0UpZDkE77ZGk/LrUlHZT0eaFPvXeTl4Ntn9D51ZmMqO4VBO2MLv+fuoN724sEJ1MxbJwQNqjBeGdNcyYbbKjOGHj+9UVIDtjN4VjjxCqsCPwl/W2/KqVfsY2WZotv7Qv9vn5edDqjKSy9pqH4SD++9WG6knl7KR1wvUd0g+/wDLlTUmLs4IlCM0UWA3exqK/wAGqFijMJIXub7nvevZVN7f3NmgERMbDfUwDI3t25UAOKXSyB5m0h/7wDp97Db30jpDKxpJpjgDRPo8QjbMPz+lKf8AO5reQwvIG35sc48iRjbwNMTZRXCa45QpbY4Hdz+WaUX/AAeZGLxwylWG/ZEEjxIHh5VtsKobfeLW8hHbSgs39hYbnxHgaTyR3EVzojV1P4hjfI8R/wAaDtriSymCTQpKNypIK/n0pgbuCR0ZX0tsTHL136NS8aDdC+4aRptF1bkauT42YeBrj2zfdysY1b9TgqfrTjiMy9mJNJ0DbOORpdlJI3bvLIv4SpzkeylGbtUAySSdloKHtFz2bkb+YpcmmRWOkow5jn/IrQ2Z7RSk0YLg/iHhQXEbYJOxMekk8+W/1rWcHktqFS2hSU72wGOeT6+dc074wRj18aJ0csfL6fpXDHtjxrWeJ70UaRt8vb66VwrnrRAgY+vh/NdaBgM7+VazAuCNsfHr68a4QSNuZ8NjV+jbHP2evlXAupc8h57j150Uwg+nbyx09fKuqvw8/Xzq4xfp69vnXewOnJ50bMlfRSFJHr1mokDoMDflV7RlRyO/OqCM5PWsN0VPsMdPHntUWwR+eatcZbz8Bt6NQ053A6bYFFGsq097ODv09daiwwR0B8PD6VeELHJHT5V3sTqIOdzpprQLHwTK+fX21YiLttt7KmIx4jHTw/irdGP3+v61wWAq0d3mK9pOdwefv/mrtI59fZ19dK4EGOYx8Rj6VrBZTpxgYHw+P8V4DJ9esVcV33Pz9fGoac+32dfXxomJY2+Hr966BjY+v3rg5j169lSA1EDbHny/itQ1F8IBO3LHhRqkY8ff8P5rlvwy8lAdIWK+Zx7Pf50YnCr7mbZj/wCkavkPyp/in+HRDG12VAYPUtn2HP1/OvDvHugeWP0H6VNoZV7rRsu39y+tvyoyysWlIJHXOG/X60nxtuiixOboCjs3Y/hGMZ35Y9fCi4eF4JD4BOPb686drarGpz4bVOJI9bM7DOnAFVjh3s6oeLCO3sVSQjRp048seFAyJ2cqyKo1cl8Nv0p1JFoiLjDyHOPAeFIuJLNDGmBkB8+ZozjR6eF+kUmbTP2L/hbxNXffQuq2j5h+nPfl76Q3d4UuI3PMSac429v57VfwwO/ELiXYplSu/LH6VJb0dMoJbGHaCO+Rzjblt1zv/FTuphauXQbTNlttqjctFJM6NthQVaqrdHuoyWLFUYLjH4vGmX4I/wBHE0GpGUA4KYP6Up+zrlb+aInTpOw8fGnZmjZR+EDbbyG3wrOTSrw7iYuHyqsx3Pt6/XzqjjTTJxdxaNTfd2MkDI8BWes7z79dSW5U6V/EDTQ3aX9qWibOrIyOY2/Okn2ZxbyXUkmnOSQR4VmrYceoO+wmXhgtEZ1PfxnB8etE8MgmNqXZAWblXm4rbPcrEWEjNgaBv8/CmgnRI+8wjHiTjTSqKvRpZJcaYrhtrsXiM6voUnukZx4b06bWCGTJ23WgZ+L21tqLznT0xv8AKom7ilj1R3BUhc4PPHs8POqxUSU3KXaIB9ZkGXhlBwcjHt/ikvFUtp40nEidqhyRnZseudMpZFubVmV28iDv7Njz86TTuq3DoTrJYb5xvvnYim4oCdDS2uhNCjQaJEbZg0o94PMZ86lYFVvZGJZWboR+R5e6k1r2kKmTQj7E6lcagvX/ANQptb6mCtJlkYZD6cEHpQdaG/R6VDjIwdti3LFTA/pld+fPJ/Ol1vfBZuxckFTjB54p0ume31JgnHQfHanSUiUm4g0JbJyRkNtjxquYAtqVtwNgF/cVegeNsuikEZyN/QrpUM5KkZHMH186yWgctgE8CSJ+KQFQCQRtj217712M4XGpDjOeQNHOwUBNQLHltjB8aElkaSEAlHVdmKjl40/H8NdknuBIM4RRnTtjn4ftVJlcxiJ1Rh/qHh9KrliInzswHP2dPdvzrz9np7MoWLNg6Rnf6/nSpWwvSK+80470ak8ldh7Oo+YrpMJbRNFCUJyjxE5/auG1XVG6yFWx3QV9ZHlVNyFMn/mQixscCVRjs2/3DqD8qtw0JyPBJEZXGkREaQxDKfZzwffVilh/TmbKPtqbvAj2/rQ0aSWUzB3Ywt0DZGB62aiZLuK0QOSSjEKW/DhvAjkG+RqdNjXRZY2pjZsq65Oz/iB8Dn61644fb3ClWRIpRt2kZ0/Ll7qU3d/lf/Iyskn4hp7yEean+32bihxxK6nhKSoHX+2SJt9vHPOi4xQqcj01vccHkBz2kbHOQ2CR+tEw3UV5HoupV1asxSo2k58M+NVW3Fw8YhkRpYydO43Vh4jofzqNxbwpJqijAV+eg/3eG9THL7odujxlkkddiuAHU9G9c6AWCCQ4fvOMjtEGx9q/pVUkFyJFy+E5JKp3U+zw8q8ksgmeHiSR61wO3Xu6gf8AV9aKWgWHgqYRpljPd0nO4K1nL6DspS8DbdVB+Hvpw4e1mLSASRA8xscUr4nCsTia3fMbbgDkR+3UUtew2D23E5UOmQZYdeR/nyo08Tju172dh7fQpUV1L2mMIT3vLyP1ppaWEMkbOjd7+5ScGknRPLfB+yoqOnLGfd9POoquW3559e/86JKacDGceHj9fKrLeHLDljHPy6+6pWfPS/tolbWpcju/D18qN+4hk/D092Pp+VM7K2DLy39egaZ/ccLspz5c/wCfzpGy0IaMPd8PaNs+HPf18aCEZzy3/Wtnf2gC4x8Pn+4rPS22JDsAPPl/FFTElGmDRW2r2ezPr2UYlmGXkCuPb69tWW6adj8zg+W/600hi1KPHPh19nj5UHkL4oIUyWowcjfO/Tf60tuLJU7y/IevhWmkgXTyzt7Rj6UDPCpU7befy/Y0FkDkiqM8LYN5j9KmtqOo9uT6+NMktsuR+3o/nRAthtp3PkM/L9Kf5DkYp+64/tP65+tRez1AYHy6eulOmgXG2MY+X6ipC2G3PmNuvx8fA0PkCkdEOD79x1z9amIfH17v0o1YMdO7y23GPp+VeMe2Ovn6+dcvM1C8oB+/r51zSR4/l6NFOnxz6/iqSAOXr18qaxSrSDgeXQevhUNO/l8fQqwnr69edQ/uHt8MejTJjR7L/uyKgMkqJnox39edH2FnbPfRAz5OoHSF60o4lCfvTkA8gwx4Y9bUZwkvE6u51EY5+Fd8ccYtWe1Dw8fHl7HtxFNK7d/CjljkB5eXlQws5RJqV3HTn+v605RAz5DZVu9jOPRqbW+OnTHL416qSaEWtCr79e2v/wBZ3xzDb7+vjR1nxaC7j0jEUvQqu3woHia4iJHLzG3l7vyrI3M01nN20TlSDnc7e/60rxp+h1RteKG8t7cspJyMqw3UjqazU1/fBlYMcf3Dw9eNM/s99rYbhhZ3rDEhC6ugY+PhR3GOCwGN54AVLpsByrzvJ8dw2jqwZ6fGSF9tfz6Rlj4AePrwqV7dExl3jMiKCSBvkVVaKJIOyfusuF3Hr400WF2tWGO9yx69GuPZ0uSTujGcQdSrEg4Dl9J9v786JiuhYy2Y7Mr2j77/AC9tM5ODpeyGXDDK4AA2x5/Sks5eSaHu/wBKN5EbPXB/KjFFXNNUMr2RFjZ0YaW7vs8f4oq0U2n2cgkkfLHv5I6N+lA3cYThrYDDWwLBv7T7ffzpzEEm4UiOABpwp5dMfHyqkY9k5PSFXE57i3WJkfZhhiT13/b21OADi1u/bZVR+Hbnlef7VZLbNccORWKlwMKPEDn7vyrnBR/Uuojk4xgfl/NGKt0Z/wBbO8FjFraPbvIO7nbfl9KV/fEccTFt3CrBFY9DyFEyxva8fdFYnVFqbfl5e2g+BKpW9dth2urV0OPzGaavQqfbJ2dr/lkP3lh2l03/ANRj+A+AHjRVnHc8SZTLN3M52PralfFb2QBtbIi8o8Np1HHvyKbcFilXh6EIhZh3tROSfPalcG5UNzqN+x5HY2cI15B8STnNWvHbIraIwjdFGFrO8RvVgZIO9IJTnATYez6UJLgqig3KtjkGJ+JJqsYrqjnk33Y+ttEbd1NIJI0shOPKlHGQIblJXdexdhjJyOXQ9Kt4fN93YRPJKNX/ANOV9Xsx4Hzqy8aK5DRNCW/uaMbFvZ5+VdGLHd2SnOgJLFY07a3f+p46tmHn9accOL6VDjQCN0I2z5Y/Kk9rbG3DGzlk0IcvBJ+JR4jPMeVN0a3A1JGVXOxztWeL8CshffwacS470Z3OCe79KacNmDIAmdtsZzj3/rQ5idoCdWo5xt651y3zBcbHunyqHHjMdvlGhzKGkTAcK3MZ29goNHEjMrqquux33opizR6iRyzkeH0paC0lwe0CN/uXun34/OruNkYMuLOswV1GByJOf5FRJEb6mUjU+x5YO2Afr4VKQ60aLvCTGVPLJ+teiKznTpOplLBehI9cqZRM5FMmpYQWGTg9z8J2zy+lQhNwIMPkherf6fpTRrIyWtu+klUPePUbbfnXOIpFbWZdGOV30j/d0qscTqyTyp6FlxMkS9gT2oxrGsgkD1yPlS+WZIWeLJMcg3BPI9PYfKld5dSxTPI8qgRvpBK8snmPAeIomeBEhjeSUYP4HHeGnwPXHnWataGjrsgb6V9aRxktGW0gfMeYNByzz3EKSwSRujIP6LnfzHny58xUJeNw20rJINgo3zvz5g/rQU/F4XbuaS+rUAV0gnx8j+dScb7KWddZ3BkhQaT3lORnPurkM87BwkmqQd7KD+4c/l0pZNxYCZlCCMP0zgD3eFBz32tzMhIkxltJ/FScfwJoEuY7hHnZ1inDY1ae6w/3URFduIGKMCpGZIn73wPT218+PErz73qJIj1aSRt8asi4rxK1u8J3W5hlG2fHHUeVbi2E333lJEcLIS67hc7nw99eGniJ0A5cR5DLyby/asl/mE00zyx9wqMMo5D2eVO+ATM8hdeeoMd6WjDWC7QpLbTgALGOe4xy+H5Utvomt7N5yusRODIB1U7aq5xRtHEGdVY6CEdeRxRPDo0khmR2JAhZfHVGRv8ADwpTCW3nEd2FchoJP7hTQQC2mUpqCsMr7P1FZbW1jdyWsoDwk5B56fBh5VquHx6oV7+uPwJ/D5eRqWTSJ5Z8Y7DhAHOrx/L6edFw2+ls43zXYVAIH5eufl1o6KMZAwPX6eXSuY8VxuVh3Dhgr8dh6+FPQiiPpjHy+n5UntmCd7bxyfl/NMRcBF5n9f5pZHRjVIC4jHscqc7dfXxrL3UY1ZH4s9Nt/XStFfT6vXr3is/db55H27j+POgSyFEexGPl9PzFHQTaRzHLx29efSl4JBPj7fXxqYkI5bH55+vlWYsZ0MZZc79SfYc/X86EmYaTt8B6+FUdqxXbGMZ8v4/Kou5O36/r+tKkF5OROMqT0xj2+h+VW7e7zP69PbQAkKN1zn2b/X86vSbO429m/oeVPRIL2yPHPIj1v+ddJUAAfL5/uKCaU6huP2+n5VMzd3fPnn1z861GQ9k7pwc8/f8Az+dUO3n7MfT8xV8yHAyMD9Pp+VCSKQSSCfLPw3/WueJRxK5G7pJ5c/XlQrvzG+f1+tTlYj49OfryoQt3T+vL+KokTaJF99vbsPXwrmvOOfxz6FV6seJ9/wAP5rhPT1/P50aFQVIXlte0U96LAbHMj11qdjPhgxyy599U2s7QSq4GehXx9eFF3Ft2SfebZc20m4B5L5Z8K7sb5x/09nwfIUo8Jdo0ljdxXS9ih/qRjUD4j10pvC6TJpfHLr6+dY3gmtZGud+fU/n9a08jF2EsewYZAHn65V6GDJqmNmh9tF9xwqSeJgFfPkPW9fOftDY3fD7pYpItcThjkLjl0H0r6HBfSxrpZDp8NWQB5eVA8dsBxq0aJ3Ck9c/n9a7ouL6Ixck9mJ+x11a2vGGiubIGF9h2g1ACvp11bqbAmNiYz3kzzHl9KwNxwCSCNpYmdbhSMjlr9nn8jWu4HxE3/BtIVxp2XWmn5fpSeRjTxtBUvumjP9m6MVAywJz5+PvplbSkxquPKrBw8KzF21HG9G21qoBOnvE5x6618/wbZ6UpxoqGWhygzz5+vnWKmaSz4pLDMiFWIcDV/u5+2voEduoBxyxt5ViPtpbIJYpFUkx5ZiNsnG3up+H6DHNXR7i8oLvHjJlj1JgeHOrre87Th1ujYEqx97NILjihveHxOrES6+ydCwyDjrVTSzQRxMRIkisGYePLpQ4tWXtUkaCxu2ls0jcEuh0n+fZ8aYWESw3Uj8tttufrwpBbTi34miqf6Td04HPb8qeLeQkSnUO01bhunl7POjC+wTfpCu5V7r7QdmFHZLGSX/1Z8fEflRHDbVbSxkjZCNbkkkcqDjutPFC+sBCMszDbn0+FOJNJspCjAxhe8wP6daKt7A2loyfGgl1xS2Ts5GOrGAuAvnT651RcNXsZo4wdiV7x+A3FC8JslnuZbp5mCt3UkfcKPp59Kq4myNeqDZSLdxt/SlVvxDwbHo1eEHVsjKfpEbS6kZu7EzDkSy438cneqGN5LO8iPpkDBVBT8Pj76eRzSxQBpURScsTjb15UDaTKxIWSLVICxK75HT3VsScpCzaSLrCwKl7h2Ltjun1+VNXtGwJUPt2zjyPlV/DEQwPGwweu+/l/NXynseY7vVl2Oevv/OvTjCkcEp29CGVJI5GYjOnbfYjPLBoi3Oq0w+W1DmBnceXQ+XWinMU8bZALb4IG5Hs/MUohlltWZZCDH/r5jH0/KlcKHUrGXD7xrd5lWPKI2GGdmBHMetqNmmh0E5xg5ydiB0P70uSN5gLiLKyqNEi52bwb8t6NaNJbcTIxBXwG6dNx+lTlitjrJ7CrS9CSNHqxv12qFxcMsbd7LL3sxjcjrt+lZxLqe3unt7lQVH4G6Y8iOY/Kj24ijtGJdR//ANi8/wD3fWhCNqmaTp2hn96SWEvG4zzUn9c9PPpVcN2JrqAK5XUA2/MNy3+GxpWIZ7Z3eGZHjPeUgaW88j9etR4bdB75Sv40cFlI/tzg48R5U6jsVvR9EspEkVk25aW264399ZTi1xNHxFon30jTpG4ZTyPs/KmXB7vLyxs/fCjTnw6fLrSL7SXizNJKh0zx90527x/Wryj9SEX9gNtMspZlDps6+JHh+9cm4bBKrwxTaEl7ykNgZ6/+k56UiF9dWnG1y2LV2Lqf9rADH/yB2o7tZYr54JnUpoZgFOe7jc+zOK5nE60xXe8JmY74LrqSQdD7vPqK5bcIDW+k6Sy472d1PgfEflT1bkTlZEXSJOzVw/XVyJ+W9QkhmFyy4BRvwuOef7c+edqhKLRRSTFg4NHOoFyrKQcbjHxPj59aWcS+zscIUDqe6R0PrpWzjhka37R0IIG6+A6j9qS8UlaEO9xsgHdAOfj5edJv0FmF4tamGJUAyzHSMb7VfZ2JjjQykP3SRr5ir5I/vU5nmyAD3FHj4+udNLaJJLJJRtqc4I/tVev5/CqdIXspHDxHrY8tOomrODTmzuUddxq0+vpTC/mhit2VSMyKpz7vW1JLeRkkKnGpipUZ8/W9Ssfsc/aAluJpLDjE0XLzX9KG4bfFlkeIDVv3S3LxHwqNwZJOKxgn8MmBQ0SDh/2iVv8A+PLkMANvd5VN7D0Tlt4r4BwNMitgY8PD209s4VgjRUGwG22dv1oO2tkiZzjIVu6ehHSjEk0HB8epx6PnXNJ2eV5ee5cUMEbHMD3+uXn0oyNyTnr88+utK45s9d8+/P1ohJsKeXL17qlRypjWOUjGD7/2/SrDc4TGRy39n0/KlIn8/bn1866ZyepHn1z9fzoMflQTNLkkePn6+NAuM8858tj7qkJQ3L5evlUsA+Xz2+lKTk7B1h6fkPXvFRMBIwMYPw/jzozSAfPlz9fGrYk1N4+71v5ULEBEtiyjnnPr30bHw/CA48uXx/iiYYF1+Xyx9Pypk0C9ln1686RzovghZmLqyBJwoHlz9D8qBaFowc7jzPr41pp4Bucb8/Df6/nSqdRrOAceQ/IfpTxmDNChYqsXA8/n9fzqx4u6N8evW1XBFDDwx7sfT8q5qy243z1+X7GnshRqpF1L1z588/Wls64O3Ly8PZ+Yph2i6NgCMZ8sfT8qW3MnfPt6/X9a5oHoOuIBOBncZ6evLzoJ9+Wf1z6+NFTvk7AA/r66UI+2+2Me3arI5MhWBuMDln1+1e0kHrjbrn1+lWY6HHx9e41wkHfrz5Y3+tMSPAf6hn3+vjT7gt4FSS0mGYpdsN62NIV88eWPXyplwyNXnGQu3v8Ad7PPpVMM3GaorgTc1Q2jtFt7CVVJAxzHrl5UyspBJZIpyZY+63t6b/rQbSNojGfxS4IPX186tgkSOEiMZDMW8/h+ldnPiz3uNoYpGpzseeM9f5qp7Uzg6dSnoV/T6Vfbvq7zHAPQ0wRVMfT39fXjXp+PNezkzJgcPDWa1VnGQBtnvD+Kvs+FpbXEki7B/wAQ8/P60YshVMLkCvNN/T06RnkP1q8ssXaOdRkugWSDLHGPp+/lUI0CbjkPyqbyhF35c6GNzvgD215WTipaOqCk0XMuhyvQ1jPtlJDDZt2kX4s4J23PhWwaQSEHntjlWR+2lkl1w2bJIOnJxyA8/KpSL4u9nzvhcjCaW1ihDZUSRNnbV158xT27uVaG3XJLKN10bKuPy8KwiTvBexGORZlXcEMenSt9eyJcWNvcW3emiwzHbvA/k3PbrRlBpHQpbRFl1d4P/wBXHPmPlzqM9y8N12nYhUc7uhY6Tyol41iMKSZYFe0LYz3fAeX5VXcWzRRCVFzHjePp7zU0gtgE16GR5BcaJ4X2jP4cfStGslxcR2iHstMx/qtH3TjoD58qyXE7Sd3EowG1BiucasbmtEFukgsezc9qsfa7/wCpjj5DPwroxw9kZy9BfE5RZwwdk5MTHS+eeMZ+ODWbuL4Wt5apE/apjUngFAXPnzz8KLvLe5vLe4BJVh/0ieRC8vdgfKkcv2fnedT99ymrtNGBkat8fOtKV6NCNdjziXFZb22FqqIRKdLKW2x5+XnVvC7KbSr6VjRf/wCtdINLbSKGxxh5JpWyuAAD68qfGdra3iRolQYDaAc7efj+lW8XHbtkfInSpDm1ZrZck6kbkw+f8UUk6MNJbb40mt77tEA5jVuT6+Br0t12eEU8ySpz638q9Gkzz9pht/JGo7mz6txnY+uhpZNhl1a27TJDHk2etLJ7u4LuVB1R7FejDxH0rpu2dY+2yo6MTypVG3RW6RYt9LYFZFYlB1GSMeB8qKi+0EMyLLGwLPswJ6+39aS3fELa0kzJKdZ2WVOvt86xnFJzaTPLbOpR21MNGkZpmqAvsfSb2dnjS5t5O6eY6Z65/wBLfKhEv+zUS74UZ1jfHrrXzQ/a25AIE2Jf7gx2b31bw7jl5dy/dhM7NN3QDudVKlGxvtVH0ZPtTENL6FKIcP1GD+lVtxqNJDNDuFOWCnfHj+9MeHf4d2Y4eHv+0aaTmVPZncbjAOKPs/8ADvhduweKScjBXDNkacYI8xSyy44vYyxya0W8B4okvFP6cgKlSxx08/2pVxyGbiV9OY37KBt8g8x9KfW32bt+FxabQnUw0sztuaieFKQAwJYbc8E+ftqWTyYV9RseB3szcliwkjjHfKY0sTsAOp+OxpnEkUgiAALr3S2MFv8AV9MURcQJFGVw409cZPrxFDw8QifvawuARnG2Onu868+XkNs7ViVFsVvCVMci5jfSVzzXH774qwSTMXjQAIpCZK6vQ5e+idK3CnZSCR1652P716e7hsoXdyqgE7nY5+v500W5CS0VXUz2VnKZpDIy7sThSf3rB8S4h97lMzlVhGw6aqj9o/thFMzKNiF3AfY+vlWDPFpuJcTUf2puF6Z9v61aON9kuRsrm8ieFU5PJz0/2LV33kx24gVVCEBdznujp+9ZqzlYk5DPv33HIEnx9c6cRzf+UNwMhhlVAG/P1tSy0OmNJSJG1E50nffmcVTIqNfwOvdWMgbf92PpVUYLW6nA72/u+lX2MPa7tsVbJ3+Gak2EZIomuyRthtXiMc6qjU3NyySryOfZRUQMFzG24cDSQPPnUxCEmaXbJHT18q55sjnzKMS4Ds4wi9Kqzv65euldaQnbbbzyP4qovzzzz18frUTxsjt2XBvZ6/Tzq9JcePP30vMmCD8MVIS/l8qFCJ0HdqduufD5/wAVwzZJxjHr5flQolzn559fOuGTz9fWtQ3IOSTvDfHt9fOiY5eWCSc9Nj/NKVkAI9evZU/vGBufjuKXiaxuZAV6Y8h6+FXQygEcse3by93n0pJ97IU8/XrnXY70qRzpXA1mnjm73jv1238/P86M++ppxnHrfb9KyycQyOeBjpvt9PyqMt+dR73xb4fzSPGXxzof3F3HpOCDt7dv1H5Uqlk1ZzjOcbnG/t/WlzXe25P5H+fzquS7AXY4z4evlTRxME58guWfHm36/ofzqgS8j6x9PKgGus756fLp7qgbrB9/r+ausZFmsmv9IOM8/n6+NBSXGfXr4UI8obljGM+WPpVTP4+Wc+vnXKo0O8jLnkzz9ftXUk3wd6o6jx+Bz9a6WAzvt8sfSqJUTbsv0oTsce0fH+Kg6OuM9RzByMfqKq1HHwzn186msmBswBJ/C3In9DR0wWRDYb5/T+ae8DTXK7f6dj0P80mZBJ+AaXH9v5kfStB9nTELWTUwIJC4I2H7VbDj+50+N/7EXXz/AHcwFcnLZyPXyogKpmDocK34s/hOPOh76IuyKV3RwWGfDl/NW2UxlYgpIhz+Fl288VecLlR7sZUrGkA7wAGBnx3/AJpmmyjGfdQEYCgAgDarjLp5EkVeEuKIzXJhDzomQT3RQ1xxGNcDUOYHOl17O65G/r9az91cyvMhAB0nofH1vUZZ3eikcC7ZpJ78NqVWAOfH18K9FKCuQdudYq4vGt43ftFeQd4gvsF6e6mn2ckmunMs0uonGB4fvUm3JlOCjG0aNJ9MelyAccs+vjQl9ax3NrL2qqdYI3O58vbRbDTlwgbbAwPXwqqd0WEvLsdPLnt4eyrxi+mR5e0fB+J2z2fFiJnKRoxXAXz/ACra/ZhUfhcqMv8AUB0jwxjII8Rjr0oj7VcItb+NmcldtmJ5evGs99m5pra4jsw/aRxE9mEfI9eVdKhaA8tG2SMyoiuE7SDYezw9tSkiImaFlysinQp/tPUfUUEb8zjXbjJRmVwdu6MZ2+FXx8QjazNwW1iNQWOc4IHX60kcO6A8vtC+64WsN5DCqg9oO8dzkeB8qdCBUkRrmTs4xHhQDy7vreg4Lw3nFQxRTFoDq45g9R5H86nfTxT3JVYdbL3i5OACDy9mDVZw4KgQlzFfGOIyyxRWvDWysYX+o4I7wyGz54oa1g4jM/dtmeMMxwSVABPOndrZieRDJH2bINQ0nYj2++ncXDEZtbSSICNwR19tc1cmWb4oz1pwuG2LSurO+AWRRnvdN/1oTiAmvJDgaFPdxpwf5rY3NssFkRC79R3+Z9n0rPvJHEBpwcbeO30rtjKGGOzzM+f7ANlbPFAIs7fp66U3SCEQKHGXVgwNBrcJpGB3iMb+vnUnus4GOuffWl5sIx+pxzzWFSww97IwcjJPr51hvtFxcW/EGtohy/FjkK1xnZ1ZV3bSQPX6V8s4je9je3P3lTqfYE74rYckp7TL+P8Aa2wW9uWWFhFMcsMkA8vH3Uj++8RdGTvOhGnBGdvCn9h/l9x/VnmjwM93OneozXsCz9nw61Mq9GUbVZW2d3FJWZOSCYZLIV/Svpf+DX2Uk4tx8cVuAPulkchdiZHxsMeVZeeDiTRsZeHELjmcAY9tbr/D77R/5Lwa/tZdMFxrDqGbn5eVUjGic5a0fYOJM1zeW3DbEgM3fmbpHGPrTkW0UCaQQdsEnmaw/wBk+NQr9oJ5LqQF7mJSGPL2e2tncXEMikK67rnbzqGTFrSE5O6YvseGyTTPd3IKgsRGh9vP9qJubSMR6kA5ULa8etJh91mcRzR5BBOxHIH2VDifGbHhNuJLq7jjQnALsBk/WueXjNaSKrK27bFPFMJbuZBjA6evnXzLiV2lrNIVmILE+RPl+1G/af8AxIiuVeHhULzTNkBtGAPPz9lfNpIeMcZyWk7Uhe8qEDR7c0IeG7tl/wCUq0fRLP7aQ2kRi7VWHhq3Hu8PKlX2p+0t9cwRtbIoVx3XDYBrK2PDIeESxXd7xC1hkDZ0Oe0cj/0j861F5xnhdzbi3jhWdpBqSRF3Xr/djcV0wwRiQnm5GGTh17ezB7ojDN1cc6c2ViLIktDpUZDSDcn14U9ThEUlgt4H7NMd4HbfyHu5VCfhxEEZt3aSR86kcaQB0OeRqzhFqiam0K7q/UzQ21tCBDq3PQ/tTGRmKoqrqwe8T19eNJJbe6iP9e30MmcZGk+3ar4bq4iMelnKr+HB5Hrt41CXjf8A5GWb9NnEqMulOaxqN/8AVRdppiuVBG2xO3r4VmuHccTOieFwORcLyrRoyvGJEIZSBvnp66152aE4S2iebO1tBk8oaUsoG3w/iqWlJz+p9fGqsnV1z88/Wurk+WPL18K5WedLI5dky59bVAtk/QV44wBiqy3PfrQ9inSwGakoJ51HTlsD9/5q9E7nlQAuyA9Y9fKuZ1bjw938VKQY/f186ki9fWaIaorJ2GdsevRqppCPbnptV7ppG3rx/igJcnpz99FGLVlzyz5YHr4V5pCqjbP0+lQjGnGfHx9fGuSZz9Kxi5Z25ajnz55+tekuNwRvnw9fKg1fDEDlUpXzkj166UyiFFhu+mdv09fCqJbhgSCR4c/Xxod2wx73WqGYvgLnPl6+VUjEpEK+8kHn8fH61BrjGPAeXr4VAQhl1eA9e6hpg6NsTTJCs1wbJx1zvn1zru+AQfl6+FUhu9jp+lXLv5cufr4GuABINt5efr51LPPx5VHODXjjl7vGmoU5gHG++/r9qkUJHdBIx032+lVhvX5fzUtWMYzz8PW/50AnhrjIDBvHfbHv6e2n/ApmeVo9WnWOR/1ezx/OkUbuT3dz7Pjt+lHWb9nOr6GUjfI5Y9fCujBPjJFIS4ysbcQaUcXtl1gxzxMOWdRHrlTOxkPZZ0atK6WJ6+vGlN5exz8Rs1kR8JKAWHnyPtrSPAI3mi7+pxqH64/WvTWNSdo9VZKSsLidHjBCnAGdxyqEkkcSatseNejnituHkySjSo3LcsdPd+VZGfikvGYHjsZD2Oor2hBI28/1pZ4uMbKY2pSqwP7Rfam3tFeCLvy46bishFc8dvpWMEMipJ/c21a/h32QRbjtbti8mrrz/mtUlrbwwMoTCY2x65eVcsMV7Z1zyxx6Wz51YfZa9EgkvGZ0U7LjOfdTnhYe04osZbShPLpj6Vfx/wC1NtwqVrOLBlYYPl76R8JFxcyyX7ya3JGMdKEo09dg5uSt9H0ogtHpXIOxwfl/NLuIrIYG0EM46ZwT7POrba+V4cbZxzHr5UvmnV2IRiAu/iMfSu9Y7pnmyy8bFxj7dFLr3F/sYb+76UvFtBDN2sMUannsPW1G302Z20uSD4n9f1oUMdQ5nfp41weRnblxj6POyZpSZN2ihtnmkTvb78jn2+P51iLnjjpxD7vYo39Ugdzrnnt7+XlWu4tC01iiKcEnb14flVHB/sQkc33m8dGfIZQOS+0/rXfhlLiuTO3Arhs7YWYsrMIz74AkI5sx6AeHKmUFs8cauzZdsLIG/uOf0086fQ8Ct5Ih/UZEzqOB63oqLg8UWNALAnOSfKo5Zpvs74JJAq26QFGRHRlAYBTy23GPHy61Ke6it4Uka4VUJPfIK7Gi57WUBGLKNIJ8QayvE4m+9s7DKIO8T/b1qKe9FKTQyv7wPbjuKw6lX6e39aQTy93c4APXx+tZTif2yuI5CLK2XslPdfHP14Vnrril9xByZ3ZkJ/DnZR7KvLxsmV3J0jxsuGUpt+jb3HH+F2WO2vIs77KdR+VAv9tLEZENvPLg4BIC5+NZO3tVdnyjf7yBv8auHDj2mIkk05OosM74q8PAxpb2BePH2OJ/tlfA/wDl7MIT+Evkk+HKs/dpd8Xlae7xqfwAU59nSmyRJAcpL2ZICZDbnx/ijVs8qXMagju5ZhXVjxwhpIrGCh/UztvwG1xq7BWfP4mbI+FN7K1NuO8F7NenLI8c00PD0jhM0kyKi45HJH716MrEqvbQhmZMLJOdh7jVUrGcqL7UxyppdSRq2096l11Y8KNw5ELdqVJ7MLqAP+rGflXla9uJJF+8OkkY0ILXugnpnxqq+t7pbmf74jvcLjRKmT3vPodulNx/ROb9FMdggVTDdXSdkcqgfKr7geVTS6+0MIkSG/umiH9zk5Hxqt+G3CFMw3KupLMew0nz5/lUWtkkdofvMihEy/bEoCoO/nRUEujOd9l/bcUaZbqS/kE2CilHAz7R+lUcT4dfXsST3dz26YLAlu0Kp1OKfWkVtZ2uUhR0XK5J5r5E8/HalJLtaJKuywSypzxg/iHxANaUAKZnI7S0juewHayyagoDMEGSfjTC/wCC/aHszLCrJZ6gnZwjBLe3rv8AnVvEb7h0t8tzHbqzKgcOd9Rx58/2qEn2lub1oUxPCsS6pNDltajnkD86lOMr+o0ZL2I7b7PMbyS1E1vHdA40u+Svjyzyp3wvhfDuFzubgteTQt/Ty6iFumWHMgUH2Ul1xm5uTiKEzbDtNwG3UePvo+OzeUIkf3kiUHVINtRPNeeOQ99UUbQjkMYuMRxKsQSJgrtr7KFUA8MY5+2m/wDmSNbxysFIjckRxFcHxGnx5VhbmzltlRggS3c4VpG2yRyNcUYV2fsomBOlV3z4Y8R+9JLG+0Mp/o7vOKzixdrazCWeoFe23Ynkds7D6UtWaK8imcIdh3g+/wD3e6uWdzD95WN7NpGdSpxLurdCPA1yNks7lgiyKNXe/X5GlqX4No9bQwxFh98jRjglGzzPLfoa0HDJ5raLKsXjzuUGpfh+lZy+hfSJInjR410kMcZI2OPpQ0M8z3itMdJA/Gqcx4kj86V4+XYbPpdk8F43Z9pGkjcgTgHyxz+lXyQPHKYpI2Vv9w5++sKOJSiZEllGo8wT6wfzptb3Rkj0QzSiInvIrZA8wK4cniRf+CSwwl0P3Ax1zn35qAUFtvX7UEL9LaJRO7Swj/8AkacaR01fWmUCJP3oJBKCc91vhXBk8acDlnhlE8EAxjlRcaYU55+vnUFi36nzoqOPKkfOudiJbATEXfAB57Y9fKiktMJt4fL6VbbQ6pN+nj8v5pssAVcEHn7/AOfzoMek0Z6aEjZhv69ZoBocSbA+zkf5p/dQZOAPh8/4pTMMZ3+NaJJqgJhj2D16FDyMSpxy/SiphhSfz+v60KTnbfmenX61ZIIMc6tvj51aOW3yHr4VIRasYAx489vpU2j07HoPX80xkgKQePh7v4qmNQWOaOkTOfb86pCFSuNvYM+vZTxYyCYINQG23z/n86HurfGV2Hn6+YoyGXG3l08PXwqNw4ZTq559fzWbMwpfxnc/H1+9FRuCeW/rP8UtViG57eXrlRMMh9p9es1yUKFscezFe1bdfjv/AD51UC3UHnn151FdmA6evWKxqLSMtz+Xr4VwMNtidvHb+K8R3c+vL+aqJxgnx8PW9YwSsgzjJPv29edXLMVORz5+efrQK5Jz19esVeFJXy8en8VkEcWF1bG5jMx0knGQNj68K091c6oMxyAyRoFyT09da+fk48c+vn51pfs+U4k/ZPIUlXwP4h7P0r1fDz39GXhkvUj5F9s+Mfaa4vWgMkqJETiOPYOvifGtD/hv9onj4JcJctgwyh8HmoI3x8OVfQ/tL9l4ZI43a3LKp05xy/b8qyV/9mjwmzmmhMjdsNJDHIA9v6125FUWjvhTpoZQfaKe6mKq7MucAD1/FMuK31xHYhbYN2p6cyPXjWF4JL9xuB2jEvjSuWx3q2PCrAzwyPK+tpCSW5kD10rixY7dF8s1HZjU4bcXdw88glkd3wcn8JrWfcYrax7FXyQuCUzj+KZ/dILJI4UUBTsAevv/AF6URc8NRINR2LfGuuPjJI5J+U3Qrs73s7UYRlcDnqz8frV014qx9zSGO+3j4e2lxeK2DLGWYHw29eyh+2G+hAB/8tq48/kcVwicWbJylotMjO42+Hr5UTmKztzPNpJxsPXT8qA7Uhhq9evGh/tFcdnHGozh19e+ufxoKTcmDx8fOVMpt+NrxDjkMLjI16VB8fr519EtOFTNE2l0Cht8c/Z7a+G29/8A5fxqC4K6gjhsDkQP0r7HY/aSzura3vYZsxyKNQ1cm8DXqRx84nfKXxvQ/gs5CixJ3dR3PgKYmAR4XpyzSa540jWZmt5UVsAjvdaydx/ieLX+jNaNJcLlSsJGKn/FQXmcjfXRjVW19zbGc18u+1n2khdJuG2cXaJJlJZBnHsU0tv/ALX8V+0KlQPuVuc95jtj9RSZsWkAeJiyt3QzuAzHnsPCqY8Kjth5N6AouHcP7MmaaNHH/wBOSfJz7Fo+KysY1WfTBJEraSBqwT4DwPspceIYZRa2kQYd5pHOTn4/KpT3IEAH3iCCRt+42fjg8vZV+uhNhzizmeXTKyIpzpRwoGeQGd6ClaDVFEEOk82eRmb3fxQk9/NHGkcUxaIPuM88/wB3z5nepyhC1wqbGORJFBPg3eGffyprBRdGklsjsEwEbOt99QHn76Z28hvGFw6IHkIYBnGfDagLW0RpHDM2hkZu63LDZ9CvTzdio+7SLuxCDTq5Md6yWhW9j2Ne0tprlERZIzpYlenXAx8qB4jGkKJIJnBcBnjWXbB8ev50t/8AOSKyPedlCQWaJH06jzxz86pzFPcNLcq41Dsyw6Y8B7qEL/TSoJk1hsRxnTqOkBsPnwPnjrihJLy8tlPYzSBI17uk4APgSRud6ta20WqG5kWNWUlVL6s59h8vdVMbwK/cOtezLsGwBqyQDVifZXHxq9ZQ88ZcS6ge07yDwPU9DQtnbtNdNM6ErsoHaZxn/VVcVtDLFOG7RyG7qsce331WySW+tw4aMgBtPMew1lI3Gh9DxmSCdUMS3UyIcEqW07b4GfbRtleuq39qQjaityyD/T1/7cUrMMSWtvcrMCrKx7ME6gCBkeXTFd4dL2d72zupC5V1Y5Mi8jv7/lTMDBuMQR2l2k8JysYEffOokaR7htVUVqJrhHDL3X15kbdgcZwFPPzrQ8ftEl4W0eCfu8mlmOB3cZDYA8M7VmrB2kkMblWKr3HVcnl7tvyoAHMtrLGZjGixQySaUVu80gHMk9fcab8M4VNLwcXkpeTQrdqsbb6QRpPe6Zxy5c6De5t+IcNiS4MNvNDpSMy/3bk8xzHmfGo2vCeJXqyLDJgEd4a9CgdORphAW9MJ7JZV0qy9xGbIVyd9QpfPw95IYUiUS6dQBVQvkCu2eXQ1aZZRfiCSGEtr0JIVbutn8Q+lHcT+/wAEK3MbIVQai0MeOzP4cZ99Bq0MnTFycLe1ukacf0HBRSTnDaevrpUmspG1yPHIECDMmTpJPgRtg9KohtGvAsz3Ou474CFiWUgjHxyaahL37msLPM9uUKrGSQAd9O3tyaEbrYZd6Kbiw+9cNR270gOXVRuHXY59o0t50onjSS4SNYZI0VcEM5+PPatJbydvaQyrKGkz2bLozhlGQfYV2NANotiwVFMMxYr3cnTzOTnbH1pNDKwJLRlKrcTdpERiNi+oDHzxRljFfW0rTiVXUsu2oMGX11pj/lSR23aTKjOFOlZPE+fjUk4jYWcjgxzMjpo7PZlz4g9KjNr0USoc2CWfEYmXX2E4OnBOx8VNC3nAL3hR+8WWp4/7olP4d98fSlqXPDzGGtO1AJGAf+XXlTqy4xKV7Ny0ihdOH7vuz4+dc7TRZNPTO2fHx+G5Ut01Y3Ht8RT6GZJEDxtqVuvrr51kL4QAm7tlAbV34yPxHxFesr9rZi8chEecPGelc2bxYz3HTI5MKfRtY3CyagR4+/10pgZwIwPL5VnbS8S5UyxPqC/iGd18M/WimvNLA6vr/NeZPG4umc1cexjMcpn2ev3pHdtpckb+zajnvlMXMe718qSXdzqJ5H5ijGIkqK5ZN+hA329fKqlAYHbp18PXWqHl1Ng9etWwtsd9886rWhCYJGy88+vfUnbfcn163FDyOAuFxnyqPaZ5n1661kgolKAdvEevd+VBlssent+X80WQzee/r30M40tqHPy+n6UyGLtWnuknP6/Wq5GLKoJwM9PXyqsZaTSBjb5V2ZGUnJI6b+vnRoR7GbR4yevntVls4DEY39esV2TSF2+QoeI5cgevXjXMZ6GTTp5Y+X8flVWvD7586pdSB150OzH5UezDJ3XQOnr1tVCnPn7+n0qlX1d07e/18aKgVWb39fWxrNDJWdVcj4Z39fGrwe5nkefh6NeCY5c849fSqu0IyvT5fxS0aUaJldS7A+vXKieFzS2d/BOoxoYZ35g1B8diBjp4+vjQ4LZwn4vHrVccuMk0L2faruCO6sGimQhGXfPSswOHferRoZBHPEv4GG2oeulMeFcegu+BQySyASaAr43GeRrPv9obX/xAeDf/AFWi7RdZ2YZ9b17soLI0z0MMpKFoEtPsrYfe1ZI4xIDnvZbAzv7vKtMlpbW0QVAORPfbTgch+xpK9/FbQtFhsFssdRGT4A/rQs3G8KRnn+E56+FVhiUULkm5MNii+9cWL6gUiPd0Z/F9fzrnF7nEJQREkbeXr8qosuIR2NiR/c4zgtn0PypPe3ySuwIyTse9jPv/AFpPIyLHj7ObI9gU80gJ7gTO/wCH9f1qvtXC/iPxwf5qTOAuVZx7D+n6VAYIycMPXyrwZO32TVA8k75HfPjsfXwobjNzHLw9WlkAkjGlV55Hr4VbeFIVBXdvA+vnSiQFpNUoJboPCvS8HxZv7votjXF2jPJw6+v5DrPZJzL538vfTizsxZ2D21s8ioc5Od/PHhRLzBUDSYAA7o5fAfpXreK8v3MUUZSML3i2fhXqVGC0XtyFKpIpKNNO5bGELk/t9KYW/DkTvSDtpQR/RQ7KOXeNMJ+GrZo0Ikj1N/uAI9vPH60Je8RtrC1aC1SOR/xSF1xnfGfH3eVQ5WUpLoIjhLu3by9oiDXpUbJ+9KeJcVhMEkSLEzb6cNk/THkK5acV+9zOrOQpU4VVwF6bCihwL7yzzpoMA3yV1OD4bZ33oOl2HvoSzKohSa3SZpioLK6gjxpfcqHbUswXvZxyKnzrXzfd7e2SxtJJXOS0sgJ68yT+lYvi0moqIgpZRpDeG/kK0XYJHYri4E7Sav8A4kg0/mtklMyq/wDWmRWB354yaSWtkSSsiB3de6VGynxpxeRTROlwiMcoAMEjJAxmqULYwUGCaeNk1SqjAeH4QefxpTc3dtF2bxIzyMjagdsNt9ad2faXUsc5DDtNnA/3Jg1nme4tSY1twhjYrk7nBGnnWiK2Dw3DSz41Y3yeXLHjWqg4XYPZLFc3Lx7Blkzp7vv2NZ5OGyoFlMQOFJKA7jwyKNm4fxOFLdVeSTbeMZZV9g5e6jszGd/DZWto8UMbXBl70JlJLqw5geRzWbZ5o7mN+xVE05xj8WdsU0tDcx3UciI4khXdwc46dfbVs/F3tdSG9a4f+/K6wM+GRj303QuwaC7uryzi4dbWQd1ctiNWGsEdT1r1/YXSX/3e9thbIAP6Zk07YzqOeZNG8O+1M0CSnhURVirBgF3Xf8WkdaOtp+HcRle6v7KRJ3GDL+FWI5nf8h40jlTMuhVZcOuZEuo4YtcMaEs/Lp0r1vA1vP2N5BHqjXtFRiPw+3wxWw4SsVrYyGCZTbykkhDup9tLPtBbJeSO0VoVYae0cg5YdB7fOjDJboElonNbpLbpFPLh5Iuyc7bsn4SfaM7+VZ7hfCI57h4O1CrGR32XdtW3xOxp8/dtra5Tfswr6QuxxsRj2Z2q+0aFGuH/AOjo2yeZH4l9o50/KhaYqu+AvBA/ZTRzNGT+NNOPIfSucPt7myXJzpxp0DGDnmD5Uzk4hOFaExRXBfG8j7N8/gaFmF9NG6fdoVQv1G//AMiTvRU0jOLei+3sbO6m17RSFml0l9WpsfpXb65mkiuo2UktltLLp1NjGfy2pfbJf2dypjCoh/04Pt6/KjrviyS5kvHhjOw0Lgkj3UssjXRo477FHZK8Kytbv2yqevIZ2x4imSzzQwzI9oHMiYYPIWOnz2+fSkM18/3h5IZZVPQh2FQjZdS3RuZQwbs2Qam38q3LkhnGmOG4Ybf+payB7e5ULIHJ1QSf2H2ct6XN/UuVR1CtjGccmHNf260Tw+7SwaTR2sxkITEqY1e7yr3F3juFluYnRtXMD/UMD0ak7seJY11qUlmYrgZUb/Dy/KqAsBZpChOpSp7RWX17aEZka1XWoC6sEg9a5GGMwSOecRrnu74I9dKTiU5HOzt0lPeZVH4SG04PjRcckkSLlgVbk2qgLlFwv9WVSP8ASpwce+r4ImeFnjYyAfiTSAeft50HGzXQxLxT6ezGqQD8I3z9aXszxSa4l1J/cP0/evRTOFbvAnpty+hrscxSNtaFhj30FEzl+l1jczRMLhNSqHxqUcj4Gn0lz20QnjyE5Nnp5+ysbNJLZ3Jy+uCTfSeR8j9aOs75TIXjkIHIoWqOfApqxJxUtD43JK4br4n18aHdmznln3VGNlkQY31eHr5VZIFCdSK83jxdM4WqbTBmOG22GcY/OrlYhRg/Squ63h69c6kn4geuaYU5KxJO9VpJjBzvmrGxqGBtjpVEhOTyxWRrCBPq5ez15VAtqbl570PHsxJ2PKrx3e/8MVqNbCrZVEnj6/P86rvsEYHI8qjAdUmzbY6eH0rt2QV6c8bn18aKQ/oYzyYYjOPfXraP+qD4+vQqb2jSrqVdvXrFSjXszhgARz9frXItI3xuuRfLHqXbGPlj6UPNb4TI55ojUfD16+NTYK0Xt9H+KFiCwL1xiiYm0gdPfmvIo3zivBADy69acybQTr1eBOPX81x1z7efvqKLhht5bevlUmAU52x8sfSlGuy0tpiAOwx6/igJ5yFOMBRzwfX7VbeT6V9nn6+NJ4VmeL7yjCSKVtXf27M+ePy611+Lg+Vux8UObGaXdz91Zba5CkMpAPLV5/Wk95dcQi4xHxFzai9hJAxq/Djly29lXFbeTUexjddegsNSr7aJazZJykkds5xghZCwwPFvDzr0seLh7OyHKMeN6Iv9pZJ43M85RgOSR5AHj+1W8Nngl/qLxJZSeaHZvZg/nS24tI7eYF9KKN9YOR8aFnSAQrJFJGdzkbbef7VeXNrToVx/DaC5zlY1yg6nn/NcHZqu/wCE9OlYWDjVzZN2speSJxpKauQztjY5/Smo+0YkujarCTIzYjx/d1/LFefk8bLklTdkZYZGjaUBCdh45+X80uub5kUiLSD/AKn2Gfr+dCNNI4JZ8Y8N8fvUQvaEBFcv1cjPwz0q2LwI49z2NjxfpUbm+lw8MJcsThj3aHll4wsZ0RW6vjmG3+dNTanPfzhRlsnOB9KF4gEljCQTOOYwyYPLx8a61OlSOjghbwpZH4h2vEE7WRSx0yMTk42394qxb6+1yp2rRrHLumy4X9K5EWt7yBGBUhdwN+efWKsv3Th84uCrGOQMsvmfOg5W9mootnle6e1ebTFMh0yHnknIPnuaJPB3u45XbDzLs68sttz8vA0LEsU4jAkPYqR2Uq8hn+1vDem0U0lsoEx1Sjk4ONvL6UG6MZ08MuBO2VYYOTjclfPFMba+ubUzHW8JVRjAyx8/P2U7iaGQqXCTltv9Jx7OtVFLdVKYiRAfwvINz7qWcwxiKYr664k8izNI0ajf8K6vAE+HnS42bvdGQyQrjuqcfpTriOTZF4kCqTj+kmN/ClCWyCNi8WCRt2j4A93hVcTTjaEyWmNLSS1SNUS77aQZ7iIdI9woq5le5jS1R1Wf8KxBhyxuTis1HcdnK4MuVxjs4Nlz5tVY4lcR3Sm3RFdX1FY8HV7Wpmrd2LZroQ3DIokYZ0ldm3HMD9edLbq0mn4hM0ICRByuZDtq1ZFMJL6Ge1tnbOpkLHruOePpXJLwm7MMKRhXw6hj3JCeYNC6B2LuIKLYxfeuEiRwN5Y2P6VASW2pxHaXxUKM6pdgaON+WmMTw3dvIMZ0kDl51ZJfFFKxXNyWwchdOa3YQW2ZIrzEkKRw6O8TufjXJ7uzW3zJewaZNRjVIsBd/Kld1O8wJ+7TSlhgmViAKUtFJJ/RKomCe8u4FbjbMFw3dpZcQd4LuRlbdiM97y9lMkt7HiMY7Nbhm/Fp8/f+dZtbO4W4ZFfUqn8WnrWjsrS7jQu16VUdO6c+7PypuIORd/mD8Mia3WOKAMSdcx1EH2DrSxvtFdG5LPObhlXShI7q+weFVvwea6uMvMZHYFmCJ8KZQ/ZhUhUyzxqv+nVljjyXlRjBLYrdhXA+NGe2aKU4aLPeP9+fOvcclkVbXs7j+mqkZB7y8vngVdBwiGKM6DoODiRgMj2Dxol+EpcRjVJqI6Fc4/XFC1YeOuxAeIXlzKND286LurzR6Cf/AG0YvE76CJEbh0bd3H9OXZv2okWKWRYIGyB0Jwa62tHy8UhA5g4NFpPoG0J5bq4lkDNYMuCCxZydNDXdw5LaAfvB5KseBWnku7ZowiRaW6f0wfXsqiW6bR/T1nu8lXGKXQdmcS2v5I1ZI+z1ZBdyAPgaMi4ZxRCxllDoV7xzkAY50bJC0uzwtjn3iOfrrXZI5ShREdM9e00/KsmGrEU1hxEzdkxC6TnXq239c6YLGllAiNcKURWAQd7UTVz2Mksh72APB87ezNQ+6QRHU8sZOOTNz+FI3YyQCrt2eh9S5zv0rqTQREDtBgtnLE86LnhtmhBWAsM7sSQxNDtZgvnsJI/cG9eytVhOSzxSxljNoOTy3J+VetOJR2NxHIXkuIxnUh7o+X5VXBbIiiSWbGDuNGAT9KsltLObvJMipjOZBg59oBoLRmHXM9s8zy2mtcYcKyqcgjPjvQF3xeKcK0dpJHMow5DHTJ54/tPs2qUV0YYJonniZZVCBw0jFcHYry3oSTsJJcmTPTZfxefP5U0hUv0EmluLl9blNhpCKKDjuHguCpCHfdWGfhTcvFAMRqzn/SQAPlzpZI0zuks8BjhY6Q2nA+VIOhxwfimqVYmCqpOnblWoKlxlc1homhS57roBj+3OMj21ruF3na2S69iFx3t8+Hurh8nFX2Rz54f/AESd9EuMYrqSZHSgLmRxdZPL20Rbt2qrp2OfnXLXs5AwkEZO58DUSmpqnIUCgjf2UHPN3dIPSlQU7ZcE3x08q5cy6Y9B5+BriXBUgb5+efrQ8/8AWLHfY9OlMlsNBMEgjbLAnHP140NeX43Gdh0qMJznO/j7KVX0bLKcg8+VWjG3RTifSbSYLH3vxZyc+vnUJdDzll2znl4+ulCiRBGjqd9O/r9Klbyhw2QPj8K803ytqi5hhT4fEY+lQBwpDfM+vjVrAiPYdff/ADXBF/T9u3r6UUrJ+ypAe0AHL2et/Kozns325Y6VajHXpOPHPlVd4urB2OKahXpFKysQasWRsnV41UikY3wf1+tRJIbS+w/T6UtCpl3dlVs4wB6/ilFhxVIJIuwkQLG3dDjUCg6Hyo69m0W7pFhVAGST+Z/WsGP6KHs5DENerffPiK9XwI0m2dvjrVm44j9pre5nEV4rSGMnSsRjRWB8SFG4xSG24xNNp7NJGPeYhensHSsvI00zSSBVQL4Hb50fZ3d0bgxEx24eJhnG0nVd/dXclR0jbiHFBFw8feX3J1acd8ny8qRcJ4tJdcSVDHlXPcB5E+BoC84fxJple5QszDI/qAYFHcMiNjcDDo0zLpjCZITbnnx91M6rYqWxrNAHeWXSXR3z2RfG/MnHSq7WZIuLwaSwUqUXbOk486ulmt0soxO6nAJJ1DvY6E+GPfWW4pfSm6M0PdjYjspP7u7yNCD2GdUfQpdaR7JrQDvADOOXX9aJtLmQvqtUjyjYfUO8fPflj21z7OXfDftHwJ7uTiX3fiNqn9azEGsuRydTnkeWMGibeXB7kXZhtmLfSrTdonB2y5i/d1O2dR2J288D9KBvY2LYjww0nrTAW8hY6HyG5ltgB661c9nohLGTILfgT/V9ahpdlrszl5JNE1vMw1vgZz8Nz+RqkcTzIwuo8/27cwfGmssSTNy3XdT19eVASWiuwV0AUYAfcj4/rW0wbK44o4pGuLW4SLWO8h3V/d0ohJpn7nZKq89jqQ/SgpuHo87rr0gDaq7O1uo5CySHsxy6UaYtoZTXaQRFECM55AsVOazyXV2Jz2ojHlWg7LtYxriDbfiIFQ7JVypQqD11frTKH6Dl+Ab3V3ewrbQwyFcZJB0fCiV4Be3YQJDbQjq8hLn50bbxsrnsou94t3jRiWUs0ZaRy3lv+VNGKiB3IEf7P2awql9xVpiD3UjUBfgKHHC0DsLSEleuNqbfdVgTOkAHx51cOzt0aUy9wb4O2/1puQFH9FcHC7nOXcBOqgfKq5OCuJNIlwM5VQ2MH2HaiZuIG4JA7TSrbae769lWQh5gJpICdtjnO1amtswF9wu0ZFMzgA4AKd0/CmH+XkOXRYstz7NCB8zV0U7SQ3EmAIUAXGOtVXnEZbbs0hkSIacs5GWPj/FMlboRvVlc/CNb63kfK7kHG9UHhlmMkPk/7Rg+7lUUe6vsYa40/wCpzpBFcWw7RwOzB3HekY0eC/QqTJRNw7Vjsu6o7ylQQfzq2Oez1YSbQGPMDGPKj04W0bZ1RBRzxHv8aEulxIMyzaNWciIbH10qdJuh91Z4RIpWaOVpFbu51daoju4V1pFC8rjIJAwPiedXX+mOGziTCqFLsSOefGhgO0VWzI4Yj+mpxk+f1rR/0EiTrIluTJL2XLbOo+vPFU2oeFZLm1jumKtl3Z8avdTYQOluAIooh10jU3ryoVL60tneH7sWA5u3M+6s3eomquyT37PGpQSqG3/6eceP8VVHerPMuREVHM6WUiipJ4GgTsXmjBGcFdSioQSnHelVz1LLpP8ANBN0akyFzJZs+6prbbIkHr30FKmm/eLA7mAccw31oqUQyXUTv93eNO8ehPjt+lLY3Z3YnnIxZse2hfoPsZxG3hGMxhsY55x+1XiRA5SfGAue6c58Pd+VKo0KOSsQB5nJzRLjTC2EGo8sbfwa2g0wfinFeHq4tlV9RGnLDYe0igwsUQ1aBhur9KXx4ub1Yuy0NqzqPSj5pJJC2hQ7HG+fnS6Dui0cQtkkaPBd16Iny9lWpfI8ZElrIWG55n3fvQoVYZFWNkt8HMZ063Yjmfb4UTalWl3a4LEnvMQvX/Tj40eNAUmyDy2ExaJoZkZhkd0jzoRY4i2l8nz57eulOhIh2WQKfw6CQwYUvubXRLr3AbmTyz4VN/4N/wBBmtoVD97IB5auVVm0tpo2jR8Odlyc7+utNY7YOo14CncHlmrDZQIF0FdXUKo2+NKEyyQwa17QOzasMpp3xAQX3C3uLF/6NvgOsqgFcA/9v1qV7ZRt/VhQq394G+R+tCJZ/ewyRntAD+DGPYaZS0ZoRyxoYyrIveG++2fGiOF3pgZFdtSgaRvRkllCgeD/AOrjbpShomUPnY9M+NK0pKmaStUzRtpuP+n06gVyJ+xfRgfpVXD50EfZnGoY1E9fCrLnMJRxvvzrz5Q4viebOFOg5XYxsTueefX50vkPeOo435Yq+K7VFAyN+XQ1RKQ86JnAPWppbBBUEW7BpGd+XTHKrWl/r6tKFQckdPKqkgRxoMxi0oW2XJZvD96oFwYEVkYhwcg+dFDF4dWkOPGqbyJ3jLIB5H1+VWXEtvHEjR/9Rhv+vurzSv2GX225H5fzTJu7C3uzSXFpIVRUw7YGCDz6+jXuHxmRmJU5FFWkzSd4pqbvN3fngeHlVJuEht5VjbSXwefhXGxNBcjquMDu4x4jHr4VTNJlMjY+fr51TbGSSRde4bfzyf1qy4iQ63VgNAJIPh66UEElbzxs3fXujqNjn61abeJbXtFly2dlP+n10pXZYDOHxy938VN7kXMnYM+zHJPI5+vnTL8F7PGVu22GnbNEGfXbsJB/VB7pxv8AHxqq2gcDv76DzqyKJJCchu6GxpGdgMk+ylfYBbcQyXlnPGP6ZZCM451hpBiHfGc6cE7ivodzN2PD7q5eMns4yRvj17a+YPPbyyPJKm+Sw3PeB5V6Xh3TO7xemda6EDL2ve1Nlmxmr1u7W4UHS0DJ3lP+oeXgaCmhgli7XtWQsdWDy09cZqqO2dssk6pGBzbmfhXejoZqrTjl2Q0V1etLEqFUDjUP4qp5Y7cdonZ4VSuAN5PDl59az0d9ELfRPE+oNvIH7p+HWom+UFimCB3lRiWGrxH0NCtmv8JXtwtzK6SSFXyWYL+H2Y8aVNK0kq6jnBotLO8unLwW8r6tydPxopvszxQRGRbbWVGp1RgzKPHFUUWJIr+zl6vD+P2tzJGsiqSNLtgElSBv7629x9pOIbJDax25/udm1ezHn5181kB7ZlxuNq1nBb8XdgYr4HMAxFOfD/S3srNWLF0ba3d7uNWcdoeZJOnPuppHPC0aoo3XPeByGPL4VjY+IMsZhhwFb/qa+ZpinEYtMcURe3K4zq5Mf0pHBjqQ9ltx2uEyHyN+vv8ArVM0Lr3T3jnptv7Ksimdo11OASue5hh8KHknknKxqADjn1AqWyhWYSszKuh2xk+AFERqezGlYyfMbVSkZTK52H438TRWgsAypINsDAx8KtHRN7KpI8sMogXwFea3iUf/AE1IO3t9lSMDPpBD4x41VdjDLGNXjhzmi5MPEIheHsu3de4B3gDjlU04g8uTGhVOgbbNDssYsYU5n8RBHOh5RMi6lUO/9ur6Uy6F7DGmSTaSXfOVES5NA3Fw1vcMIkVcDPfOon3VYnbSRq0mNSjl5UVcQCW1UhooXJGS/P4VrRuiiETS2+p441bOSzjn7qvK/wDlzgqQP9Bxg1TP2VrFpGqVuhYYz7BVEU7Mv/TKhzttWezdBUKdjapGoY9q2s53qIkSaZ1VgHbYORyxRMmuFYCXwdOTilsdxIsmpFV85IwKrBctkpOtFYfsrpT2Us7eMjcq1VqrPEskxjjB/CqjcfvSiIhSjy7x4wAu1MoriF5F7FVwB3iwz69tGSBZC9dNLaJSSR7hSdl/qkfeW38ScevOmV9ApkLdoTnp4UNbWrmcBQG3zypIyiO06B+Igvca2IzGgWu8PKaTGPwt18qnxLa8kdoxjPIeFdsVMuhiuFXn8a2uIPYWHFuNKJkHmelLr6BHuE7ZWbVv3TpGfrWigtu3kGrI222x6PlVb2sTHIUMV2yevu8KklY8pJCbQkUUaLIe6PX8VZHhl1ZRsePhRUlqvbZ0rhQds8/XjVQTsWwVwPbzogKJ44hb3DsneCYUjpnb+KVRRTC7EaDWeerz8KeXaaeHOCrDVIuPZQtlIq3Urbee+wrN6CuwQWkobvf01GxOnNEqpaTecgDbJGoYplGyyTFHKjbIz6+dRmjJU9mofvdNt6VSG4gEsEbzqEbtBkB3Mek4pSbYpI4XcEEDHl1pzbt20miQYXOwG3trlugkulSRtOQ2Pd+lb3s3oUyQJcQ5XKyqmVI+ZqFtDDDG0l1chtuRJx8K0C8NchsYJPXPKlFxwG2hneYzFTzIzTpWI2WKpYJJFChRt1ceudXNiSJkfCjIbB6ezy8qutmgtrZA1yrPp2wuot7vCg7viNmWyrK+TpPdwB68aSSp6GjK+yuJ0UPEw2Db55/xRCYVhq5ePWlUvHOFibE15FrGQRkLyohftFwOFdL3ynH4QOlBq9hUktDBrR5F1xvqTPTn+1L7nh0gPaxJy545GhD9tOHxvoSaJc7FsE7e6hLv7f28CqlmrT4PNl0+z30KByDQiuNBXDk7nO/rzqmTgk98x7CJRMDsrOEJPv2zWXuvtrxC4lDrDbId/wCzNUf+L+L69RmT2aNqagfIh+yvbSskyvFKh0yI2xA9ntox5P6DCTDKqDH/AMhWaj+013f3CDily8gUaUZgDp8ieeKcx3tulvLHOpkBibTvjvf2n3Zrmz472SyJSVkLm5DSAxjlR8EimATNsMkDzpLbmLT/AFfwn50awWT7uA+nUGKjocHauaUfRBpDTh9w331WYgE5ULjI3GPhS+5dBMyA8m60XArLeQAqF3xucZNKQGZxI+devkK0YmSDmzJKMf2kZz40u4vxScoWAx3/AI0Q081veHVA4PVdPIDmfZQ3ExNPeaHQLDpBTHKqQitWPBb2fT4MwPFJH/auo49nWhZ7XtbtIon7rfhOMZyPD9KkLlI5iUHcK6duWeuPpUmUy6GjU93G5P615pC0W2adgqvJp1ju4O4x4+yhyvaJeidCY8rEJQfwb6viQvOroWUQmJiA4bKnfVk9Krv5HMzCN9UaxjOnlnJ3x408GltoKkl2LomIxHz1HA23/mprZiO8Z8AoATsedA3ErRQq0g/qlwEUdBuSfyoiC7aRmDHB86V2tg6GtgheLTJJo1ZxnfYeNXaz93YJIIm7JmJwMtuBj50Ddy9n93SMd7Tgkdarlupre57PYmSJkwV8Rj6UsFbATWTtERT3k0nUvj5ftWP41wEtIbjhsUbQ570GcYP+3yrV3JSAxw68XBG8a749p8eVC3Ek8EYdSGUupYKdy1dOKUsbtD45OLPnt1DxG3gMslpPFCp0sxibA9/LNQS5t2tdErtNpGEQ7ac/nX0i+4iP8kd4oRpL9+Nt1O/h4VgeKWnD5YLdoEMUrbMw/Cw8cfSvRw5fk7R1wzcuwOOKXilwIrK3dtC5fI2Xx91OeGcDtpkU3U6IVkI1JnHjvtUPs28FvJ2SEYmJ1uScgDl8aeQNci+WFtKwEnSDGAQMfh2q7f4VQ9splgjRERC67NlcaR9fzzV7NayWbp2SgN+F0bBG/P8AalsNm6q4lkRy/wDu0kr9KlLbPDAndaJBtr5n4j86ZMDMtx/g6QSZcwlmHdlUbSD9DS3hCrF21tImtSMgNkDmM4rUXq9rHJHnXGSNeQBk+I86y85aGfto0cuo3AGzehRsNDOQfdlFwkepQclGGR5Uy4NxbhszhJ3NuHbuq4JVh4ZqFhfxXlrrZQruPwOv9vtqm74dbSE6E0qrY7m2k1jNWbcdlKgjs11Ajd+lUJE5YpkquctkYJrCcP4xxXg11I9s/bQA4KldmrQxfa+C+YtJK1u2MMh3HxpHE3Q3+8RTv2EGAq7Y8fE+yjoziMbqANhqPP140utDahAyTB5GXO/j5mj44pAO3kCNjlnl68qSSaMmjusHvFowQcbUHdEG5U6s+VHSXCppULGA3+nBoKXIeRyO8RgE9KC7HOyf/tLcEc/3qyKETQsHJ0pjl18s1RHk2iZO4OathaTsnXYcsbV0LaI9AUstwSyaezijOBnb4Vdw9bZ5VkuZTqTbvbg/tVdzbySEHUNZ2wedQ+7FAdTAtnbzrohBNEpSaG81xDdXOjQHUciKjIoRxEVKb5OaAt4pYgr6dDA5q6WeWWWJiAw8xyqTx7pDqf1LL4jIWNtQSLGw5VXZwRzaF1d47YqV6c3EythcYAxRHCCmojTqI8OdZajoz7C5IYljCAbdSedV2VqMEudIz3QOvrwoibQsR0LnNLo5ZhKQFOPDntWim4sEnsvlKQvpbw5AdK5byGN3ZFKjnvUp76GS7RXjkY7b/hod5RqBXIUvtmoqLbHc1VMp4udbSFPx5FWcMfs4BnHPPKqb3Mkkwj0kDqK8qTJCikFR4mrNNxFVWOY+JRpIB/aOZPr51y64iJ/+muATz8/rWYu7p2JUNnSedVRTS6Q+TkDGPKisNqwOS5GhlkVXAcFfbVU7Q4XDEdMYzSmScyadRyeec12SRzpwc5I2/T20nxsfkNLpnkgiQbHXqGfDFL7CNC8rd7WXbugdc1fd3WmWOF8BljDZHMN66VPh5Tsy5Xs2Ud45zmlr6mUvsVvcpDC52DKNQoSDjq3LqgKIORU1y9jM9zJpI0BRz26VnBE8PE8xxl0Vt9PLND4qVglkNrbxSHVqxgsNJ8arGmK/GRqYOdudA2ImuuIo79wKpOj1+VR4jxKysT94eZEbGnSTRUd7Cpa0aJpkS3eaJVU+3as5eXJvAyOwC4xz/EM53P61nL/7awdiY4Q0jZzk8qzd59pL66wNQXAxkCjDjEWTbNXxS/tuGxdozguv/TQHfNY6Tjl65bRJoQ/2jwoCSWW5l1SMWY+Jr3ZYY55Kd6VuxURCvKzNnJ5kmuFGHMUxtrdkLSFVOldhnzxR6Whv7osQA57x22oXQ/AQ6OgOT4VM2sijJRgMZzpphcWKxSFXOXz+FaLsrMhmVU7q/jkkbuZ/0+dE1L2LZ7AQwrISQSmobUvrc8Ys4F+ziS2oLyu+g7cx/t/WsebG4CBjC+DyOmhF8toD30DZpraXTi3CSZcttHnoBVUcbJGYpIS4xqyF5VcTFFJCoXaNcsR1NLJ3oXYQrOY3Dv8AhPTqaeWsZY2U2RojY689OXrFZzUyzxMBq1LqwK1dlaveRxoZDCpjZnPgvU1y5VVE5jBuzWaa8IDrkrCg5NnmfMDNDm1hWEO1zEsysNUZJywqjid6jW8U1rlIhEYVTqMcj7fOl5LzFXlfCRKD3djmpJUiauhldt2k80kUbsI7dw+OSilsdybhULDTDqwrMOu2f4r0jzRuLh4miTtNMiHO4GNWfiKsay0cIuY1B1Ws6ugB/FqH7CmSrTCnRvrNkELGTGliAcn18amxdYXAyFXvAjpQUjxLOLWKQs7rqxjb15UUs7NblRjRKMac88HHwzyrzkmTSIorMV73eYA4/OqHDSZkWQB86VOfzqxGzdxaCcnPl09e2hzpiV2znUhbOOW/QePlWQK2cnjLWrPIoZ2fSpA/SqIDrkQgAE+HWi5Gf7iYwxB06lpNDMYeILqBZe0GoDwp+NjUM2kkbsSHGkHmT0oiW4ktrZ5P6RnD5iLc0LfxQ4lhjkRVGpS2IwDguSenuqPEFNvfzduNOyqQ/wD6QRisotdAS9oos5WFxNFKmmRMuxPj+vjVfFLoHsrS2zhY1PiSxNU3UDniA0TaSQrajy/06T470PkLemNnVZZO5IjH8PvqyjseKCbqTtfs1MscqmZWOoj21i4L10ncOQI4jgBl/DmtdZ9gn2auY45BKdZ/qLy3xWOvMhGd/wCl2j9/AzkDrXXgqLKY3VjjhMSSSy/1BiKUOuB3cEdfhTe74hJJavKjIexdUIC7HzzWf4TfyT3DWtvCxhaMs6puxVf7jTp7o2PEJZhAtxalAWRuQb/UfOuxK1ZdSCZrsT21v2PeukGXKrjf3VUOJth445ZNMvdKEagKUTOZ+JLdxkRK3ewOQo+3e2lheSMzB/7gcYPs8KC12UYOt4YWkVmRA22GYFW9lRZop1Z2Kqy457Zzy5be+qBw43cmIe1VFyDtnFEGR+GpCsVsX0A/1mP4s9PZ7adIWweC4+5yaNeIi/dPh5e+n8U6I7iRFKMvPOTn9RSy7t47+1a5gQ5yAU1br7vChre8W00bKzL3WV1I736UW6COJuG9nrEbMRpVtB8fbSm+sI9COqkZbSTitB20dzCZrVymV1OhOrA8jXfuXb2bqsgbJDA+O35UqlyDdmMN1d8JucQzNobofwtWg4b9tpEZY5kJTqvMUNc2SSpFr2I5+/nSe64bHbWTyu3e1/0x5VpSSVMFLs+l2nHuH3h1ZZW6g7Uwmms5E7RZEPd2xXy7h0yQQhrzWQfwaT+LFaPhHFoYJRElkAD3l7R871O4vpAuSdGhtowttl5MKx5mrknj7R4zuByaujjbz2p7OOEMF8OVIeIcTlkK6CFlI5jlVFKPsH3foZ3VzJHOGKEgn+0VyO7EtwFEUmo7asVn4uPTJOsc7MDyLeFN4OMLc2MsfaxiZDqTB7zCulNJWRk2NOIm6V00qSv4jQaXKx3ALvuNylehu04zbGIOwlj/AN/4vZSaWRIbx4Zsq5OnHWk+RJP9NDemOTcPdXDzMNSt3gPKmXDImNy4B0n8ODS2+Cr2C2ksYMKKsuf7mO5oCTiHErU9pbo+puRxSRzQUabHlFt2jTXME9qzSFiynrQ8NwYJGdydXIUBa3HG7m1P3iZYUb/UKAveIvbBoJJ9b+QqyywcaRJwkNJpWcE76l/DUJWBshMWOqM9/ek9peXKlpJHLLjlmkfEuLyT6lTWiO/ex4VGc4xdIMU2zUwcXhSQ9rq0sefnTm84laparGSV1r8Kwl/wya2s4LxLhnhkGQCeVFY7exXtnJbbBJ2FD5Yqiyjy2grt7ZptTXGFJ/1c6IF3AxZFbVjr661kLmJ7W4ABDedetrxjPjk75wuKu/IVaJvG12au5vIFi1xtqK9MgGhbPjlvJcPG4K4BCljjBpLHYdoXkuZCBH15E+FCRIkCsNn1HZn5iuaWe9IrGNuzZWE0M1q8UrZmDanYncn20wTilrErxgb6BsfhWDgunM3bAEFRp7vWo397JHKhTdZB3Rmo/JJNBlFctmpk4xbJHMXXBHhS171Z9cdsMMNwTyNDLfW0KJavZr2khGuVzqPjgeHtqp3nd5Etz/Xjbu93GR0NU/kt9kXjV6PXHGeJWUYtkfDONOMb1mbsSPCZpyxlMpXJPlR3E3kXjizOdJbS/s8aq4tP22kKumMysVXHIaVH1oKblTGvSSFKLqO5A9tFWsKm7gMwzC0gDeYGMijEsnFmJo4WZdILMeQya5KGThVs7BFPbF9hvjl+lZy/DOqB7mf7zxR5OzWMau7GoAAA5CpJFm9VY8ay2wPI1GW2K3mSSA5LAnYEZpnwu2j/AMwjkZ8sjgop/uUEZPwoOSWwXWw7i5Fv20COB20iiTu/hA8PLNV2MTTZa01ySRsFwOtG8St4Lm/SeZn1zkPHAm2fb4UBc8XSzZLeGJVVDgx6sp5sccz5UkZ2qRlO+hjPYxwxKz6DeEd2NeWaFlWW5hiEkgIUaEVBjTjy99ekvbbiEXdEkc6rqjkQ6lY55EcxVxtDLFFdBGZs6XjU7+t6aLrTDdaYZxWN4eBWCqmI8sdR6mgeGyTQzRSQvodSd26jr8qMlupLvhIsw+Vjk7RVx+GlyTJE2IQH/tyPA8/l86CacWkGLuLDp8skV7A5+5TKfasnVWoizu0LRpHFGzMdIXRmoWzRRs0PdW2uF7wc7K3Rvj+dXWMfZXCs6YKSBM8t/Kt8vBOzKSUdh9rbW0UclzLbRLpTAZ1GxIwKtlXEEcVtbRKkyZZ3AXI6L767fxxy9jHJIvZibU6j+49F/Laggs1zeukQXLKSrEHC/X9KlCXNXInBqbtkI7K2ignSU6VfOnByAfLyqjhkFlFa8T/zEh9VnIlsVTVpkxs3l7fOp3Eum3keRwUD6V/1E9WoZ7gOsobsVYxlFRE+ZPWlTu6BJrdFb/8AmBZz3hY25te8itglvb0J7tHfZyNZb+3u3X+kCEYMudSg8/Pag2iiuLL7v2gEzuJu5y0ciPXhRXDbjt7vdNFtFGRGHHQjGfbvzpJfVO/RCXWhw9hcrcpczH7ugJBZufLpjn5VfHM0TJxQPMsEZKrpXS7MOYA/CM9fDNdvrR7mxh4jDcOwC6lR8KGByG26EMAMVTFbSSG3tpJUaSIFoTGQUZWwWUkes1zVxHa/CcXEre8jjuNEaZleKWNNWx2KsDnfIO/splxC0e14bF2eCdRDN13XK0k/y+Gy4gR2pVEkXuZwckePjT3jF0IoeGWr9ti6iOMLt2nQfEcvOg0m3oRqzOGee0WOZ2eRTgpp5ksPDxop7T+tHc47MOCoRhghvZ5Cg5ke64WrW8jt2T6CEjbBU/7hy38auitntODywuSCi68kc8nfzPuoNNJP2F7VnIrNf8yBOQioDEwyVRtQ5+XM+2ruKzrccTH3iEzZCOVzjJGw3FEW8hg4C8pVZBKRGi5wQwAPx5bVRFIbi2juXgQuuzMRhI+o5eO/nTrVMwFxe8SO+iVIShjAZ9B2Ax3sD34PtpHLruuJShiVWO6wukbIu5PurSSWkF3MXmeOEyz6e0Ybsu5OkDkM4+FBcUsYllVLTtMtcdnMQeTZx8/M1SDDFoA4MyPwLiMSorhMtu34jppVx61iez4YlrDL2zKzyNrLd1mwi46bD50/4IEW9vYHha2ctqWIxnlvzBqg30C3sqnZ7d0TlzRef61fG6yUNF/ZgHAuEcStONW/EUEcSq3/AE2OSyjmMUxk/pT3iy6izsT2RGMDNUX3G4ZpmWBXUfh2X9aFurx+IXiPKJDOqnEgP4iMbsPHau9uKVIulZyB/us7Q3MOFYlWJ5+6mFyq8OMbo+EZcqwX+2h7hjerqiXWdAc4Oce2uW1795uo7a+lnAiXSuQO6KWSspFjWBriRB92nUK/Mnu5/iibmSOSQWc0ZZwd9OMH3/rU+FyRLKyK6tERgnAB/Y0yhNnCjO0PZlTntBuW+NKpeg+xVd8LaHh6okSFNWeePf7aQNaSTTDEZMj/AIhWrm4sJmIhhklc76SNj5k1Lh8FtdxzSTIsU0MioAGyMt51nJIz0ZDhzywcSMbEK6bEZ/EtaGwl0zlGcIDurAczSS9tE/zWZ1kxNFIRgLs3szVlnfDW0Uir2kLaXDr0z+VBPdoyYzu7VlmdC0bZw6uu450qvreS8mRQMRrsB0AoqXiS9powVf8AC2eRqNjJkltLFF7uhtsedJftgMxxhHS6WNNo41xHjr41fw+9fVHqK5XxptxrhzvbmSNArLlkx1pNBbw30faRMI51/EOntqla0OujSW112YkkYZwvLlmiPvYWyYtHl3XSinmKFvFFtFELl1EYTcryzilpux2Mc25Ukrhv7QKlJ8qFU7K4o2lndZz/AF+lXrFdQ30c/ZAaDtkc6uWVCRcFAM7gipLcyXQyO8qjl4U3yMdwi0NWjhsrkXUbBUm/qKq7aWqriU8ZH+ZSHBC6YRj+7HP3b1TGsU1npk0syHKqD0NFXNrZ8Uhht9YiEYyozzrn5tzJaugLg8rNAYpnY6t8+Vdm4rcQzBIpn0rt5VKJILO7eF5cKqABkqubhbyL2ttKsiMc5bun4U8mn2UtXTG3+fXzWUMjqrDV0GaEmeC81ySxvlsEYXTvVSXclnbxxvBpAHPFFXE/aWFtBrR3kbUzqN0G56e6k58Y6INUrQui1xfeNeBGsZUKT40K1ubxkQ4jGwDE7c6fJGI7efWqOWGktjc0HacJ7K7Wec6bZe+pZgT7l+tIsnJuTNGatsaSyQPGlirAgR4A6aqy/wB6ngdojHgBtPOnr3AjuH+72ile62tzkCh+MJDd2js0ECOzZeYc1psbSVNjQaixTDGLoh2wwB77E8hRP3WFbppER1XOUzgny3pCbvsx2duwaFf9XMnxNERcQa5kSIpuDzHLFVafbKtjDidrchIzHrZpm74zkADpUIbCCKP+vJqmYjnyUe6i2vvvdk0QkGIyP7vA70D98WKy7UthllIDAbkfnSwdLYkZUtld0gGhAHGdgTsPYB+tBcXYCK3tIAXkU6WYbnPUD41fdcTNnMjmDE4G5lOSvu8aL4ebm4VJVIxksxRQMjnRba2yWSfsCvYynDreaR9Dxr2bjmc9OXlV/DbqFpVvEaTRHtPkY1UPGb6JpPvkjRx3Kkxg4ySORx09pq+3kMM1vYSxq0TnVOSNix3Ce7881pL6tE5SdUT+19lre0urePPapkgUu4rGlkllrCSyFMuh5DvE7/GtdxFlubHsLdUR4XESqw2Y4zt4Uu4naWEssTTrI6xuIJQnRtO3uqeHI6SfonCb0mUy8MNzPrDCSLsda+EZxnSaU3luiX0Nu/e0xAlc89yQPftW0tODqb24mtrkGB4SujrkDHx2pEvDSL4sjsL0dlHEunOBjvN7qMcqboaOS9AFzbfeJgkcZmkikPbzAc2wO4vkKK4RcIl6gRoGn7Nlk9urYD4j4U2ks4eHq1nAXIYs0kmMEt5Uu4fwPsJHnEervZTPXn8OdD5U00wOSqji2rLJDEVKXDayCTns1/0il0/DEjsJpjs1uACTvqJP71puE28892jXcLa0lwz8vR5CocStFuOH3MRiWOd5cFQM6iv8VOOVxlQI5HFme0SWq2qzyv2FxGGBHIePvo62BS6Yv/UVh03z4OPyIoninDlh+zUAucCN5NEZJ7ybZBPzBqvgds8Fui3Ualw+mPDA5XFWeS1yC52rBogsFx93l5yZAB3DCruGWN2I7t0VWitVD3AZsE55Y/OhftBFNZ8UEv4YkwwIPL2edPYpWueC3HY93tzlyD+IheVbnX2/R+db/QSykhvXlhlGkHGgDnmmFpdQfcNTgSrauS+eZKjApBw2VVvYta8z2eodSPXOjA8UPDUVc6Lucyu3XT4e0mhP7Ohcm3RoLm5t/wDyzRDJuB2oV+YPOqo1hhuu2jzqdtH/AKR19nsoK+iSTi9tMxKJbx7Y2Hn/ABU7qaW04lC6KDbv+M567YNRi6mqZKIHx2F3swXGHSYg45adX7UuS1nmh4msWWYIhP8AtywH61qeJSRlZEGALgDnj2+jQVsFt4LzLRoLm2b+o3Rlw36U0Z7aHjKxEVZeKC4iZY4beHTl84yowBtR9tK8P3mSV+0HZgxsf9J5D9qAszLccTEelewQFjt06+2vX90zWQSI6g7frRkuVRGkr0OLa5ee3VfvvY20hwIymrP92k789udS4VcXEgurlZon4dGjEK0ZQyMOQGR48/fUhFCUXV+KaRXXK50nkdqB4vLFYr/l1uuoa9ZcHfpuOvOpwny+oyk3of8ADbhry0g7QwrDFmWVFUvpHjnlgbDGelM7m4tZF4fqdmCsXiZx16YyfPnWetrhUsIYbWR2muO7r0aS2nmf3ppG7Hg8BcYXDJLhc4bP4hn8q58jalZJ3dlYVbS9+7iQHEwul0EYBI35eX5VdxHiDr2OEWSOQOC+nZABuFPP65pfYNHNxAwAvapbg6yu8cozt/8AcfjTp+31xwz5ls9u0iOMeRBxsdgM/GqWuWwlVjeQtYCOaaO0iVWdkPebHXC/3CgDxCYcKuhapmBbiGQAMCxXS4b379KLn4bLc20vdSAAgQPKAMkHO/hXrWzjS1MkK2uqXvdxtQVupAB8+XnQU4rZq0K+ITvFIERVdNo9CDBydyfLrTC4cP2bTuUgkhZTq/AW6a/lvzG9HWtgkNrNcSIVKrnKjUfHfy86W/aC3aTXbrrZpY0lQu2QGI+XOjB8qa6Al7JWcF5/mhhulhZViAUBc6McgGG3zrOcWtr43M1wE7RQwVzHHiQryJPiPZWp4DHMkEHbW6RFFZBpG+kY5+PXahOO3MUv2hht0R9SrowPA5zv1G+fbVMc18jQE/toS/ZKacy/dpbW2uNOdUkq5K5/D7eRqjiv2ib7lNngltaSSNiOSInVs3Ly5U5SE2FnM0+000mElXZ2UHY+ftqHFuGdpxaO8lhWTh4BeQJ//d5gbk8qvDyXza9FFP7CPgyPBYQ3dsCXmR1lydjv8jULnh97IzIVX+l30CsO0x10jr7KjNa3tpZmGFXhBlZVWQbuN9xTninCb+54bw+6+8LI0MYJmTukdPlVvmr2WUyrhfE5HtHhmRZQB/1NGCMeNaLh5iueHSSXTK8EaYC/7vXWl3DoI7RWszL2t52TO8vLH70sj4k/DbFZYiGZpDpIGoHFS5vloLm/QbccVtkkRlmmOgkDtE3Ippw6+sm+zfEdY7JWukClcsWBArPxC34veIXuEaVjyRce6rb6f7vJ9ysbYW5ifL4OrWw6mqyauvY72ih57S1k7EO7NI+vPIkZ6eJptxHhVrawveWCtdrMmlldcGLI399LLSCGTiLJfAXEusmIdEB/ubH5UxbiIsOJNaLbkI/OQn8TY6eVQcnaUSLk70Ibq2uLe0DSaRnupnYkeyjLSf71w4ap0D2eBJnmUPL4HaldjiXjgu+0Z7Ryzydr/Z5Vbw8RyfaGa2t1GiQHO34hjmPH9qo5NafoPP8AR1Z8SF9ILPtNR16QARt0zSHiPA57PioNuMKGwcHFE3Q4fwqZGs1kaZnaJ+9+FvZ4Vbh4rayExd7m4lLRuOi+JovLSoPyV0D/AGk4gr3K2TDQscY3HjRs8EEXDeFwTIO1kjJLKMHypfxzgSw3wldmlLEMxDfiGOXtoz7TXS21xw+2+9PGqRqSg/DU001FREclpI5czR29nYwyRaUkZtR6geNU2cM8HEZ9EqGBVOXDAhh0qvj5mLW0qJr7OLUdIyu/Ko23apFbx3UJiM0mo5IXbwxzoxlcLGWR8RnwSG8W7ugYo2g7FwTjr0rkllNBwXVNKI7hn/GTtj1ij7S4nt450UhcZRQu+9WcS4fcX9siOY0mxnDtgedc3zfbZP5Xy2ZSw4n2E80McAllY4Wd8t8KX393ePcgTNI3gCeVa7g3Bks5JrmaTVpGVUL1pLdQXTXjRWtupuJCSSzDOPfXVHLFypFflVhNte8QEEUfad1sHS++aN4dcLe8R0SJGCo3YHFW8PtzHw+ITaVmZu9nqBRPDODyzQ3i6Y4FbZZGbORXM5Rdoi8ieihb1FvpYluEmZzjSn4V9leiuHa4lJmZiCVIY/AUjmhtrDjMUVjHczSROO2mcYHuHStA0f8A/kGcqvZlC2fMUMkVBiZFT0Lb69uZWudQOlMAe2hIXkkjltX3SX+8eOPjR6t9+tZy6aLcgjIPXNI7XhT/AHuKWG3bsklVe0Rs5361fHKPGmi8ZXGgngvAY+Iy3NjLI8VypBjlHIgcxj2UdafZ+OC8u55WZLeFWC6juPbTz7lLZXr3qxyO7sNESALy8fDereOWt5fcIZYrZ0kuGUTCPp4+6pvM26T7JvK+jIcBtFaW4uVbFrGwXU39wLc/hvVF42iW8uWZmh1BoAfHOw9lOrngUx4XPDa4RJJUyXOkaVB2HjREHAJ+IXFnbQpGyQZEhZ1I5f3dBnaqc03ZuduzBlLq6k7Vss8hy0kh5n31q7G4fh1hIcO7/wDSDOcqx/2iuW/BnWS7jvHBks01pGD+J2pjY8Ljn4ZGjwtJ2MgIy3dD88GjlyJpL0bI9FNxNNJxN42gjlghiQ6nXct0x4+ymi8PiuRazTxYmiOsp4HzoM29zFxZbmQ4jVe073VuQA9gFHcKuWnmfWhDt3jluprnyN1o55PQLHbhuINc5OgPqC9NeMZ91BWlwnEZZ7e6V8u7aTjYsoyDTWOEpbTHIjKuW5cqruEa3i1x7alzkcjtSRnRlJk+AdrDYwC6kPayEoFXpvnNHz6LWUmdO+O6JAMlfOhrCSKW4tZe4zxxnWR0c86Oiufvdw6svcBIpcruRnqQnvIXhu+1ncFAo3J3NWm4ZFyM6QN/dyxUeJWP3q6gtlUpAzcx0oVoJYIZbV2y6OQrZ3IHI0ErSbGavbGHC0W1up9iFI1E89THc1MOtyxlLY3zuBtVFrKsVmqk6umrxqSgkaQN2OxFC92I9sF4+TdwJaKhaJ1Uso2yNWQfI0Jw028cUdukT6U/CXycez6UxkSaUwRRRrgEqxb1uKOe2FvFEioCFbJbxNU5VHiNy+tGY45ZG/jhdpGTS2G7vQ9Kt4cYURrYs/N373d0rTC6lQFpHbQATgNy1UHDbSSRPLLvMYtGPKqKVwpjr+tCyZIcRCCLAjuNETA+KnP6VobG0jSO2iZVeOFMZxkZFI0hSI6JThFOvA5aulWcNu5IIZUbZckDHjTSbcdBa0S48bl2iRO8k8hVtO+3T+adoxW5mR+Zwo1dDjn7aACvOkbrswPSuszNdypMPxyKVPLapOVxSAugjiFkbmKMI+TG2pQP0oa/ttNu9tKSEmAYHxxTjUBKoYdP4oW+EizHLI0JXCMeaP5UsJOzR7EcFiLIvOGZnnGSM7KM0tilllaRZUjAmLGLP9pXly8eXvrQyxFkdN8FFj28KBS0dkhUorGJiuojGV8fyq8Z+2Ope2NobO4iuUkupgS+CnRccl9eVen4fZ3g7aWVfvKgoRpdcb8/byqy9vJG4nFEI0dpE/pHT3YivJceVNOHXEs1oDerEZlJfWqjGPP1tXNycPsB62LA0E8kK3MOmFT2UeD0A6Y8TTBownCbMRIIoix3lbY78v3ogpZXgF0XjtLxfxNjIbAwCG5r7RVa8MF0AwkQup1Kx3GfH9qWclpmk+iqyP3aaWKXLAgFUXB7x88jFFNNbQA627KKEFm7R8nOegx78edLjbXSXLSrIjK577KPw45EeVWRQi64h94nVJo0XA1f6h1JpU0KFssd1I8zIs6oMxo8jKvswozXpLCKQrN2AhlZQHjExAHs86IhiCxxPGVZW56KreIx4LynCjVn/V5ftQU5VxDyfQRPbrc2KLHOy6MAAf3DqprKcQc3PGbopbRvJNIQqMrHQDnp1ArRTS3EFzAuzRyKqBjyxjFHQlDqlSNe11aQSNx76MMjggp0AWMD2zRo+vScY193HdHh7KW8Rlif7SiLs3imG4ccn8Qae3TSNeQaZBojByAOvrpXXt0u/wCqFDSRDKkb4H6ilU6bZNdlUsMVxJHLLGNUWyY8Tz2/SlK2Ub8WmR5mCyyrcIoY4BX9DTuK37aNdPjuT4+dTMcPDtQd1/Fu43NaM5JGQn4ybeN0nmQMVbbI31fWirO5t7pJYJUVos6tSctXX3VbN/l/fTDXEpG2fwr13FdDxWNs9w+jsgn9p6/SqU+KXsdIy/HJbuS7u2tLaOKBoQpkJxq8qVR2rL9m5WeMv2ZLbbe01rLxmm4YsscfaGVsEdV86NuPs8j/AGbigeZxG28oRd5N86f2q8MnSY6bZ8ht7pLO/Wa0Ltp3BYY38q1kF797iTiKQBpWXvaea+dRvfs/wuHiBneeSGNZVSKEjIIxzHlmtHwvhlpw+4jlV5FhmGjRKBnJ65/KujLkhotJ6swV7cQ57G1vJI5nky4K7s3/AKhWqhke74bBEtz2lxFtufxYpLf/AGWmj43MLY6gHJyw5NmnfDeFtw+1W4vJB2kSkggZ260maceK4sSbVWmXS8LtL6wmjdyrMuGZdgtJOHcMfh/FLdJSH0KdM6brp8M1onKtZydmyvDOuSDyIrnDbXRbG3nMc0ZBCFWyEHhUFklTVkuTpg6cARLqa+uArrKMuM4r3HOFNJecOudAWCIYCkEYH1pyz9pGIWTMSYINee5+8XEiDv4bCjVnYVP5Zdipy9iG94b2yx61btA2pUMh5Z6mucW4GnEuJxySLEnZhRqeTAbyxTmdFV4+7qZtmGndaz00lxbXzx3KuElk/phznT5j6U+Kck7Q8bsLkidrSS3V2TUNLGEDBHlmkEX3Sbjqdu7MV7qllyF251poNdvCXm04UZ8j+1THB7bi9mZraKGK4yGlULgSfSnxSq0GH4JbtZbe0lNrK8rdsveHdLezyo97C84n2TxqZEYDtQTnHxpoll2hjQ6cR74xsp8KnLrsrRooGIdh+Ll8Kk8gjYotuHm3t5YEkkXB23o6wFtEZrgr/W/ArNyx5VTHcuCtq5y+nnUbeJ5brQ1rup1Bs4HwoW3diK22U8YtdU8LtJL3cAJHzO9PbUYgRRpHj5GglkSW4ljeMkjyohzFHbqO27ORzk5Gdq1XURoxvRRNw2Rop/xSaiCpAwxqb8NIkjUSan06nXy8KZtdwx8PScamxjJrsM1v+OLAMg5itJtdg77FR4TbwWZa7XWzONESnAWho7T7rJHHZWpAZhkj+0++nS2SjUzS6mZs5oq3EcEuj8Tv8hQjN2N7KBbiCY5fU7AbeFWPODF2QXLk869xgJbov3dtUp3Y0NaOrASY3xzpZP2hJ6kWX5d7H+pCGRmCg43BxQKWsVvZG3TuhQC4Ubt4UWjPJIw1PpzyztVscCzzHcspAJONh4VlJ9B5AXD+Hxx8NvLoxF+6QQ2NfLwoHh0CXUEdxb26RjJYIXIBbxNPJYmgVzGWLHPI1G2jitoANiW5notW+VNGc01SM/f2sksvaMSOyP4PGqLVkhZH33bPPmKb3sYW6ZmyQRnFLTbtOQQhGltsULtErvQdM+XwoyW51O5t+2t4w/dC1YNMMiF8aevtq8lJu+RlE8Kj0boXx2ENnDGyyquSdh/dRESCN8889cUuubeSa/WXOY15eVGRtMjMBvv7KZu0M6L7iMsEYDBXLZ60qsLR7y6mDM39Ru6Dz/amPaSAjP4T16V77yIVYRhdfjjpQTpUNFr2SbhCWUZZ3ByO6oGwoDTnQ6Dc1ezieHtJXZnB8a4W/pR9N+Q55+tE0qfRVJK1tiUoW0+G1Me1F1ahgNMfP2eNDhe2hK6dhzGM0M5ZY5rdDzwMU0XoVbFrMhDa0MgVuY3oG84w0VxKqRgKi6QeppnJEljbqus6jvvSsRmcSyFVK884q8KKqjqk39tIyRjtVXZRzJqpUaJbeGRcOBnA5edUW97NFI/cCI3IjrTO3m/8xumSw5n603FrQUqGPC3S6DxKNBA/E3X141b2SF01fiVufjVMSNawws+7vnJArzXHaszDZUGyiueSt6Fe7oukJa6168Z2Cj18qq4hCZ40CYwOYpdeXkaSoruysTkeNXx3jSsqqcjPWjxemCn2HzW8sSx63LFUAHjmgxHO0KQqh1aj/UPjRn3xPvEascnlkURdXCOq6cdwZPs+lMtDJ0CytPbI9zLICGwqALkKCPH9aIt5DaWKO0RWT8O25omVFjggRGCA7YxkeyrFtw0AjcglVwrD8JH0rn58uwyqiktG7oYdIVjyQHl66UU8afdlETEMo58vdQhvBGrQwKgZSFYsd8/WmKzj7opU6pG5kDmfXShPoWXRK31nQrJp01TMGRnJRVDHmo5+P8VZBdpqC5wcb59cq5dzFlYqcjrSrsmSwiwxx2wVQRkmr42L2b9ogK+J+R/elcUpkUZ3A6jYrUpL6OG7WGNy8WMYxnf10pqvoo9hUzdtFAiyaLmE5wp6/WqredxdNGzEFenQ1CeNtpOg7wNdhmW7UsCQw5/ShWgOSovlkS4DOhBZDhhnf3/WrIS8c8cjvpZ10lV6H9DS9IpPvDOjYwd1xRodSw2wxHSgkCOmT/zB42W2iOV1ZAxyNWXM4gKytH2hU5A5j+KEhgSK9ebOVO+fCrJZo5O6xYjwGx/mmemmPLTQNbStfXAQhBLLJ3lzinF7w+ztmEOdWn8QffOfEfpSPhNraWfHjfszSSf25PdB9lGy3VxPfyyXbrHGT3Ex06b1dSio/wClV1Y4nS3htUljRCVUd1F2x448KiL9JDFGzBQp1Pq5Mvh+9JrRpf8AMyUeRueR0FRtOIGaNUWEswkKuTzG/OhuuSMlYZNaQ3jTPJCrx6soCPlQccQ4gjwrjsY2xpK9R4U2FzKkTxAIEK4Vhvt7KDsw8QZUCgn8XSouVgb1oplRUOp3GMbseZNKpbgyyBIWyX6SDb+ac3WlQTsWJ/CR6+FIeJXFx99s4LW2xCBnWnT9qbFsSNWd0PJKIZZi8mNONOn4UdZWP3G3l7hACbDmTXrmKTQr9mcrjvdcVYeJyEIjA5558qNuzdsOtLSN7fSsx1PuySc80MLZOHXStGqLjIIPMUxtoI5IVdco4ztnOasmZXws2l26ORvQcgv/AEWs8Szo3aA/6hVq2NvPcJ20Xao3JsZ059c6En4aXkLo5A8KJtQ6MuhyMHlSKVbFUq2KLnhtzbcdktY0L2xXuZ338PbR1vAOH3aR6jkrhschTlbcvOJe0wcY3oGW2YzSO76gTzqjnqxpNVaKuyT73/TbIOWIFCLbPfcRdWOmCMj30RA0cF53QcedWzQf1HdXILbbfOlUkKqSFfErW1SZbu2OoY73jVf31UXUjgK2+aK7AQuyatQfmT0FDz8Mjmz3SoXlvVdMfTRaEkEqyJgbfGiprcyKXIDE/nUojClusf8Ad416Wd+z7GJBuOdRv7Eq32Dw4NhLCzDqPZQsMsUSJEshLA4JxXbaOWNn6b71XdRJJE6QH+qarfpjLvYdHdp2/ZhicdaYpcxQ2cmhQZpf7uvlWZtLG5cq8h0sNs0Y8mUMTDONt6F8XoTJS6JMZg+51IRRVu4VDsNuhpe8sgXfOF386KtN41YkkkUr6IP9C8oY9ge91q6JmihRV3xnSBQ6qwOdsc6uD5XSaQaMmRFxthzn2UPNqkVlzsfjV0sfcyp3/WhoFLIeZpl+ga3aBjqSRTIcAdQKuiukVcFSE8qKSJRqZhnO/soT7uzyldwPCnuzXXR2Zllj1YKoor0F3FhYxyPnVpTEJjfJz0x1oJbSODLL7s0B3+h3ZxtpZTgA8hyNWyShI27v9vWqYdSx+zxqqWbXsc+JpBUyUeG77HGKoZVIZs/izyqxyDEVANCJqR9ByRTDIJs7cPNpLZHhU7myZySjBVUVXHL2RzjDnoTVk1yGVsNvzreysaKrNCJezZj5g8/5qEuhJyRv02ob72IpMEnON6lKwMZKnvGmcdizohxKCO6ttWMkchQMNvosxBJzY5wdqsgnZJir509M0VcQJcYl3zy25VRNrTNDTqQou7NnmiihxgcwalA9wLgRGJdIGOWaNjiaMag3dUda8GeNS7/3HO53+NO5+joc4rRK5mMiRRkYVPXo1Vft2VqXRcsTv7audtSB8bctqlJCulVIBGM5xtSJkm09gKWqyxdvPG2sKSM+vlUIhJHbdsU3YcsdKZysjKI8Dl8vXWo3MqiyKqCfZsabnejRl6Zn76VwRpPeGM0fb3KtB2bvlyMevOl0dzCyMpI1Z68q9DIiM8sn/pUVVR1RZws+xt/h3xB0Gqe0JI2y7bf9tXv9hOJBEUXFqdByCZGz/wDbXq9XJxRP0B3X+HPEndXW5tFI7uA7Af8A21R/+nHGYZQYr200nYhpH5D/ANter1MkqF9BY/w+4m8Qf7zaAjc99t/+2oxfYPiwOlrmzI3Ozt/xr1epaQjRdH/h9xJcr94s8NkHvtz/APjyoC9/wy4myARXNmjg5La33/7a9XqeCVjxDU/w/wCKyRKGu7UbDkzf8a5D/hzxO0Pdu7RgSeZb/jXq9QpUZrRYPsLxVTqW4s9x1dv+NSH2D4mxaR7m1LDGMM3/ABr1epFFCxLU+wnELe2kIntSzNtl2wP+35Unb/D/AI/KXH3ywVCCMB3/AONer1WaVIt7DrP7CcSiu0JntCjKMr2jH/8AGmcv2Hvi347MgcgWb/jXq9SOKCweH7BcQizJHNaqxOk/1XP/AOPKuv8AYS/kQES2iFTk6Wbf/tr1erUTXZ2T7E8RERVZrXI3BLt/xqNt9gL+NS73FsxYY2Zv+Ner1GEI30OipPsPxM3G81noIJ0h26f+2p3H2Cvy2pJrQYOd3b/jXq9U2lyFl2dX7FcUNtgz2e+34m/41BP8PL8umue0Oo/6m2/7a9XqelZktlyfYjiMUjMs1rg741t0/wDbXT9juJknVNaHB/1t/wAa9XqSUVYr7OSfYviUg09raDbH42/41yL7E8Tjz/XtDjc/1G3/AO2vV6mUI/gaCv8AwfxIL3ZrUbZ/G3/Gg5vsVxYggXFmMn/W3/GvV6hSAwL/AMC8XEykXNlj/wBbZ/8Atq+L7C8UadtU9mVxn8bZ/wDtr1eqihGuhktFV99geKlCYriyVg2ASzcv/jVC/wCH/GSgAurLcb5kc/8A416vUIxVDeiT/YLjKlCtxY9Ocj+/+2pv9huLMCPvFn/82/47V6vUeEfwk+yEH+HvF0lJNzZH/wB7/wDGrJf8Ob8yKyzWYzz77f8AGvV6s0qB6Lm+wnFEQgXFnkcjrb/jQh/w+4oW1febPOf9bf8AGvV6kSQrRxv8POKOjIbiyyOR1N/xqUH2A4qiAfebPHP8bf8AGvV6i0qEpBp+w3FFUZuLM5599v8AjVY+wvFRIf8AzFnz/wBbf8a9XqZQj+GomfsNxQrjt7Pf/e3/ABqofYXii5Ans8kAk62/416vUqig0WD7C8UA/wCvZ8yPxt/xqafYXiPPtrTfY99j/wDjXq9W4oVJFU/2C4owGm4sx7Xb/jQr/wCH3FSpH3izx/8A9H/416vUUkNRbF9geLCMI1xZHp+N/wDjUf8AwDxMuCZ7P/5t/wAa9XqDigtKyw/YDiICgTWeP/W3L/41W3+HnE1fP3izzno7D/8AGvV6iooKRV/+nXFnIIubIb4/G/8AxquT/DviuQBcWWN+bN/xr1eo0iiRVP8A4ZcWOrTc2IO2+t/+NWW/+G/FwpV7mxODgYd+v/tr1ep2kZnJP8M+KByy3FiCOffffH/tro/w74yMZubE4wf+o/8Axr1epWlQDk/+HPFW5XNkNwT3m3/7ajL/AIacVZMfebHbxkf/AI16vVq0H0dT/DjiyRKBPYf/ADf/AI11v8POMDc3Fie7n/qPy/8Ajzr1eo0hfQOP8NeMtK+q54fnfcO//Ghk/wAMuPa9Bu+HkEY/6j/8K9XqdJWUXQCP8HeMGVpRd8PBByMSOP8A8Ksj/wAJuNIjl7nhzYOQe0fP/wBler1dD6K3o//Z\n",
+            "image/jpeg": "/9j/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAGGAiADASIAAhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAABAUCAwYBAAf/xABHEAACAQMCAwUFBwIFAgUDBAMBAgMABBESIQUxQRMiUWHwcYGRodEGFDKxweHxI0IHFVJi0jOiFiRygpJDssIXNERTJWNz/8QAGgEAAwEBAQEAAAAAAAAAAAAAAQIDAAQFBv/EACgRAAICAgICAwADAQADAQAAAAABAhEDIRIxBEETIlEUMmFxBTNCUv/aAAwDAQACEQMRAD8A+ocW40kaHvDlXzXj3GjMXVW29tD8Q4vPdFhrYDOcH9frSaWJ5Gy3M/H+fKvIX6z0+SiqQHLMzserZ9eutUkHTzxz2A9fCjRb45bn2VE25GOR36+vnT2D5ELtw3MEgZ39cqKjyB3ix9et6mLVmfrkeNXfdmGMZxjp6+VZyD8hFXIxzz6+dTMmRhj7ue30qz7q6gbGuizkOefvpLQflQLK4weh8+vrxqh3JbcmmDWTMPZmq/uRG59CnTQryWLJGBFDO+pueenjTeSyIzz9/r50NJw/G4z5U6mhbFpLDn+dQZvAn2YpkbBj0qL2BycZPmeVMsiBYqBO4ztipBiDsfZTIcNY+Rz0FEQ8I1MccwcUfkQOQoycGpByDjl7KcDhR5FcV7/KySDvnkD4+vGj8oLFBZsE8ia5k5HMY+dPF4Sc7Bs56VenBCRnSTny9bUPlRuVGdBbGMHbbP51fFGxG25I61o4/s+7EnR76Ptfs42QNPlSPOjc0ZiOF8jAJolbVxjPwFbKH7PADB3oyL7PKWxpz86R54g+RGANsx20+yuixkOe4c4r6rafZGI96Rd6MP2Wt9Oy77nlU35cfQ6Xs+NvZSrgaTz6c6Ga3ZeYORX2G4+zKdU7o8qU3n2XhYbJvTLykzPR8raI68j51S8bliBua+gS/ZkK4YjOPGqB9mVeTlnOTt0FP/IQFK3Rh1hdm1MMUYkWCNuVa9fs6hXU+ABuSak3DLO1t+2OWbIVR1ZqV50Xjjk/RlRE5OdsGpLBNKe5G7GtcnD4lTW6LgdMUVbRYmlTs1jiVRkkcqT+QvRVYH7MbHwq5Zc6GA5AY3+FSl4TNCQrRlm6gb+6ta3dZhE++dyOZ8s12OMKT2smJW/sU7j96C8lmfjL9MU3DZgdJRi/kK4nDrhjkxn219Bfh7mIRKW1vzwvL14VTHw6KA4lJLcmJO1N/KaAvGT9mSteBz3A2TCjxFGf5G6g9ptp/wBW3xrYQSK7Na2aZI/Ew/t/eg7yze4kP9Xs4VP4s95vGpvyZDrx4mXk4Yqg6CD51S9n0Ix7PXyrTpw5FVSkLyEjujwGeZNQvrW2tk/8w6l2/EqEbn2/rRj5L9iywfhknsPAd318qqa1KYwKezzRuF0DC9AKGEBfoQAeZ5VaOdMhLDJCtYsbYx0xUzEpG4z7qYtahD5daisSatI5Z5inWREuMlugB4uVQaMgY59d6ZtbkrlRt7Kpa35j9NqPJA5itoznGABzqHZE7nFMTCRzFUtFpfFDkCUwNY21AdPOutETt6zRPZYBOnA57CrFjwNwK3Mn8gIEwNxtVgjXOPLrRKxYBIQee9SCciBv5UOYyyIhCTEwI5frWp4PxHs2Xw5cqzfZ4OQMHriiYXMfPao5KYedn1Gw4oCow3TpT624kGX8Q233NfKLTiZix3ts+NNoONsoB1493r4VxTgzfIn2fU47tG61aJlI5181j+0bL/ePw+Prar//ABSwX8Xxpakhfqz6H26eNRa5jA5ivnrfatwMZ6+vfVf/AIpbHecY8qP3DUD6C17GOoqv/MI8Z1Dlmvnz/aRXGdfz2/jzqiX7QZOA/nud/wCanwkG4I38vF41JGoUDNxxFYLq8ueN/wBKwEvGDj8fw+f8UE/FWbfWffv/ACKb4WxPkXo+jHjSn8JGT5+vhUP80VtwRjGTvnb6V8+XibFzlvLHr86Ng4hlgNWd9vb9fzofEMswrW3GfHw29fCovbLpA6DbyolCp659/r41xsHxz88/Wr/IyDyME+7DV4kH51H7tkgHl0AHr4UXpAHlz91dRVOQ2NvP18aPyMX5GDi0UDkDt691SW23GTjrv8qIAOdPPfl5+vjVkajnkc8+vpQ+Rm+QrW1Axn1+9Wi1BUch7vXwq5cDbpjr4fSrM7c8Y8/h/NJ8jB8gIbYDI0jHr1mqpbYeG/X20cfDr5evlUHUN4fD1tTLKwrILHt11d0ezb18Koa3TV3Rv126frTVotWSfePyqhosOf19bUyy2N8tC0wAcga4LXXtzPKmRgyMDn5evlUlh3ycYrfKD5gFbNdPIHb3YoqG1XJyPj6+dEhPjn176IRR7/XrFH5RflBRZam9/hvn61bHw9dth4Db18KNQDT6O3r4VaPM+3Pr50/yGWQGWxQb7ev0omK0TOdPrpVoB67n9frV6d316+FSlMPM7HaoeQ+Xr4UZFbKF5AfT9ajF0zy8T6+dFxnbcb5+f1qTmI5nEgXOw9dP5prYWajc748qBjIDdKd2pAXH5VOci2J2y8RgDGBXdIqYIqqSVUI3pFI6VbIyImk6thSi9EEIOph7qpv+NArphPNse4UiurlpphHIxLsRtnfflVIpnXj8dy3ItvLmLTlRzXI9eFKppy0ngq+XM0dFbm6cu/diUYXzFVXNqzMixIQreWcb/wA1TZ048WOL6FLF7mZk16IhzP50TFbJcSxTKp7JF0RA79Satv7YWwWNsHxHLboKb2cMEdpGHI1EagBthdtvjTIeX6CW1sdDh8E7M2F7q+AH1oOaAoxghiIfGok9CeuPGtCEM6kQxqoB758PAeZ8qpu4wkbtCwLtzZt9Rx+WPhWehU7ZmprUmPs0ZhjZmHj66VZacJMVs7rH3jvrY/rV9rZ/e7hRLK628f4wv93jv+taSZYJIE0DEX9oHh4iilqwyluhPHDJBCDLIDIwzt09dKT8SleVvu1vkaSVL45t63NF8cu3kxDaJJrZsal3J8h1oyw4bClqsCRNJdacs+dlz4mtV7BdAPCoHt4TDEgJbdzjn7a9MpVi8zMFB9g8h+9PYrNY42iEikse+x29frXOIRJBEHbSiqM6sb5P5Vq9s3JdIzst7MVEcMTDcaRnr5+dVxWYlw1++uTGNER50UljJcKDChCj8WroPOrTZtAhU4JPXGB686HKjcUDrZ8ND5KDtMAED61RMtnFIWZQZcZCl/0/Wuy2dw0p7Z+zjH9ifjb39KJslitoz2MCIx/E77lvXhWX+sP/AATyWtzdMuVEEf8A/Y3M+QHjVYto0Vvu6rIBzcnZaZXEvbSBXk7QD/SuBj6V6USOgSKBIVxpyRk1uT9BcV7EghYyHMiqPHVtU3ijYfjBbyom5tERdtOcbud2J8PKl8jrC2dWTzOBk4q0cno483j89xOSQjlihmi72f3q+GcTA6gMHxq8xAtjBP1rObPIyqUHTAGhAPWvCHcDn0o1o8dflXhFsTj9dqHMhzBVi93uqXZ0YI9jt7ia8It+XWsph5gmjA5beZqJXVzyPX50YUwo8/L18KiUwdhtW5jLIwYKc5G46VLU42DZ9tXsu29V6duW/rNDkNzOCRwy9ff1qSynYZPuqI2GknmK8Rt9T8P5ohUyRZjg5yPPlj6VMZdTk7jb19arQdORzirFGACDt69YrDLIRbKsCDv69Yqsk8uY8qIIGCT69eNQIAbf0aFm5A2p98+/Pr514k7DfPQZxv8AWrynl8PXyqpl0jVjbnyyMfSjYlnFYnA9evKrUdvHHr8vyqjAyc8uoqTnQxA5eJ8fXxrV7NyGy58fgPj/ABXcg8qgGGk4Px39e2u6upbJ9evOuYjZYCMYI610c+vr1yqCtnb9PXwroxjmBTUCyQIzsfp/FXIfEn3+vnVI9p5+vfUw2D093r5UGYvB8T1+f1rofzz7PXyqkNt69YqWefhkdfXxpTF2Vxz/AI9dagTk5BOevtqsscdf3+tc1ZH0FCjEidtufs9fCoZB2z7/AC/UV4tsQfLn6+deB235536b/oaKNZ3pn459fOug6agGydj69dK6TjbbYevXSiZkwQSB+Xh191Wq2NqGLYbwJ9ejUw+c0UKGK4A6gjf151NJMHb168KCEmFz0+Ix9KksoI3I9/r501jJjFZNs7cvl9KuR/Xr86WCbBHt9e+pifB+X1/ikY3IcJLgjx9nx/irluBgYO2Pbt6+FJFuTnPT2+vjVn3vHM9c+vP86nTFch4twAdz4ev3ptb3yhFBO/KsetyS2N/XOmFtKxGdW2PXurVZfApSlo1R4iqg77eVZ+fjEsplZDyGAa9E/bSLnONG4/T96rjtU7CQ9Gf600Y0e5gwqP8AYVJMSodgQvr51C1c3fEFOTqkcKMeGRn/ALQabzcODxyRIg7649xpVwwPDxKeZsBQMR+QG35DnTx09na2nH6jm4Jj4jHbxYIxkDwXkKvltAmCDiNANx18fpQ9gHuL2WViQ34RmnjWyyoi6tlxnbnVKvo5pS49mQ4lC0t6rsHMY7zAD8R6L7T+VWWZkup2VHXbmRyz9PKnc9h2haQMeoXbOkevW1Drbx2NuQmzyc89OlJ0yikmg63AS0OkM6xju/7z+9AujqGll0tI4wuDsmf1NGcPZnlwR+Ad3pz6nzpj90iYlTgjctjrjp7KrVo53Pg9mahtMsAWwm7Njwou4m14ggbs4Ih/WkP9o8B62q7iS9kpKEITgr9aWW8hjykAzpOpnY7Bvf1/OlT9Mr/ZciC2kbzbHSnh5e31mnraYYWjijOfZtn61zh9iiIsgfvDcEjGTUb+XsI2VVDYQgk7D4+sU1UiblylQrjkxcuhQHfZmHXrgUR/lEEshmca5M5Jc6gM+Xj50O6CIE6grHn3snPtoqxllXcPsT72P6eyhBjzTq0SlaKBirlwVGyqaTy31vAzSMFQ8v8AU30pveoiRlHZUdhnYdPZ6xWflt4knR+xBI/ubvY/fzoOxo7JK095GXhtlVCMdozHlS1rW7jkK/eBjqI05e/9adzXsyDTHEx0nBYsq4PvqtJJo2DNAMtsveZ/bgn8qCoNvoWpZiOQu7SKSeg1Mf0FFSvbdisUdtI+RuXBY+/n8K81xFPMziKR237xwEbf8qi7f7RHkZYBsH+fOhtDUmJbyxF1qXsJcY2AkCigU4UqS6Wgu/aV17+HlWvtkAXU0cu2/IZPx/Khbq80jWySRKNizRbfvTJ0IzKtGsDYMZj322xRkeGTIO2Kt4lcwyRa7URy5G/+qk0M1wkpzCUPSitnH5PirJG0NSB1rmCDjfn78/WuoxkX/psD19fpXeQ9Y/ilPCnFwlTOjOPpUQOeeWPlXc+XxPrfzrmdTbePMevlWAe2Od6ixA/P317I5nn69Yrx5Egjl7sfSiayl138jUdhtkVbo2xj4+ufnUW+eenr5URkys522PP2b/WokA+fmB6+FSBHjt+n0rh659u/1ohs6o7o9nt9fpV2MqDn4n18aqXG3P8AX+fzruvG+w68s+vZWCXEYHXPz/muFFwO8PL14VDXtp6Yweu3rrXi+SMZ+PX60DWcbOo5GPb6+dUse97+ecejVjP1xvn1/FUMw0n+aKNZ1snbkfZ8f4qvO/IE/p9PyrxYnO/tzUSx1AY3J9/80xhumoYz7PX0qWcevW1VKSF8fXrepBjj31zindRDADHPfPh9fOrQxBHXrtVAbkD69eFeDYGevnTGLwxBxsfdUix/n186o1e31+v511c7bjw/j6UGAIyduv6n18a8G8CMeQ9fCqi2Rz6e7+K7k4/f18aUJcDqG5GP0rp2wevt3/mqlYkdf3+tSzkfljwoGOlsE+vXsrsfeA3ztjb1uKgBz6+3186mgwN9yT19bH86YCLGAHs5+XrzrhTBxv6/WvYywO+fL18q8eY5Yx8qwzKyvgfh6+VcwBzqxgSB4+fr51HGCTWEOFuuf0NdBG3j5evlUCMetv4qQyV5ke3186JiYbPhj410nc+vXtrqjHx9e+ub/L1/FAx0H4nw8a9r89uY9eFRwTv0/SppGWfHPesZK2XwszrgjZfXOm8ULQ6ixymPmfyoG0Tsm3B/FjHr8qYxyPI3ZsNOSM0JHv8Ag+PwjyZOCbsGCopY4JyN9h0plbRg2UaE5OsjPiOf60ohniguOxcjWVYrvvkZyPhTPhkms95STrbblvyox2dk1Wwt1bJKk5Zdj4Uo7JTxVozsFVS2fZsB7+lP2j1MkYwMjAPr2UsnQNxSR9GrszhR54wD86ZxJwnugcR/dp8KdGofhPMCnVnG7w4kbY/iPmayt2lyLprhs9nqOkewfnmtbw/As41YbkchWx9hzpqKZCVNL61OIo1OPM9aR3VxJ95UuqpltgeYH8fnWjkXSwXA7NQGJPLb9KzPE0lv5gyDEAYksRgtjl+tDIqF8d2x9w6JTDrXrv7+lNFCgkEABR3vIeFJOETvJGFK6COlPHwkG4znfA3zV4P6nPnTU6EfEZEmZiV/pLuznbHlj9KDs4kup1cxnQozGp5DzPjRF86RxJbpDqIOTq/CPaev1qy2kU4CtqbmTy/ipf8A0XjqGhnojgTSBqY9796CuikMJkmRh4JjejIpMNkj5c6EuohcTBjuw5D9TVpdEYXexRcrrn0JbAMBq05/CD1x+lVSySpIlvGVMhxluZHrxpr92+5wtIArXDHctk7/AFoS2tGMjuRpnl5lV3Udf4qXHejojPROOyhjjV5y8jodR697z8/lUbsCK0ZuwYzMAcjb3ftRixFEIRNCjYuRgt5DyqqKFHnR7lstnKJzCnpnxNHvQvL2ILXhs9xM0t0MJzCYzhfPoB86ZXM1rCrRxhZCAMxxjOfaf1o+9WQkJGj9mpyXIyfd50luYLjt9cIKL/b3ggx12559taq0h1LkL7uW+Gf/ACEiL+Adnsc0NFC0jFpZJGOebdPYBRtykzIcW88rsukkS9OgU9fb0r1rFHFAwkt2HLU0hLEe2g0UUidtG8aB0uZjEfxdpgj60NfyWzRv2jh1U45fn5+dUJHJFKTDPmLJ0aV5e7xqt+F3FzP3XCyHlltIPuP5UKs2uxV93tJpsW34z/amxzVN2kkOAihseA5e0VoT9nhbIryjsph/er6gfaPCgRb9tdCGWaPA5PnBzTAdMUw3zv3Xi8sj186KDFl1cj8Dn60fd28VuVVNLPz2PP3fpQTSBz+DT5c/Q/Kg9nleX4sa5RRHHl7hUGOOu2PXurzHAxke/wBfOqi2+/PPvz+hrHl0Tzt69e+vat/H3VSWxgjz5evlUkYEHbp691MaiwHby9esVW24wa9kb9K4Cc7eNYCIELnPQV4Hbbn5evlXTjyxjn66VWTj3+Pr50QnS3T1/FQ1b7nBHj6+deLFt8c6gz4IPuomLu02543qsydNhtVLtkDfAI38KiSfj5+t61GstaXPX1661Evk46Z6+udUB9+ePZ6+VeJ7uPLHryo0ay3UM8xnz9fKo6sDIH8VUSB5+ZNc1efI+vfRoI+Vs/6gelTGM77ioAbeyrANzuefj63rkETOHffr69ZqWnLZ393rnXdOVGOXl6+Vdx3emPPlj6UbGsioBGAdvIdKmAQOuPXrNd04O+fX614DPTfy9fKg2JZw/i6/lXc+Xy9fCp4x66V7A8NvM+vjS2ayHMeVSFSIO/Pn7N/rXCNvL2evhWs1nUz5+757fpVq7j9B65VWOW/z9fOpg8zjfPz/AENFGslkeWPXy866Nz1z4+uv51AH2+6pFuYznb166UyGs43L1691R8yf4r2okk4Pr1zroG+d/X60QFbKfA868p2+nr5VYV26cseX8VDHvPn9f1oMBNT7h5V4nJ9evfXOQ8fb6/mvDn69e6hYESB39evrRljF2s2CRpAz7vpQ0cZbpt6xTmKzNta632ZgV9vrxopnZ4mGU8iKZZDLb612ZCFY+PnVltdiR0KYzgZzt3vrS8TlO2hGWXmCPb62qdraM/fXUM94eG3OpN7Pqo40kMLi1y8Fwq4IkxnT+HpRfDpXW9IKkBlGx6ePuq8qZETlp2O/UeutWy2ub2ExgEoSTjz/AGJpkmuiMpJqmM4p9UqY8CaDgy/E7oAfgYAE9MjNd+8RRzuq94xrvj5VdbqqOwCglt2bxx41dM5araFssQmuZJMMIIVKqDtnzHl+1N7RzpXVkEbYqTQgqGCgsTsPGl8d4BxAwA5wDlhsAfCh/VjXzjQ2lPaDQdlPPzpTewu0mtABFp04A5DpgUxjPaYB/Dy5865doexLgADOQW+VNJWicHxlQNwmDsGKknUTk55486Zzsxzgnljfp4n20vtX7MBnJZvZiiMuVPaOApOwzufGtF6oXIrlbFU6Ga4VWzoH9ijz6+HsqNm5WdgwOfIfAez50XxCdbSJVjQiRwcKvP25/WgbJJyC8i9mM59p/U0lVItF3EbpJoGtyMk7D2dfZ51baplDJuNW+W6f7qCDu0ywRRd0jMsp5ewUVc4Nqy6gEx15H9qtfshJXorllW5kAV8Ivh19eFS3jRuyYKMbuaEso9TkkaRzGKPngyozqP8AtFJF3seSUXxFUJkeV9DPLvjLt+E+HlTABlcHC8t25b+X0qqLAkCdkEjA2A5VOaVFYDLbn8QXUPL+aKRpMrRca2BVgf7jn9fyqhLJHkYupZiNye8asliYOuQ7BB+J2ycjr5GurKQjA6gB1Lafbj6VvYy6ISQW0al3LAfhAc7A/EChJJoLSFpezSFRnBI5+wD8q9LJMX7tizqf7tQbHwzQl4s9xIu9xBg7qGwPy+dBsaKFd5cxXcgYPy5AMMn3eFRi4Va30eqWWRcYYZOkg+Jptc2MrWf9krA9O6w8d+vspa8NxHZF5rbTz/C2+nrt+lBaZW7WgG7N5aM0ELzSJj+9Q2Pf4/nQMMEMsrfe2eNhuEKAg+zNPLeJRbMEjyeYIbO3TO9IuJrMkxfSZEUguo2I9eNMa9HJIFTU0cutRvpJ9fGrQ0EsOdR1fixnB/mupbW15AslrMNZ2aKTbB8vpUl4YAmmdGVSM6huP4pf+ksitC58asA593x/iqGfPl89v1H5UXc27W5Ckg5/uDZoI8/P4b/X86KPn8sXGVNESxGcZ8fX1qavjbr19tVk4Pt6gevhUA2Bjb1+lMSsI305Jx7vXwqOvC8tuo9fnUVkOSD+fw/mvczsfZt6+FAB4sud84z699RJ8/LaoEb9D51BlwfrWRrJlgBt18vW1VOc56e/9a6Sff7d6g34fl6+lOjWQBJPM1HPt5VPGF5fL1tUGTDZojI9nI2Hr11rhLZ/evDIO3wFebfp0rGoizH35qIkwu+nFeIznu/T+POoFTnYtz9e+igGmB22Bzn2ejUl5eXh5VEfhyQK6OfT4+vjXEhS4c99z459fGugY/Dmq1znw9nr5VJT5A+3l/FExYBnAx7/AC9dKmN+p95z69tQHdOfjk+vjUl2ION87Y29GkYp056+vXjXQM/t8/4r2M49evZUwu3IH3+vjSmPDkeWMe7+PyrhTb96mFJz45+dSCbDbxO3r5VrDoqEZ5DOfXrFcCHAPTy8PL6USFwMEfHw+le0tvnn5+P186awA+Nj4dfD+POvY38fb41cYz68fXxqOjHnRTNZALnl8vXyqQGB5fpXcfH16Bruknx9frT8hkyJXHtzz5H151HR6G3r2VesDE7D9fXsptacI+8RZO2ocufr20rdlceGWToTR2rscKCdvlTKHgkzt+Hpjf186e2drBZoupcup3J+X81OTiUSuY0/FjbA+NZJez0sH/j9XIHjsLe0iXtO8VOc49b/AJ0PNcRyqQ5xpBwB+XsrvELh3jCDAZhnl68aW8LtjedsJMgjfBPwoOXo9fFgjCNonw6yjm4n2OCf6e7dOf7/ACrUJZxW0KkbBht5nes1wiZjx2aJS2oQZH/uPP8A7a1UmPu6/wC0bDpyqkUuNsXNKXKjPJMDfQxQaljjwmB4DnTlJFjZjgKSME0saAwydtnOOePOpzRtJpXWccyRzz4VLkx3BMMtAqhnKgtI2SfLpRelD3VBHUnxoBZFj2YA7bAcjRmpXjyTg45U6eiU47sruL9bbnJg4wM9PrSl4QLqOVGXURuz81HTSo/OuvwWK4neQ3UhY/8Ab5+2iYrCMR9j2rghdORzFFW9BSjEOt7lGQCNtYXbOavuT2sSqSvPcgcvZ9KTWiRWs4tw5KgHG2RTZyFjBBA6Z9fnVFdE5RSlaKoXQ3GAQxHhv/NMlVAdR7zAbEjlSUzLDKJHKhm/CBtn2CmsDs4GCBnqfzo436Fyx9gt86RR9rMhLE4VEGon2/ShVf8ApmSc6WI/DjZR4Dxo+8bEbMmlT/cxOAPf09tJe0TtFy3aSEHHgW9o5e2mlRobQ2ttJEgDAoAN85J8vZXLuAzyKXUsF2UBvnXeG5EYJVC3XSMfKiboqhHTVsRj5+daStC3UjlpCAMgY28MVdcL/TwoPmPEeZoOMsrZaQ+X71c8ihf+py6k0INJAknysF0Kk7uGPg2cEZoC6l1SqxhaRs43bA9w8asnEb5xI7P/ALfniq4QkcZLKiEDcKdZPt+tG/wol7K5Zo8qHkZlXmFQbDyHh5VcLuNYwgmcKNtP4vXt6VGO4EoISJdWQNTsNXs25VSbMNKSxJUHkxBGeuwx+9azUEpOMuBlH8VYZ9/garMrAZR1bqAyn3jI/KgruG7JDdlpjU93sdy3kBvt+VVz3EscJJjMYJ21nDL4DBH/AHUvQaD24hM0RA0tvsyvnHt8vOll9dztausyhAvQDI8jj9aoteHpdP3rfJO/aIQj/I4z+dHzcLkaNVjc3CLyQ7Hz2P5VthVICivjJGEikhMi+I7N/bg9aDt5kkmZ7mPUgbSTpzjPQ+VXcT4cGiDRJ2UnNkc5B8x62oWwhuHEvbIrFRuy7Hy1fWsOmRaGO1u5Ee3HZOe667hais72Mja5v6ernn6143PZTaXV1cZABHx99Qjt7a7Ur2gQnkp5fxQ/6BnplS5h7SLdSDuv0/Sk0qMjaTt9P1FNJLJrfWquo0nffn68aVyai52/u556/X86yPK86Frl7KSCCTUBz2+no/nUzqxsMez18q5z8CP0pjyURJ37vr14V3lvt5+H8VIrg4PXn6/WvAYGRnn78/WsEjjO56VHp1znG3r5VPA/t5cvd66VwplTk+eDvWMVYxj6dK9p272+POrCDkk+jXmHe5593remCinGGA5EV5hhtvy9fCrjHleQx8v4qJTxPnz69K1oogfSCTtt511hy2BI8fXOrSu+1QljJA3Pu3o2YHIxVZI5fxir9OdyB7PXSvMp3HP20bFZoFB6g5+efrXtP7eyrQvXbH6fSvAbnb5+t64hWiIXIOfXv/WrEBBzvnPzqSrvy9euldC4HTTj5UQHiVJ5KPZ8/wCK90/fNc055gevXOpadxyzn176VgOgb58/H18auUbAdeXn/PlVSry9evZVwXA6evXOkMTUAjpjHu/irFUnp8T6+NdjX4/A/wA0THDn2es/xWoKi2UqmOm/r51LTsMfL18qL7HI93Xw+lQeLxHtz+v1rBcWgUrjOcaf0qDR9Mb+vWaK0EDGOXxz9agY874HhitZOnYKE3GBvv6/aiobbUwyMD5Y+lFQWZK62Hd26/D+aJ7QRZQIWIGoDrmmVno+N4M8m2St7JCy5OlhjY8/XnTX/wDbwkxDOMkgczQuteyYt+NdwQOXrwq5HzFqyCp04PkelOtHrY8EcfQt4rcNAYmXJV2WP4mgeKK1ncpJHh9snPLFE8RBub2GAtlRKrfA+t6jek3VzdIFJWNNOw5tilatHdB01ZLhlwb+FmbkAASef80wNoLRSsS4Dx8wOXLalPB4fuFncd0hQof2g09tLlL+1TS+ogc+pqiRObaeuhBYwdhxSWcZPaKFznwPL2b09upTHa6mO472PDfaqZ7TsdZQddj4Hwoe/kJ4Y2M9o4XBFJuthdSaZTdX8hg1JozjOfz2r1hxFZlC6DgjbAOKHLQzWZQOAVXBfmT68at4Wn3aQkHC5zuN8/Wh7KUuL0FmZozj7qxUtjcbUclwpjAaMjPVahcduyh49BbGMAb/AAq1Yn0KxDbfixT0yMpJrYC7GO5yDpU8yen7VXPxGAXQhMZ1sMqwOM1bcqJ42k15VT3vP140FKLCa37GZoyxOVzzPs8K0dSM6asou7ia0lEvaFmdsaV5DzPn8qd2MsdwiOcFiPn+lAzcNs7i2CyK7YXukNg491WcNEETGGMNpXbBfV69tVVpitpx0EXUiq+VEYJIwSM5Hh7KKilYYDNjlVU0JZlPZsQDnvNj0a7JgoCCpGOimlapg01QXJJGU3JyeuP08aCMpbZAq42OjvHHn9KMQgw5KqRjrvQwyshVYwif7e5v51VE0iPD5Jo7h0f/AKDAENrOR5cqYzSRLt3dQxsTjf11oGJmS5UFgEz1xz8vOiZoYLiEpMNSDlgfLzFOJJbspZ3eTvMcDfA2qOBKQcDA6Zz6FUTuIFYJAzIvgcHyr0UpZDkE77ZGk/LrUlHZT0eaFPvXeTl4Ntn9D51ZmMqO4VBO2MLv+fuoN724sEJ1MxbJwQNqjBeGdNcyYbbKjOGHj+9UVIDtjN4VjjxCqsCPwl/W2/KqVfsY2WZotv7Qv9vn5edDqjKSy9pqH4SD++9WG6knl7KR1wvUd0g+/wDLlTUmLs4IlCM0UWA3exqK/wAGqFijMJIXub7nvevZVN7f3NmgERMbDfUwDI3t25UAOKXSyB5m0h/7wDp97Db30jpDKxpJpjgDRPo8QjbMPz+lKf8AO5reQwvIG35sc48iRjbwNMTZRXCa45QpbY4Hdz+WaUX/AAeZGLxwylWG/ZEEjxIHh5VtsKobfeLW8hHbSgs39hYbnxHgaTyR3EVzojV1P4hjfI8R/wAaDtriSymCTQpKNypIK/n0pgbuCR0ZX0tsTHL136NS8aDdC+4aRptF1bkauT42YeBrj2zfdysY1b9TgqfrTjiMy9mJNJ0DbOORpdlJI3bvLIv4SpzkeylGbtUAySSdloKHtFz2bkb+YpcmmRWOkow5jn/IrQ2Z7RSk0YLg/iHhQXEbYJOxMekk8+W/1rWcHktqFS2hSU72wGOeT6+dc074wRj18aJ0csfL6fpXDHtjxrWeJ70UaRt8vb66VwrnrRAgY+vh/NdaBgM7+VazAuCNsfHr68a4QSNuZ8NjV+jbHP2evlXAupc8h57j150Uwg+nbyx09fKuqvw8/Xzq4xfp69vnXewOnJ50bMlfRSFJHr1mokDoMDflV7RlRyO/OqCM5PWsN0VPsMdPHntUWwR+eatcZbz8Bt6NQ053A6bYFFGsq097ODv09daiwwR0B8PD6VeELHJHT5V3sTqIOdzpprQLHwTK+fX21YiLttt7KmIx4jHTw/irdGP3+v61wWAq0d3mK9pOdwefv/mrtI59fZ19dK4EGOYx8Rj6VrBZTpxgYHw+P8V4DJ9esVcV33Pz9fGoac+32dfXxomJY2+Hr966BjY+v3rg5j169lSA1EDbHny/itQ1F8IBO3LHhRqkY8ff8P5rlvwy8lAdIWK+Zx7Pf50YnCr7mbZj/wCkavkPyp/in+HRDG12VAYPUtn2HP1/OvDvHugeWP0H6VNoZV7rRsu39y+tvyoyysWlIJHXOG/X60nxtuiixOboCjs3Y/hGMZ35Y9fCi4eF4JD4BOPb686drarGpz4bVOJI9bM7DOnAFVjh3s6oeLCO3sVSQjRp048seFAyJ2cqyKo1cl8Nv0p1JFoiLjDyHOPAeFIuJLNDGmBkB8+ZozjR6eF+kUmbTP2L/hbxNXffQuq2j5h+nPfl76Q3d4UuI3PMSac429v57VfwwO/ELiXYplSu/LH6VJb0dMoJbGHaCO+Rzjblt1zv/FTuphauXQbTNlttqjctFJM6NthQVaqrdHuoyWLFUYLjH4vGmX4I/wBHE0GpGUA4KYP6Up+zrlb+aInTpOw8fGnZmjZR+EDbbyG3wrOTSrw7iYuHyqsx3Pt6/XzqjjTTJxdxaNTfd2MkDI8BWes7z79dSW5U6V/EDTQ3aX9qWibOrIyOY2/Okn2ZxbyXUkmnOSQR4VmrYceoO+wmXhgtEZ1PfxnB8etE8MgmNqXZAWblXm4rbPcrEWEjNgaBv8/CmgnRI+8wjHiTjTSqKvRpZJcaYrhtrsXiM6voUnukZx4b06bWCGTJ23WgZ+L21tqLznT0xv8AKom7ilj1R3BUhc4PPHs8POqxUSU3KXaIB9ZkGXhlBwcjHt/ikvFUtp40nEidqhyRnZseudMpZFubVmV28iDv7Njz86TTuq3DoTrJYb5xvvnYim4oCdDS2uhNCjQaJEbZg0o94PMZ86lYFVvZGJZWboR+R5e6k1r2kKmTQj7E6lcagvX/ANQptb6mCtJlkYZD6cEHpQdaG/R6VDjIwdti3LFTA/pld+fPJ/Ol1vfBZuxckFTjB54p0ume31JgnHQfHanSUiUm4g0JbJyRkNtjxquYAtqVtwNgF/cVegeNsuikEZyN/QrpUM5KkZHMH186yWgctgE8CSJ+KQFQCQRtj217712M4XGpDjOeQNHOwUBNQLHltjB8aElkaSEAlHVdmKjl40/H8NdknuBIM4RRnTtjn4ftVJlcxiJ1Rh/qHh9KrliInzswHP2dPdvzrz9np7MoWLNg6Rnf6/nSpWwvSK+80470ak8ldh7Oo+YrpMJbRNFCUJyjxE5/auG1XVG6yFWx3QV9ZHlVNyFMn/mQixscCVRjs2/3DqD8qtw0JyPBJEZXGkREaQxDKfZzwffVilh/TmbKPtqbvAj2/rQ0aSWUzB3Ywt0DZGB62aiZLuK0QOSSjEKW/DhvAjkG+RqdNjXRZY2pjZsq65Oz/iB8Dn61644fb3ClWRIpRt2kZ0/Ll7qU3d/lf/Iyskn4hp7yEean+32bihxxK6nhKSoHX+2SJt9vHPOi4xQqcj01vccHkBz2kbHOQ2CR+tEw3UV5HoupV1asxSo2k58M+NVW3Fw8YhkRpYydO43Vh4jofzqNxbwpJqijAV+eg/3eG9THL7odujxlkkddiuAHU9G9c6AWCCQ4fvOMjtEGx9q/pVUkFyJFy+E5JKp3U+zw8q8ksgmeHiSR61wO3Xu6gf8AV9aKWgWHgqYRpljPd0nO4K1nL6DspS8DbdVB+Hvpw4e1mLSASRA8xscUr4nCsTia3fMbbgDkR+3UUtew2D23E5UOmQZYdeR/nyo08Tju172dh7fQpUV1L2mMIT3vLyP1ppaWEMkbOjd7+5ScGknRPLfB+yoqOnLGfd9POoquW3559e/86JKacDGceHj9fKrLeHLDljHPy6+6pWfPS/tolbWpcju/D18qN+4hk/D092Pp+VM7K2DLy39egaZ/ccLspz5c/wCfzpGy0IaMPd8PaNs+HPf18aCEZzy3/Wtnf2gC4x8Pn+4rPS22JDsAPPl/FFTElGmDRW2r2ezPr2UYlmGXkCuPb69tWW6adj8zg+W/600hi1KPHPh19nj5UHkL4oIUyWowcjfO/Tf60tuLJU7y/IevhWmkgXTyzt7Rj6UDPCpU7befy/Y0FkDkiqM8LYN5j9KmtqOo9uT6+NMktsuR+3o/nRAthtp3PkM/L9Kf5DkYp+64/tP65+tRez1AYHy6eulOmgXG2MY+X6ipC2G3PmNuvx8fA0PkCkdEOD79x1z9amIfH17v0o1YMdO7y23GPp+VeMe2Ovn6+dcvM1C8oB+/r51zSR4/l6NFOnxz6/iqSAOXr18qaxSrSDgeXQevhUNO/l8fQqwnr69edQ/uHt8MejTJjR7L/uyKgMkqJnox39edH2FnbPfRAz5OoHSF60o4lCfvTkA8gwx4Y9bUZwkvE6u51EY5+Fd8ccYtWe1Dw8fHl7HtxFNK7d/CjljkB5eXlQws5RJqV3HTn+v605RAz5DZVu9jOPRqbW+OnTHL416qSaEWtCr79e2v/wBZ3xzDb7+vjR1nxaC7j0jEUvQqu3woHia4iJHLzG3l7vyrI3M01nN20TlSDnc7e/60rxp+h1RteKG8t7cspJyMqw3UjqazU1/fBlYMcf3Dw9eNM/s99rYbhhZ3rDEhC6ugY+PhR3GOCwGN54AVLpsByrzvJ8dw2jqwZ6fGSF9tfz6Rlj4AePrwqV7dExl3jMiKCSBvkVVaKJIOyfusuF3Hr400WF2tWGO9yx69GuPZ0uSTujGcQdSrEg4Dl9J9v786JiuhYy2Y7Mr2j77/AC9tM5ODpeyGXDDK4AA2x5/Sks5eSaHu/wBKN5EbPXB/KjFFXNNUMr2RFjZ0YaW7vs8f4oq0U2n2cgkkfLHv5I6N+lA3cYThrYDDWwLBv7T7ffzpzEEm4UiOABpwp5dMfHyqkY9k5PSFXE57i3WJkfZhhiT13/b21OADi1u/bZVR+Hbnlef7VZLbNccORWKlwMKPEDn7vyrnBR/Uuojk4xgfl/NGKt0Z/wBbO8FjFraPbvIO7nbfl9KV/fEccTFt3CrBFY9DyFEyxva8fdFYnVFqbfl5e2g+BKpW9dth2urV0OPzGaavQqfbJ2dr/lkP3lh2l03/ANRj+A+AHjRVnHc8SZTLN3M52PralfFb2QBtbIi8o8Np1HHvyKbcFilXh6EIhZh3tROSfPalcG5UNzqN+x5HY2cI15B8STnNWvHbIraIwjdFGFrO8RvVgZIO9IJTnATYez6UJLgqig3KtjkGJ+JJqsYrqjnk33Y+ttEbd1NIJI0shOPKlHGQIblJXdexdhjJyOXQ9Kt4fN93YRPJKNX/ANOV9Xsx4Hzqy8aK5DRNCW/uaMbFvZ5+VdGLHd2SnOgJLFY07a3f+p46tmHn9accOL6VDjQCN0I2z5Y/Kk9rbG3DGzlk0IcvBJ+JR4jPMeVN0a3A1JGVXOxztWeL8CshffwacS470Z3OCe79KacNmDIAmdtsZzj3/rQ5idoCdWo5xt651y3zBcbHunyqHHjMdvlGhzKGkTAcK3MZ29goNHEjMrqquux33opizR6iRyzkeH0paC0lwe0CN/uXun34/OruNkYMuLOswV1GByJOf5FRJEb6mUjU+x5YO2Afr4VKQ60aLvCTGVPLJ+teiKznTpOplLBehI9cqZRM5FMmpYQWGTg9z8J2zy+lQhNwIMPkherf6fpTRrIyWtu+klUPePUbbfnXOIpFbWZdGOV30j/d0qscTqyTyp6FlxMkS9gT2oxrGsgkD1yPlS+WZIWeLJMcg3BPI9PYfKld5dSxTPI8qgRvpBK8snmPAeIomeBEhjeSUYP4HHeGnwPXHnWataGjrsgb6V9aRxktGW0gfMeYNByzz3EKSwSRujIP6LnfzHny58xUJeNw20rJINgo3zvz5g/rQU/F4XbuaS+rUAV0gnx8j+dScb7KWddZ3BkhQaT3lORnPurkM87BwkmqQd7KD+4c/l0pZNxYCZlCCMP0zgD3eFBz32tzMhIkxltJ/FScfwJoEuY7hHnZ1inDY1ae6w/3URFduIGKMCpGZIn73wPT218+PErz73qJIj1aSRt8asi4rxK1u8J3W5hlG2fHHUeVbi2E333lJEcLIS67hc7nw99eGniJ0A5cR5DLyby/asl/mE00zyx9wqMMo5D2eVO+ATM8hdeeoMd6WjDWC7QpLbTgALGOe4xy+H5Utvomt7N5yusRODIB1U7aq5xRtHEGdVY6CEdeRxRPDo0khmR2JAhZfHVGRv8ADwpTCW3nEd2FchoJP7hTQQC2mUpqCsMr7P1FZbW1jdyWsoDwk5B56fBh5VquHx6oV7+uPwJ/D5eRqWTSJ5Z8Y7DhAHOrx/L6edFw2+ls43zXYVAIH5eufl1o6KMZAwPX6eXSuY8VxuVh3Dhgr8dh6+FPQiiPpjHy+n5UntmCd7bxyfl/NMRcBF5n9f5pZHRjVIC4jHscqc7dfXxrL3UY1ZH4s9Nt/XStFfT6vXr3is/db55H27j+POgSyFEexGPl9PzFHQTaRzHLx29efSl4JBPj7fXxqYkI5bH55+vlWYsZ0MZZc79SfYc/X86EmYaTt8B6+FUdqxXbGMZ8v4/Kou5O36/r+tKkF5OROMqT0xj2+h+VW7e7zP69PbQAkKN1zn2b/X86vSbO429m/oeVPRIL2yPHPIj1v+ddJUAAfL5/uKCaU6huP2+n5VMzd3fPnn1z861GQ9k7pwc8/f8Az+dUO3n7MfT8xV8yHAyMD9Pp+VCSKQSSCfLPw3/WueJRxK5G7pJ5c/XlQrvzG+f1+tTlYj49OfryoQt3T+vL+KokTaJF99vbsPXwrmvOOfxz6FV6seJ9/wAP5rhPT1/P50aFQVIXlte0U96LAbHMj11qdjPhgxyy599U2s7QSq4GehXx9eFF3Ft2SfebZc20m4B5L5Z8K7sb5x/09nwfIUo8Jdo0ljdxXS9ih/qRjUD4j10pvC6TJpfHLr6+dY3gmtZGud+fU/n9a08jF2EsewYZAHn65V6GDJqmNmh9tF9xwqSeJgFfPkPW9fOftDY3fD7pYpItcThjkLjl0H0r6HBfSxrpZDp8NWQB5eVA8dsBxq0aJ3Ck9c/n9a7ouL6Ixck9mJ+x11a2vGGiubIGF9h2g1ACvp11bqbAmNiYz3kzzHl9KwNxwCSCNpYmdbhSMjlr9nn8jWu4HxE3/BtIVxp2XWmn5fpSeRjTxtBUvumjP9m6MVAywJz5+PvplbSkxquPKrBw8KzF21HG9G21qoBOnvE5x6618/wbZ6UpxoqGWhygzz5+vnWKmaSz4pLDMiFWIcDV/u5+2voEduoBxyxt5ViPtpbIJYpFUkx5ZiNsnG3up+H6DHNXR7i8oLvHjJlj1JgeHOrre87Th1ujYEqx97NILjihveHxOrES6+ydCwyDjrVTSzQRxMRIkisGYePLpQ4tWXtUkaCxu2ls0jcEuh0n+fZ8aYWESw3Uj8tttufrwpBbTi34miqf6Td04HPb8qeLeQkSnUO01bhunl7POjC+wTfpCu5V7r7QdmFHZLGSX/1Z8fEflRHDbVbSxkjZCNbkkkcqDjutPFC+sBCMszDbn0+FOJNJspCjAxhe8wP6daKt7A2loyfGgl1xS2Ts5GOrGAuAvnT651RcNXsZo4wdiV7x+A3FC8JslnuZbp5mCt3UkfcKPp59Kq4myNeqDZSLdxt/SlVvxDwbHo1eEHVsjKfpEbS6kZu7EzDkSy438cneqGN5LO8iPpkDBVBT8Pj76eRzSxQBpURScsTjb15UDaTKxIWSLVICxK75HT3VsScpCzaSLrCwKl7h2Ltjun1+VNXtGwJUPt2zjyPlV/DEQwPGwweu+/l/NXynseY7vVl2Oevv/OvTjCkcEp29CGVJI5GYjOnbfYjPLBoi3Oq0w+W1DmBnceXQ+XWinMU8bZALb4IG5Hs/MUohlltWZZCDH/r5jH0/KlcKHUrGXD7xrd5lWPKI2GGdmBHMetqNmmh0E5xg5ydiB0P70uSN5gLiLKyqNEi52bwb8t6NaNJbcTIxBXwG6dNx+lTlitjrJ7CrS9CSNHqxv12qFxcMsbd7LL3sxjcjrt+lZxLqe3unt7lQVH4G6Y8iOY/Kj24ijtGJdR//ANi8/wD3fWhCNqmaTp2hn96SWEvG4zzUn9c9PPpVcN2JrqAK5XUA2/MNy3+GxpWIZ7Z3eGZHjPeUgaW88j9etR4bdB75Sv40cFlI/tzg48R5U6jsVvR9EspEkVk25aW264399ZTi1xNHxFon30jTpG4ZTyPs/KmXB7vLyxs/fCjTnw6fLrSL7SXizNJKh0zx90527x/Wryj9SEX9gNtMspZlDps6+JHh+9cm4bBKrwxTaEl7ykNgZ6/+k56UiF9dWnG1y2LV2Lqf9rADH/yB2o7tZYr54JnUpoZgFOe7jc+zOK5nE60xXe8JmY74LrqSQdD7vPqK5bcIDW+k6Sy472d1PgfEflT1bkTlZEXSJOzVw/XVyJ+W9QkhmFyy4BRvwuOef7c+edqhKLRRSTFg4NHOoFyrKQcbjHxPj59aWcS+zscIUDqe6R0PrpWzjhka37R0IIG6+A6j9qS8UlaEO9xsgHdAOfj5edJv0FmF4tamGJUAyzHSMb7VfZ2JjjQykP3SRr5ir5I/vU5nmyAD3FHj4+udNLaJJLJJRtqc4I/tVev5/CqdIXspHDxHrY8tOomrODTmzuUddxq0+vpTC/mhit2VSMyKpz7vW1JLeRkkKnGpipUZ8/W9Ssfsc/aAluJpLDjE0XLzX9KG4bfFlkeIDVv3S3LxHwqNwZJOKxgn8MmBQ0SDh/2iVv8A+PLkMANvd5VN7D0Tlt4r4BwNMitgY8PD209s4VgjRUGwG22dv1oO2tkiZzjIVu6ehHSjEk0HB8epx6PnXNJ2eV5ee5cUMEbHMD3+uXn0oyNyTnr88+utK45s9d8+/P1ohJsKeXL17qlRypjWOUjGD7/2/SrDc4TGRy39n0/KlIn8/bn1866ZyepHn1z9fzoMflQTNLkkePn6+NAuM8858tj7qkJQ3L5evlUsA+Xz2+lKTk7B1h6fkPXvFRMBIwMYPw/jzozSAfPlz9fGrYk1N4+71v5ULEBEtiyjnnPr30bHw/CA48uXx/iiYYF1+Xyx9Pypk0C9ln1686RzovghZmLqyBJwoHlz9D8qBaFowc7jzPr41pp4Bucb8/Df6/nSqdRrOAceQ/IfpTxmDNChYqsXA8/n9fzqx4u6N8evW1XBFDDwx7sfT8q5qy243z1+X7GnshRqpF1L1z588/Wls64O3Ly8PZ+Yph2i6NgCMZ8sfT8qW3MnfPt6/X9a5oHoOuIBOBncZ6evLzoJ9+Wf1z6+NFTvk7AA/r66UI+2+2Me3arI5MhWBuMDln1+1e0kHrjbrn1+lWY6HHx9e41wkHfrz5Y3+tMSPAf6hn3+vjT7gt4FSS0mGYpdsN62NIV88eWPXyplwyNXnGQu3v8Ad7PPpVMM3GaorgTc1Q2jtFt7CVVJAxzHrl5UyspBJZIpyZY+63t6b/rQbSNojGfxS4IPX186tgkSOEiMZDMW8/h+ldnPiz3uNoYpGpzseeM9f5qp7Uzg6dSnoV/T6Vfbvq7zHAPQ0wRVMfT39fXjXp+PNezkzJgcPDWa1VnGQBtnvD+Kvs+FpbXEki7B/wAQ8/P60YshVMLkCvNN/T06RnkP1q8ssXaOdRkugWSDLHGPp+/lUI0CbjkPyqbyhF35c6GNzvgD215WTipaOqCk0XMuhyvQ1jPtlJDDZt2kX4s4J23PhWwaQSEHntjlWR+2lkl1w2bJIOnJxyA8/KpSL4u9nzvhcjCaW1ihDZUSRNnbV158xT27uVaG3XJLKN10bKuPy8KwiTvBexGORZlXcEMenSt9eyJcWNvcW3emiwzHbvA/k3PbrRlBpHQpbRFl1d4P/wBXHPmPlzqM9y8N12nYhUc7uhY6Tyol41iMKSZYFe0LYz3fAeX5VXcWzRRCVFzHjePp7zU0gtgE16GR5BcaJ4X2jP4cfStGslxcR2iHstMx/qtH3TjoD58qyXE7Sd3EowG1BiucasbmtEFukgsezc9qsfa7/wCpjj5DPwroxw9kZy9BfE5RZwwdk5MTHS+eeMZ+ODWbuL4Wt5apE/apjUngFAXPnzz8KLvLe5vLe4BJVh/0ieRC8vdgfKkcv2fnedT99ymrtNGBkat8fOtKV6NCNdjziXFZb22FqqIRKdLKW2x5+XnVvC7KbSr6VjRf/wCtdINLbSKGxxh5JpWyuAAD68qfGdra3iRolQYDaAc7efj+lW8XHbtkfInSpDm1ZrZck6kbkw+f8UUk6MNJbb40mt77tEA5jVuT6+Br0t12eEU8ySpz638q9Gkzz9pht/JGo7mz6txnY+uhpZNhl1a27TJDHk2etLJ7u4LuVB1R7FejDxH0rpu2dY+2yo6MTypVG3RW6RYt9LYFZFYlB1GSMeB8qKi+0EMyLLGwLPswJ6+39aS3fELa0kzJKdZ2WVOvt86xnFJzaTPLbOpR21MNGkZpmqAvsfSb2dnjS5t5O6eY6Z65/wBLfKhEv+zUS74UZ1jfHrrXzQ/a25AIE2Jf7gx2b31bw7jl5dy/dhM7NN3QDudVKlGxvtVH0ZPtTENL6FKIcP1GD+lVtxqNJDNDuFOWCnfHj+9MeHf4d2Y4eHv+0aaTmVPZncbjAOKPs/8ADvhduweKScjBXDNkacYI8xSyy44vYyxya0W8B4okvFP6cgKlSxx08/2pVxyGbiV9OY37KBt8g8x9KfW32bt+FxabQnUw0sztuaieFKQAwJYbc8E+ftqWTyYV9RseB3szcliwkjjHfKY0sTsAOp+OxpnEkUgiAALr3S2MFv8AV9MURcQJFGVw409cZPrxFDw8QifvawuARnG2Onu868+XkNs7ViVFsVvCVMci5jfSVzzXH774qwSTMXjQAIpCZK6vQ5e+idK3CnZSCR1652P716e7hsoXdyqgE7nY5+v500W5CS0VXUz2VnKZpDIy7sThSf3rB8S4h97lMzlVhGw6aqj9o/thFMzKNiF3AfY+vlWDPFpuJcTUf2puF6Z9v61aON9kuRsrm8ieFU5PJz0/2LV33kx24gVVCEBdznujp+9ZqzlYk5DPv33HIEnx9c6cRzf+UNwMhhlVAG/P1tSy0OmNJSJG1E50nffmcVTIqNfwOvdWMgbf92PpVUYLW6nA72/u+lX2MPa7tsVbJ3+Gak2EZIomuyRthtXiMc6qjU3NyySryOfZRUQMFzG24cDSQPPnUxCEmaXbJHT18q55sjnzKMS4Ds4wi9Kqzv65euldaQnbbbzyP4qovzzzz18frUTxsjt2XBvZ6/Tzq9JcePP30vMmCD8MVIS/l8qFCJ0HdqduufD5/wAVwzZJxjHr5flQolzn559fOuGTz9fWtQ3IOSTvDfHt9fOiY5eWCSc9Nj/NKVkAI9evZU/vGBufjuKXiaxuZAV6Y8h6+FXQygEcse3by93n0pJ97IU8/XrnXY70qRzpXA1mnjm73jv1238/P86M++ppxnHrfb9KyycQyOeBjpvt9PyqMt+dR73xb4fzSPGXxzof3F3HpOCDt7dv1H5Uqlk1ZzjOcbnG/t/WlzXe25P5H+fzquS7AXY4z4evlTRxME58guWfHm36/ofzqgS8j6x9PKgGus756fLp7qgbrB9/r+ausZFmsmv9IOM8/n6+NBSXGfXr4UI8obljGM+WPpVTP4+Wc+vnXKo0O8jLnkzz9ftXUk3wd6o6jx+Bz9a6WAzvt8sfSqJUTbsv0oTsce0fH+Kg6OuM9RzByMfqKq1HHwzn186msmBswBJ/C3In9DR0wWRDYb5/T+ae8DTXK7f6dj0P80mZBJ+AaXH9v5kfStB9nTELWTUwIJC4I2H7VbDj+50+N/7EXXz/AHcwFcnLZyPXyogKpmDocK34s/hOPOh76IuyKV3RwWGfDl/NW2UxlYgpIhz+Fl288VecLlR7sZUrGkA7wAGBnx3/AJpmmyjGfdQEYCgAgDarjLp5EkVeEuKIzXJhDzomQT3RQ1xxGNcDUOYHOl17O65G/r9az91cyvMhAB0nofH1vUZZ3eikcC7ZpJ78NqVWAOfH18K9FKCuQdudYq4vGt43ftFeQd4gvsF6e6mn2ckmunMs0uonGB4fvUm3JlOCjG0aNJ9MelyAccs+vjQl9ax3NrL2qqdYI3O58vbRbDTlwgbbAwPXwqqd0WEvLsdPLnt4eyrxi+mR5e0fB+J2z2fFiJnKRoxXAXz/ACra/ZhUfhcqMv8AUB0jwxjII8Rjr0oj7VcItb+NmcldtmJ5evGs99m5pra4jsw/aRxE9mEfI9eVdKhaA8tG2SMyoiuE7SDYezw9tSkiImaFlysinQp/tPUfUUEb8zjXbjJRmVwdu6MZ2+FXx8QjazNwW1iNQWOc4IHX60kcO6A8vtC+64WsN5DCqg9oO8dzkeB8qdCBUkRrmTs4xHhQDy7vreg4Lw3nFQxRTFoDq45g9R5H86nfTxT3JVYdbL3i5OACDy9mDVZw4KgQlzFfGOIyyxRWvDWysYX+o4I7wyGz54oa1g4jM/dtmeMMxwSVABPOndrZieRDJH2bINQ0nYj2++ncXDEZtbSSICNwR19tc1cmWb4oz1pwuG2LSurO+AWRRnvdN/1oTiAmvJDgaFPdxpwf5rY3NssFkRC79R3+Z9n0rPvJHEBpwcbeO30rtjKGGOzzM+f7ANlbPFAIs7fp66U3SCEQKHGXVgwNBrcJpGB3iMb+vnUnus4GOuffWl5sIx+pxzzWFSww97IwcjJPr51hvtFxcW/EGtohy/FjkK1xnZ1ZV3bSQPX6V8s4je9je3P3lTqfYE74rYckp7TL+P8Aa2wW9uWWFhFMcsMkA8vH3Uj++8RdGTvOhGnBGdvCn9h/l9x/VnmjwM93OneozXsCz9nw61Mq9GUbVZW2d3FJWZOSCYZLIV/Svpf+DX2Uk4tx8cVuAPulkchdiZHxsMeVZeeDiTRsZeHELjmcAY9tbr/D77R/5Lwa/tZdMFxrDqGbn5eVUjGic5a0fYOJM1zeW3DbEgM3fmbpHGPrTkW0UCaQQdsEnmaw/wBk+NQr9oJ5LqQF7mJSGPL2e2tncXEMikK67rnbzqGTFrSE5O6YvseGyTTPd3IKgsRGh9vP9qJubSMR6kA5ULa8etJh91mcRzR5BBOxHIH2VDifGbHhNuJLq7jjQnALsBk/WueXjNaSKrK27bFPFMJbuZBjA6evnXzLiV2lrNIVmILE+RPl+1G/af8AxIiuVeHhULzTNkBtGAPPz9lfNpIeMcZyWk7Uhe8qEDR7c0IeG7tl/wCUq0fRLP7aQ2kRi7VWHhq3Hu8PKlX2p+0t9cwRtbIoVx3XDYBrK2PDIeESxXd7xC1hkDZ0Oe0cj/0j861F5xnhdzbi3jhWdpBqSRF3Xr/djcV0wwRiQnm5GGTh17ezB7ojDN1cc6c2ViLIktDpUZDSDcn14U9ThEUlgt4H7NMd4HbfyHu5VCfhxEEZt3aSR86kcaQB0OeRqzhFqiam0K7q/UzQ21tCBDq3PQ/tTGRmKoqrqwe8T19eNJJbe6iP9e30MmcZGk+3ar4bq4iMelnKr+HB5Hrt41CXjf8A5GWb9NnEqMulOaxqN/8AVRdppiuVBG2xO3r4VmuHccTOieFwORcLyrRoyvGJEIZSBvnp66152aE4S2iebO1tBk8oaUsoG3w/iqWlJz+p9fGqsnV1z88/Wurk+WPL18K5WedLI5dky59bVAtk/QV44wBiqy3PfrQ9inSwGakoJ51HTlsD9/5q9E7nlQAuyA9Y9fKuZ1bjw938VKQY/f186ki9fWaIaorJ2GdsevRqppCPbnptV7ppG3rx/igJcnpz99FGLVlzyz5YHr4V5pCqjbP0+lQjGnGfHx9fGuSZz9Kxi5Z25ajnz55+tekuNwRvnw9fKg1fDEDlUpXzkj166UyiFFhu+mdv09fCqJbhgSCR4c/Xxod2wx73WqGYvgLnPl6+VUjEpEK+8kHn8fH61BrjGPAeXr4VAQhl1eA9e6hpg6NsTTJCs1wbJx1zvn1zru+AQfl6+FUhu9jp+lXLv5cufr4GuABINt5efr51LPPx5VHODXjjl7vGmoU5gHG++/r9qkUJHdBIx032+lVhvX5fzUtWMYzz8PW/50AnhrjIDBvHfbHv6e2n/ApmeVo9WnWOR/1ezx/OkUbuT3dz7Pjt+lHWb9nOr6GUjfI5Y9fCujBPjJFIS4ysbcQaUcXtl1gxzxMOWdRHrlTOxkPZZ0atK6WJ6+vGlN5exz8Rs1kR8JKAWHnyPtrSPAI3mi7+pxqH64/WvTWNSdo9VZKSsLidHjBCnAGdxyqEkkcSatseNejnituHkySjSo3LcsdPd+VZGfikvGYHjsZD2Oor2hBI28/1pZ4uMbKY2pSqwP7Rfam3tFeCLvy46bishFc8dvpWMEMipJ/c21a/h32QRbjtbti8mrrz/mtUlrbwwMoTCY2x65eVcsMV7Z1zyxx6Wz51YfZa9EgkvGZ0U7LjOfdTnhYe04osZbShPLpj6Vfx/wC1NtwqVrOLBlYYPl76R8JFxcyyX7ya3JGMdKEo09dg5uSt9H0ogtHpXIOxwfl/NLuIrIYG0EM46ZwT7POrba+V4cbZxzHr5UvmnV2IRiAu/iMfSu9Y7pnmyy8bFxj7dFLr3F/sYb+76UvFtBDN2sMUannsPW1G302Z20uSD4n9f1oUMdQ5nfp41weRnblxj6POyZpSZN2ihtnmkTvb78jn2+P51iLnjjpxD7vYo39Ugdzrnnt7+XlWu4tC01iiKcEnb14flVHB/sQkc33m8dGfIZQOS+0/rXfhlLiuTO3Arhs7YWYsrMIz74AkI5sx6AeHKmUFs8cauzZdsLIG/uOf0086fQ8Ct5Ih/UZEzqOB63oqLg8UWNALAnOSfKo5Zpvs74JJAq26QFGRHRlAYBTy23GPHy61Ke6it4Uka4VUJPfIK7Gi57WUBGLKNIJ8QayvE4m+9s7DKIO8T/b1qKe9FKTQyv7wPbjuKw6lX6e39aQTy93c4APXx+tZTif2yuI5CLK2XslPdfHP14Vnrril9xByZ3ZkJ/DnZR7KvLxsmV3J0jxsuGUpt+jb3HH+F2WO2vIs77KdR+VAv9tLEZENvPLg4BIC5+NZO3tVdnyjf7yBv8auHDj2mIkk05OosM74q8PAxpb2BePH2OJ/tlfA/wDl7MIT+Evkk+HKs/dpd8Xlae7xqfwAU59nSmyRJAcpL2ZICZDbnx/ijVs8qXMagju5ZhXVjxwhpIrGCh/UztvwG1xq7BWfP4mbI+FN7K1NuO8F7NenLI8c00PD0jhM0kyKi45HJH716MrEqvbQhmZMLJOdh7jVUrGcqL7UxyppdSRq2096l11Y8KNw5ELdqVJ7MLqAP+rGflXla9uJJF+8OkkY0ILXugnpnxqq+t7pbmf74jvcLjRKmT3vPodulNx/ROb9FMdggVTDdXSdkcqgfKr7geVTS6+0MIkSG/umiH9zk5Hxqt+G3CFMw3KupLMew0nz5/lUWtkkdofvMihEy/bEoCoO/nRUEujOd9l/bcUaZbqS/kE2CilHAz7R+lUcT4dfXsST3dz26YLAlu0Kp1OKfWkVtZ2uUhR0XK5J5r5E8/HalJLtaJKuywSypzxg/iHxANaUAKZnI7S0juewHayyagoDMEGSfjTC/wCC/aHszLCrJZ6gnZwjBLe3rv8AnVvEb7h0t8tzHbqzKgcOd9Rx58/2qEn2lub1oUxPCsS6pNDltajnkD86lOMr+o0ZL2I7b7PMbyS1E1vHdA40u+Svjyzyp3wvhfDuFzubgteTQt/Ty6iFumWHMgUH2Ul1xm5uTiKEzbDtNwG3UePvo+OzeUIkf3kiUHVINtRPNeeOQ99UUbQjkMYuMRxKsQSJgrtr7KFUA8MY5+2m/wDmSNbxysFIjckRxFcHxGnx5VhbmzltlRggS3c4VpG2yRyNcUYV2fsomBOlV3z4Y8R+9JLG+0Mp/o7vOKzixdrazCWeoFe23Ynkds7D6UtWaK8imcIdh3g+/wD3e6uWdzD95WN7NpGdSpxLurdCPA1yNks7lgiyKNXe/X5GlqX4No9bQwxFh98jRjglGzzPLfoa0HDJ5raLKsXjzuUGpfh+lZy+hfSJInjR410kMcZI2OPpQ0M8z3itMdJA/Gqcx4kj86V4+XYbPpdk8F43Z9pGkjcgTgHyxz+lXyQPHKYpI2Vv9w5++sKOJSiZEllGo8wT6wfzptb3Rkj0QzSiInvIrZA8wK4cniRf+CSwwl0P3Ax1zn35qAUFtvX7UEL9LaJRO7Swj/8AkacaR01fWmUCJP3oJBKCc91vhXBk8acDlnhlE8EAxjlRcaYU55+vnUFi36nzoqOPKkfOudiJbATEXfAB57Y9fKiktMJt4fL6VbbQ6pN+nj8v5pssAVcEHn7/AOfzoMek0Z6aEjZhv69ZoBocSbA+zkf5p/dQZOAPh8/4pTMMZ3+NaJJqgJhj2D16FDyMSpxy/SiphhSfz+v60KTnbfmenX61ZIIMc6tvj51aOW3yHr4VIRasYAx489vpU2j07HoPX80xkgKQePh7v4qmNQWOaOkTOfb86pCFSuNvYM+vZTxYyCYINQG23z/n86HurfGV2Hn6+YoyGXG3l08PXwqNw4ZTq559fzWbMwpfxnc/H1+9FRuCeW/rP8UtViG57eXrlRMMh9p9es1yUKFscezFe1bdfjv/AD51UC3UHnn151FdmA6evWKxqLSMtz+Xr4VwMNtidvHb+K8R3c+vL+aqJxgnx8PW9YwSsgzjJPv29edXLMVORz5+efrQK5Jz19esVeFJXy8en8VkEcWF1bG5jMx0knGQNj68K091c6oMxyAyRoFyT09da+fk48c+vn51pfs+U4k/ZPIUlXwP4h7P0r1fDz39GXhkvUj5F9s+Mfaa4vWgMkqJETiOPYOvifGtD/hv9onj4JcJctgwyh8HmoI3x8OVfQ/tL9l4ZI43a3LKp05xy/b8qyV/9mjwmzmmhMjdsNJDHIA9v6125FUWjvhTpoZQfaKe6mKq7MucAD1/FMuK31xHYhbYN2p6cyPXjWF4JL9xuB2jEvjSuWx3q2PCrAzwyPK+tpCSW5kD10rixY7dF8s1HZjU4bcXdw88glkd3wcn8JrWfcYrax7FXyQuCUzj+KZ/dILJI4UUBTsAevv/AF6URc8NRINR2LfGuuPjJI5J+U3Qrs73s7UYRlcDnqz8frV014qx9zSGO+3j4e2lxeK2DLGWYHw29eyh+2G+hAB/8tq48/kcVwicWbJylotMjO42+Hr5UTmKztzPNpJxsPXT8qA7Uhhq9evGh/tFcdnHGozh19e+ufxoKTcmDx8fOVMpt+NrxDjkMLjI16VB8fr519EtOFTNE2l0Cht8c/Z7a+G29/8A5fxqC4K6gjhsDkQP0r7HY/aSzura3vYZsxyKNQ1cm8DXqRx84nfKXxvQ/gs5CixJ3dR3PgKYmAR4XpyzSa540jWZmt5UVsAjvdaydx/ieLX+jNaNJcLlSsJGKn/FQXmcjfXRjVW19zbGc18u+1n2khdJuG2cXaJJlJZBnHsU0tv/ALX8V+0KlQPuVuc95jtj9RSZsWkAeJiyt3QzuAzHnsPCqY8Kjth5N6AouHcP7MmaaNHH/wBOSfJz7Fo+KysY1WfTBJEraSBqwT4DwPspceIYZRa2kQYd5pHOTn4/KpT3IEAH3iCCRt+42fjg8vZV+uhNhzizmeXTKyIpzpRwoGeQGd6ClaDVFEEOk82eRmb3fxQk9/NHGkcUxaIPuM88/wB3z5nepyhC1wqbGORJFBPg3eGffyprBRdGklsjsEwEbOt99QHn76Z28hvGFw6IHkIYBnGfDagLW0RpHDM2hkZu63LDZ9CvTzdio+7SLuxCDTq5Md6yWhW9j2Ne0tprlERZIzpYlenXAx8qB4jGkKJIJnBcBnjWXbB8ev50t/8AOSKyPedlCQWaJH06jzxz86pzFPcNLcq41Dsyw6Y8B7qEL/TSoJk1hsRxnTqOkBsPnwPnjrihJLy8tlPYzSBI17uk4APgSRud6ta20WqG5kWNWUlVL6s59h8vdVMbwK/cOtezLsGwBqyQDVifZXHxq9ZQ88ZcS6ge07yDwPU9DQtnbtNdNM6ErsoHaZxn/VVcVtDLFOG7RyG7qsce331WySW+tw4aMgBtPMew1lI3Gh9DxmSCdUMS3UyIcEqW07b4GfbRtleuq39qQjaityyD/T1/7cUrMMSWtvcrMCrKx7ME6gCBkeXTFd4dL2d72zupC5V1Y5Mi8jv7/lTMDBuMQR2l2k8JysYEffOokaR7htVUVqJrhHDL3X15kbdgcZwFPPzrQ8ftEl4W0eCfu8mlmOB3cZDYA8M7VmrB2kkMblWKr3HVcnl7tvyoAHMtrLGZjGixQySaUVu80gHMk9fcab8M4VNLwcXkpeTQrdqsbb6QRpPe6Zxy5c6De5t+IcNiS4MNvNDpSMy/3bk8xzHmfGo2vCeJXqyLDJgEd4a9CgdORphAW9MJ7JZV0qy9xGbIVyd9QpfPw95IYUiUS6dQBVQvkCu2eXQ1aZZRfiCSGEtr0JIVbutn8Q+lHcT+/wAEK3MbIVQai0MeOzP4cZ99Bq0MnTFycLe1ukacf0HBRSTnDaevrpUmspG1yPHIECDMmTpJPgRtg9KohtGvAsz3Ou474CFiWUgjHxyaahL37msLPM9uUKrGSQAd9O3tyaEbrYZd6Kbiw+9cNR270gOXVRuHXY59o0t50onjSS4SNYZI0VcEM5+PPatJbydvaQyrKGkz2bLozhlGQfYV2NANotiwVFMMxYr3cnTzOTnbH1pNDKwJLRlKrcTdpERiNi+oDHzxRljFfW0rTiVXUsu2oMGX11pj/lSR23aTKjOFOlZPE+fjUk4jYWcjgxzMjpo7PZlz4g9KjNr0USoc2CWfEYmXX2E4OnBOx8VNC3nAL3hR+8WWp4/7olP4d98fSlqXPDzGGtO1AJGAf+XXlTqy4xKV7Ny0ihdOH7vuz4+dc7TRZNPTO2fHx+G5Ut01Y3Ht8RT6GZJEDxtqVuvrr51kL4QAm7tlAbV34yPxHxFesr9rZi8chEecPGelc2bxYz3HTI5MKfRtY3CyagR4+/10pgZwIwPL5VnbS8S5UyxPqC/iGd18M/WimvNLA6vr/NeZPG4umc1cexjMcpn2ev3pHdtpckb+zajnvlMXMe718qSXdzqJ5H5ijGIkqK5ZN+hA329fKqlAYHbp18PXWqHl1Ng9etWwtsd9886rWhCYJGy88+vfUnbfcn163FDyOAuFxnyqPaZ5n1661kgolKAdvEevd+VBlssent+X80WQzee/r30M40tqHPy+n6UyGLtWnuknP6/Wq5GLKoJwM9PXyqsZaTSBjb5V2ZGUnJI6b+vnRoR7GbR4yevntVls4DEY39esV2TSF2+QoeI5cgevXjXMZ6GTTp5Y+X8flVWvD7586pdSB150OzH5UezDJ3XQOnr1tVCnPn7+n0qlX1d07e/18aKgVWb39fWxrNDJWdVcj4Z39fGrwe5nkefh6NeCY5c849fSqu0IyvT5fxS0aUaJldS7A+vXKieFzS2d/BOoxoYZ35g1B8diBjp4+vjQ4LZwn4vHrVccuMk0L2faruCO6sGimQhGXfPSswOHferRoZBHPEv4GG2oeulMeFcegu+BQySyASaAr43GeRrPv9obX/xAeDf/AFWi7RdZ2YZ9b17soLI0z0MMpKFoEtPsrYfe1ZI4xIDnvZbAzv7vKtMlpbW0QVAORPfbTgch+xpK9/FbQtFhsFssdRGT4A/rQs3G8KRnn+E56+FVhiUULkm5MNii+9cWL6gUiPd0Z/F9fzrnF7nEJQREkbeXr8qosuIR2NiR/c4zgtn0PypPe3ySuwIyTse9jPv/AFpPIyLHj7ObI9gU80gJ7gTO/wCH9f1qvtXC/iPxwf5qTOAuVZx7D+n6VAYIycMPXyrwZO32TVA8k75HfPjsfXwobjNzHLw9WlkAkjGlV55Hr4VbeFIVBXdvA+vnSiQFpNUoJboPCvS8HxZv7votjXF2jPJw6+v5DrPZJzL538vfTizsxZ2D21s8ioc5Od/PHhRLzBUDSYAA7o5fAfpXreK8v3MUUZSML3i2fhXqVGC0XtyFKpIpKNNO5bGELk/t9KYW/DkTvSDtpQR/RQ7KOXeNMJ+GrZo0Ikj1N/uAI9vPH60Je8RtrC1aC1SOR/xSF1xnfGfH3eVQ5WUpLoIjhLu3by9oiDXpUbJ+9KeJcVhMEkSLEzb6cNk/THkK5acV+9zOrOQpU4VVwF6bCihwL7yzzpoMA3yV1OD4bZ33oOl2HvoSzKohSa3SZpioLK6gjxpfcqHbUswXvZxyKnzrXzfd7e2SxtJJXOS0sgJ68yT+lYvi0moqIgpZRpDeG/kK0XYJHYri4E7Sav8A4kg0/mtklMyq/wDWmRWB354yaSWtkSSsiB3de6VGynxpxeRTROlwiMcoAMEjJAxmqULYwUGCaeNk1SqjAeH4QefxpTc3dtF2bxIzyMjagdsNt9ad2faXUsc5DDtNnA/3Jg1nme4tSY1twhjYrk7nBGnnWiK2Dw3DSz41Y3yeXLHjWqg4XYPZLFc3Lx7Blkzp7vv2NZ5OGyoFlMQOFJKA7jwyKNm4fxOFLdVeSTbeMZZV9g5e6jszGd/DZWto8UMbXBl70JlJLqw5geRzWbZ5o7mN+xVE05xj8WdsU0tDcx3UciI4khXdwc46dfbVs/F3tdSG9a4f+/K6wM+GRj303QuwaC7uryzi4dbWQd1ctiNWGsEdT1r1/YXSX/3e9thbIAP6Zk07YzqOeZNG8O+1M0CSnhURVirBgF3Xf8WkdaOtp+HcRle6v7KRJ3GDL+FWI5nf8h40jlTMuhVZcOuZEuo4YtcMaEs/Lp0r1vA1vP2N5BHqjXtFRiPw+3wxWw4SsVrYyGCZTbykkhDup9tLPtBbJeSO0VoVYae0cg5YdB7fOjDJboElonNbpLbpFPLh5Iuyc7bsn4SfaM7+VZ7hfCI57h4O1CrGR32XdtW3xOxp8/dtra5Tfswr6QuxxsRj2Z2q+0aFGuH/AOjo2yeZH4l9o50/KhaYqu+AvBA/ZTRzNGT+NNOPIfSucPt7myXJzpxp0DGDnmD5Uzk4hOFaExRXBfG8j7N8/gaFmF9NG6fdoVQv1G//AMiTvRU0jOLei+3sbO6m17RSFml0l9WpsfpXb65mkiuo2UktltLLp1NjGfy2pfbJf2dypjCoh/04Pt6/KjrviyS5kvHhjOw0Lgkj3UssjXRo477FHZK8Kytbv2yqevIZ2x4imSzzQwzI9oHMiYYPIWOnz2+fSkM18/3h5IZZVPQh2FQjZdS3RuZQwbs2Qam38q3LkhnGmOG4Ybf+payB7e5ULIHJ1QSf2H2ct6XN/UuVR1CtjGccmHNf260Tw+7SwaTR2sxkITEqY1e7yr3F3juFluYnRtXMD/UMD0ak7seJY11qUlmYrgZUb/Dy/KqAsBZpChOpSp7RWX17aEZka1XWoC6sEg9a5GGMwSOecRrnu74I9dKTiU5HOzt0lPeZVH4SG04PjRcckkSLlgVbk2qgLlFwv9WVSP8ASpwce+r4ImeFnjYyAfiTSAeft50HGzXQxLxT6ezGqQD8I3z9aXszxSa4l1J/cP0/evRTOFbvAnpty+hrscxSNtaFhj30FEzl+l1jczRMLhNSqHxqUcj4Gn0lz20QnjyE5Nnp5+ysbNJLZ3Jy+uCTfSeR8j9aOs75TIXjkIHIoWqOfApqxJxUtD43JK4br4n18aHdmznln3VGNlkQY31eHr5VZIFCdSK83jxdM4WqbTBmOG22GcY/OrlYhRg/Squ63h69c6kn4geuaYU5KxJO9VpJjBzvmrGxqGBtjpVEhOTyxWRrCBPq5ez15VAtqbl570PHsxJ2PKrx3e/8MVqNbCrZVEnj6/P86rvsEYHI8qjAdUmzbY6eH0rt2QV6c8bn18aKQ/oYzyYYjOPfXraP+qD4+vQqb2jSrqVdvXrFSjXszhgARz9frXItI3xuuRfLHqXbGPlj6UPNb4TI55ojUfD16+NTYK0Xt9H+KFiCwL1xiiYm0gdPfmvIo3zivBADy69acybQTr1eBOPX81x1z7efvqKLhht5bevlUmAU52x8sfSlGuy0tpiAOwx6/igJ5yFOMBRzwfX7VbeT6V9nn6+NJ4VmeL7yjCSKVtXf27M+ePy611+Lg+Vux8UObGaXdz91Zba5CkMpAPLV5/Wk95dcQi4xHxFzai9hJAxq/Djly29lXFbeTUexjddegsNSr7aJazZJykkds5xghZCwwPFvDzr0seLh7OyHKMeN6Iv9pZJ43M85RgOSR5AHj+1W8Nngl/qLxJZSeaHZvZg/nS24tI7eYF9KKN9YOR8aFnSAQrJFJGdzkbbef7VeXNrToVx/DaC5zlY1yg6nn/NcHZqu/wCE9OlYWDjVzZN2speSJxpKauQztjY5/Smo+0YkujarCTIzYjx/d1/LFefk8bLklTdkZYZGjaUBCdh45+X80uub5kUiLSD/AKn2Gfr+dCNNI4JZ8Y8N8fvUQvaEBFcv1cjPwz0q2LwI49z2NjxfpUbm+lw8MJcsThj3aHll4wsZ0RW6vjmG3+dNTanPfzhRlsnOB9KF4gEljCQTOOYwyYPLx8a61OlSOjghbwpZH4h2vEE7WRSx0yMTk42394qxb6+1yp2rRrHLumy4X9K5EWt7yBGBUhdwN+efWKsv3Th84uCrGOQMsvmfOg5W9mootnle6e1ebTFMh0yHnknIPnuaJPB3u45XbDzLs68sttz8vA0LEsU4jAkPYqR2Uq8hn+1vDem0U0lsoEx1Sjk4ONvL6UG6MZ08MuBO2VYYOTjclfPFMba+ubUzHW8JVRjAyx8/P2U7iaGQqXCTltv9Jx7OtVFLdVKYiRAfwvINz7qWcwxiKYr664k8izNI0ajf8K6vAE+HnS42bvdGQyQrjuqcfpTriOTZF4kCqTj+kmN/ClCWyCNi8WCRt2j4A93hVcTTjaEyWmNLSS1SNUS77aQZ7iIdI9woq5le5jS1R1Wf8KxBhyxuTis1HcdnK4MuVxjs4Nlz5tVY4lcR3Sm3RFdX1FY8HV7Wpmrd2LZroQ3DIokYZ0ldm3HMD9edLbq0mn4hM0ICRByuZDtq1ZFMJL6Ge1tnbOpkLHruOePpXJLwm7MMKRhXw6hj3JCeYNC6B2LuIKLYxfeuEiRwN5Y2P6VASW2pxHaXxUKM6pdgaON+WmMTw3dvIMZ0kDl51ZJfFFKxXNyWwchdOa3YQW2ZIrzEkKRw6O8TufjXJ7uzW3zJewaZNRjVIsBd/Kld1O8wJ+7TSlhgmViAKUtFJJ/RKomCe8u4FbjbMFw3dpZcQd4LuRlbdiM97y9lMkt7HiMY7Nbhm/Fp8/f+dZtbO4W4ZFfUqn8WnrWjsrS7jQu16VUdO6c+7PypuIORd/mD8Mia3WOKAMSdcx1EH2DrSxvtFdG5LPObhlXShI7q+weFVvwea6uMvMZHYFmCJ8KZQ/ZhUhUyzxqv+nVljjyXlRjBLYrdhXA+NGe2aKU4aLPeP9+fOvcclkVbXs7j+mqkZB7y8vngVdBwiGKM6DoODiRgMj2Dxol+EpcRjVJqI6Fc4/XFC1YeOuxAeIXlzKND286LurzR6Cf/AG0YvE76CJEbh0bd3H9OXZv2okWKWRYIGyB0Jwa62tHy8UhA5g4NFpPoG0J5bq4lkDNYMuCCxZydNDXdw5LaAfvB5KseBWnku7ZowiRaW6f0wfXsqiW6bR/T1nu8lXGKXQdmcS2v5I1ZI+z1ZBdyAPgaMi4ZxRCxllDoV7xzkAY50bJC0uzwtjn3iOfrrXZI5ShREdM9e00/KsmGrEU1hxEzdkxC6TnXq239c6YLGllAiNcKURWAQd7UTVz2Mksh72APB87ezNQ+6QRHU8sZOOTNz+FI3YyQCrt2eh9S5zv0rqTQREDtBgtnLE86LnhtmhBWAsM7sSQxNDtZgvnsJI/cG9eytVhOSzxSxljNoOTy3J+VetOJR2NxHIXkuIxnUh7o+X5VXBbIiiSWbGDuNGAT9KsltLObvJMipjOZBg59oBoLRmHXM9s8zy2mtcYcKyqcgjPjvQF3xeKcK0dpJHMow5DHTJ54/tPs2qUV0YYJonniZZVCBw0jFcHYry3oSTsJJcmTPTZfxefP5U0hUv0EmluLl9blNhpCKKDjuHguCpCHfdWGfhTcvFAMRqzn/SQAPlzpZI0zuks8BjhY6Q2nA+VIOhxwfimqVYmCqpOnblWoKlxlc1homhS57roBj+3OMj21ruF3na2S69iFx3t8+Hurh8nFX2Rz54f/AESd9EuMYrqSZHSgLmRxdZPL20Rbt2qrp2OfnXLXs5AwkEZO58DUSmpqnIUCgjf2UHPN3dIPSlQU7ZcE3x08q5cy6Y9B5+BriXBUgb5+efrQ8/8AWLHfY9OlMlsNBMEgjbLAnHP140NeX43Gdh0qMJznO/j7KVX0bLKcg8+VWjG3RTifSbSYLH3vxZyc+vnUJdDzll2znl4+ulCiRBGjqd9O/r9Klbyhw2QPj8K803ytqi5hhT4fEY+lQBwpDfM+vjVrAiPYdff/ADXBF/T9u3r6UUrJ+ypAe0AHL2et/Kozns325Y6VajHXpOPHPlVd4urB2OKahXpFKysQasWRsnV41UikY3wf1+tRJIbS+w/T6UtCpl3dlVs4wB6/ilFhxVIJIuwkQLG3dDjUCg6Hyo69m0W7pFhVAGST+Z/WsGP6KHs5DENerffPiK9XwI0m2dvjrVm44j9pre5nEV4rSGMnSsRjRWB8SFG4xSG24xNNp7NJGPeYhensHSsvI00zSSBVQL4Hb50fZ3d0bgxEx24eJhnG0nVd/dXclR0jbiHFBFw8feX3J1acd8ny8qRcJ4tJdcSVDHlXPcB5E+BoC84fxJple5QszDI/qAYFHcMiNjcDDo0zLpjCZITbnnx91M6rYqWxrNAHeWXSXR3z2RfG/MnHSq7WZIuLwaSwUqUXbOk486ulmt0soxO6nAJJ1DvY6E+GPfWW4pfSm6M0PdjYjspP7u7yNCD2GdUfQpdaR7JrQDvADOOXX9aJtLmQvqtUjyjYfUO8fPflj21z7OXfDftHwJ7uTiX3fiNqn9azEGsuRydTnkeWMGibeXB7kXZhtmLfSrTdonB2y5i/d1O2dR2J288D9KBvY2LYjww0nrTAW8hY6HyG5ltgB661c9nohLGTILfgT/V9ahpdlrszl5JNE1vMw1vgZz8Nz+RqkcTzIwuo8/27cwfGmssSTNy3XdT19eVASWiuwV0AUYAfcj4/rW0wbK44o4pGuLW4SLWO8h3V/d0ohJpn7nZKq89jqQ/SgpuHo87rr0gDaq7O1uo5CySHsxy6UaYtoZTXaQRFECM55AsVOazyXV2Jz2ojHlWg7LtYxriDbfiIFQ7JVypQqD11frTKH6Dl+Ab3V3ewrbQwyFcZJB0fCiV4Be3YQJDbQjq8hLn50bbxsrnsou94t3jRiWUs0ZaRy3lv+VNGKiB3IEf7P2awql9xVpiD3UjUBfgKHHC0DsLSEleuNqbfdVgTOkAHx51cOzt0aUy9wb4O2/1puQFH9FcHC7nOXcBOqgfKq5OCuJNIlwM5VQ2MH2HaiZuIG4JA7TSrbae769lWQh5gJpICdtjnO1amtswF9wu0ZFMzgA4AKd0/CmH+XkOXRYstz7NCB8zV0U7SQ3EmAIUAXGOtVXnEZbbs0hkSIacs5GWPj/FMlboRvVlc/CNb63kfK7kHG9UHhlmMkPk/7Rg+7lUUe6vsYa40/wCpzpBFcWw7RwOzB3HekY0eC/QqTJRNw7Vjsu6o7ylQQfzq2Oez1YSbQGPMDGPKj04W0bZ1RBRzxHv8aEulxIMyzaNWciIbH10qdJuh91Z4RIpWaOVpFbu51daoju4V1pFC8rjIJAwPiedXX+mOGziTCqFLsSOefGhgO0VWzI4Yj+mpxk+f1rR/0EiTrIluTJL2XLbOo+vPFU2oeFZLm1jumKtl3Z8avdTYQOluAIooh10jU3ryoVL60tneH7sWA5u3M+6s3eomquyT37PGpQSqG3/6eceP8VVHerPMuREVHM6WUiipJ4GgTsXmjBGcFdSioQSnHelVz1LLpP8ANBN0akyFzJZs+6prbbIkHr30FKmm/eLA7mAccw31oqUQyXUTv93eNO8ehPjt+lLY3Z3YnnIxZse2hfoPsZxG3hGMxhsY55x+1XiRA5SfGAue6c58Pd+VKo0KOSsQB5nJzRLjTC2EGo8sbfwa2g0wfinFeHq4tlV9RGnLDYe0igwsUQ1aBhur9KXx4ub1Yuy0NqzqPSj5pJJC2hQ7HG+fnS6Dui0cQtkkaPBd16Iny9lWpfI8ZElrIWG55n3fvQoVYZFWNkt8HMZ063Yjmfb4UTalWl3a4LEnvMQvX/Tj40eNAUmyDy2ExaJoZkZhkd0jzoRY4i2l8nz57eulOhIh2WQKfw6CQwYUvubXRLr3AbmTyz4VN/4N/wBBmtoVD97IB5auVVm0tpo2jR8Odlyc7+utNY7YOo14CncHlmrDZQIF0FdXUKo2+NKEyyQwa17QOzasMpp3xAQX3C3uLF/6NvgOsqgFcA/9v1qV7ZRt/VhQq394G+R+tCJZ/ewyRntAD+DGPYaZS0ZoRyxoYyrIveG++2fGiOF3pgZFdtSgaRvRkllCgeD/AOrjbpShomUPnY9M+NK0pKmaStUzRtpuP+n06gVyJ+xfRgfpVXD50EfZnGoY1E9fCrLnMJRxvvzrz5Q4viebOFOg5XYxsTueefX50vkPeOo435Yq+K7VFAyN+XQ1RKQ86JnAPWppbBBUEW7BpGd+XTHKrWl/r6tKFQckdPKqkgRxoMxi0oW2XJZvD96oFwYEVkYhwcg+dFDF4dWkOPGqbyJ3jLIB5H1+VWXEtvHEjR/9Rhv+vurzSv2GX225H5fzTJu7C3uzSXFpIVRUw7YGCDz6+jXuHxmRmJU5FFWkzSd4pqbvN3fngeHlVJuEht5VjbSXwefhXGxNBcjquMDu4x4jHr4VTNJlMjY+fr51TbGSSRde4bfzyf1qy4iQ63VgNAJIPh66UEElbzxs3fXujqNjn61abeJbXtFly2dlP+n10pXZYDOHxy938VN7kXMnYM+zHJPI5+vnTL8F7PGVu22GnbNEGfXbsJB/VB7pxv8AHxqq2gcDv76DzqyKJJCchu6GxpGdgMk+ylfYBbcQyXlnPGP6ZZCM451hpBiHfGc6cE7ivodzN2PD7q5eMns4yRvj17a+YPPbyyPJKm+Sw3PeB5V6Xh3TO7xemda6EDL2ve1Nlmxmr1u7W4UHS0DJ3lP+oeXgaCmhgli7XtWQsdWDy09cZqqO2dssk6pGBzbmfhXejoZqrTjl2Q0V1etLEqFUDjUP4qp5Y7cdonZ4VSuAN5PDl59az0d9ELfRPE+oNvIH7p+HWom+UFimCB3lRiWGrxH0NCtmv8JXtwtzK6SSFXyWYL+H2Y8aVNK0kq6jnBotLO8unLwW8r6tydPxopvszxQRGRbbWVGp1RgzKPHFUUWJIr+zl6vD+P2tzJGsiqSNLtgElSBv7629x9pOIbJDax25/udm1ezHn5181kB7ZlxuNq1nBb8XdgYr4HMAxFOfD/S3srNWLF0ba3d7uNWcdoeZJOnPuppHPC0aoo3XPeByGPL4VjY+IMsZhhwFb/qa+ZpinEYtMcURe3K4zq5Mf0pHBjqQ9ltx2uEyHyN+vv8ArVM0Lr3T3jnptv7Ksimdo11OASue5hh8KHknknKxqADjn1AqWyhWYSszKuh2xk+AFERqezGlYyfMbVSkZTK52H438TRWgsAypINsDAx8KtHRN7KpI8sMogXwFea3iUf/AE1IO3t9lSMDPpBD4x41VdjDLGNXjhzmi5MPEIheHsu3de4B3gDjlU04g8uTGhVOgbbNDssYsYU5n8RBHOh5RMi6lUO/9ur6Uy6F7DGmSTaSXfOVES5NA3Fw1vcMIkVcDPfOon3VYnbSRq0mNSjl5UVcQCW1UhooXJGS/P4VrRuiiETS2+p441bOSzjn7qvK/wDlzgqQP9Bxg1TP2VrFpGqVuhYYz7BVEU7Mv/TKhzttWezdBUKdjapGoY9q2s53qIkSaZ1VgHbYORyxRMmuFYCXwdOTilsdxIsmpFV85IwKrBctkpOtFYfsrpT2Us7eMjcq1VqrPEskxjjB/CqjcfvSiIhSjy7x4wAu1MoriF5F7FVwB3iwz69tGSBZC9dNLaJSSR7hSdl/qkfeW38ScevOmV9ApkLdoTnp4UNbWrmcBQG3zypIyiO06B+Igvca2IzGgWu8PKaTGPwt18qnxLa8kdoxjPIeFdsVMuhiuFXn8a2uIPYWHFuNKJkHmelLr6BHuE7ZWbVv3TpGfrWigtu3kGrI222x6PlVb2sTHIUMV2yevu8KklY8pJCbQkUUaLIe6PX8VZHhl1ZRsePhRUlqvbZ0rhQds8/XjVQTsWwVwPbzogKJ44hb3DsneCYUjpnb+KVRRTC7EaDWeerz8KeXaaeHOCrDVIuPZQtlIq3Urbee+wrN6CuwQWkobvf01GxOnNEqpaTecgDbJGoYplGyyTFHKjbIz6+dRmjJU9mofvdNt6VSG4gEsEbzqEbtBkB3Mek4pSbYpI4XcEEDHl1pzbt20miQYXOwG3trlugkulSRtOQ2Pd+lb3s3oUyQJcQ5XKyqmVI+ZqFtDDDG0l1chtuRJx8K0C8NchsYJPXPKlFxwG2hneYzFTzIzTpWI2WKpYJJFChRt1ceudXNiSJkfCjIbB6ezy8qutmgtrZA1yrPp2wuot7vCg7viNmWyrK+TpPdwB68aSSp6GjK+yuJ0UPEw2Db55/xRCYVhq5ePWlUvHOFibE15FrGQRkLyohftFwOFdL3ynH4QOlBq9hUktDBrR5F1xvqTPTn+1L7nh0gPaxJy545GhD9tOHxvoSaJc7FsE7e6hLv7f28CqlmrT4PNl0+z30KByDQiuNBXDk7nO/rzqmTgk98x7CJRMDsrOEJPv2zWXuvtrxC4lDrDbId/wCzNUf+L+L69RmT2aNqagfIh+yvbSskyvFKh0yI2xA9ntox5P6DCTDKqDH/AMhWaj+013f3CDily8gUaUZgDp8ieeKcx3tulvLHOpkBibTvjvf2n3Zrmz472SyJSVkLm5DSAxjlR8EimATNsMkDzpLbmLT/AFfwn50awWT7uA+nUGKjocHauaUfRBpDTh9w331WYgE5ULjI3GPhS+5dBMyA8m60XArLeQAqF3xucZNKQGZxI+devkK0YmSDmzJKMf2kZz40u4vxScoWAx3/AI0Q081veHVA4PVdPIDmfZQ3ExNPeaHQLDpBTHKqQitWPBb2fT4MwPFJH/auo49nWhZ7XtbtIon7rfhOMZyPD9KkLlI5iUHcK6duWeuPpUmUy6GjU93G5P615pC0W2adgqvJp1ju4O4x4+yhyvaJeidCY8rEJQfwb6viQvOroWUQmJiA4bKnfVk9Krv5HMzCN9UaxjOnlnJ3x408GltoKkl2LomIxHz1HA23/mprZiO8Z8AoATsedA3ErRQq0g/qlwEUdBuSfyoiC7aRmDHB86V2tg6GtgheLTJJo1ZxnfYeNXaz93YJIIm7JmJwMtuBj50Ddy9n93SMd7Tgkdarlupre57PYmSJkwV8Rj6UsFbATWTtERT3k0nUvj5ftWP41wEtIbjhsUbQ570GcYP+3yrV3JSAxw68XBG8a749p8eVC3Ek8EYdSGUupYKdy1dOKUsbtD45OLPnt1DxG3gMslpPFCp0sxibA9/LNQS5t2tdErtNpGEQ7ac/nX0i+4iP8kd4oRpL9+Nt1O/h4VgeKWnD5YLdoEMUrbMw/Cw8cfSvRw5fk7R1wzcuwOOKXilwIrK3dtC5fI2Xx91OeGcDtpkU3U6IVkI1JnHjvtUPs28FvJ2SEYmJ1uScgDl8aeQNci+WFtKwEnSDGAQMfh2q7f4VQ9splgjRERC67NlcaR9fzzV7NayWbp2SgN+F0bBG/P8AalsNm6q4lkRy/wDu0kr9KlLbPDAndaJBtr5n4j86ZMDMtx/g6QSZcwlmHdlUbSD9DS3hCrF21tImtSMgNkDmM4rUXq9rHJHnXGSNeQBk+I86y85aGfto0cuo3AGzehRsNDOQfdlFwkepQclGGR5Uy4NxbhszhJ3NuHbuq4JVh4ZqFhfxXlrrZQruPwOv9vtqm74dbSE6E0qrY7m2k1jNWbcdlKgjs11Ajd+lUJE5YpkquctkYJrCcP4xxXg11I9s/bQA4KldmrQxfa+C+YtJK1u2MMh3HxpHE3Q3+8RTv2EGAq7Y8fE+yjoziMbqANhqPP140utDahAyTB5GXO/j5mj44pAO3kCNjlnl68qSSaMmjusHvFowQcbUHdEG5U6s+VHSXCppULGA3+nBoKXIeRyO8RgE9KC7HOyf/tLcEc/3qyKETQsHJ0pjl18s1RHk2iZO4OathaTsnXYcsbV0LaI9AUstwSyaezijOBnb4Vdw9bZ5VkuZTqTbvbg/tVdzbySEHUNZ2wedQ+7FAdTAtnbzrohBNEpSaG81xDdXOjQHUciKjIoRxEVKb5OaAt4pYgr6dDA5q6WeWWWJiAw8xyqTx7pDqf1LL4jIWNtQSLGw5VXZwRzaF1d47YqV6c3EythcYAxRHCCmojTqI8OdZajoz7C5IYljCAbdSedV2VqMEudIz3QOvrwoibQsR0LnNLo5ZhKQFOPDntWim4sEnsvlKQvpbw5AdK5byGN3ZFKjnvUp76GS7RXjkY7b/hod5RqBXIUvtmoqLbHc1VMp4udbSFPx5FWcMfs4BnHPPKqb3Mkkwj0kDqK8qTJCikFR4mrNNxFVWOY+JRpIB/aOZPr51y64iJ/+muATz8/rWYu7p2JUNnSedVRTS6Q+TkDGPKisNqwOS5GhlkVXAcFfbVU7Q4XDEdMYzSmScyadRyeec12SRzpwc5I2/T20nxsfkNLpnkgiQbHXqGfDFL7CNC8rd7WXbugdc1fd3WmWOF8BljDZHMN66VPh5Tsy5Xs2Ud45zmlr6mUvsVvcpDC52DKNQoSDjq3LqgKIORU1y9jM9zJpI0BRz26VnBE8PE8xxl0Vt9PLND4qVglkNrbxSHVqxgsNJ8arGmK/GRqYOdudA2ImuuIo79wKpOj1+VR4jxKysT94eZEbGnSTRUd7Cpa0aJpkS3eaJVU+3as5eXJvAyOwC4xz/EM53P61nL/7awdiY4Q0jZzk8qzd59pL66wNQXAxkCjDjEWTbNXxS/tuGxdozguv/TQHfNY6Tjl65bRJoQ/2jwoCSWW5l1SMWY+Jr3ZYY55Kd6VuxURCvKzNnJ5kmuFGHMUxtrdkLSFVOldhnzxR6Whv7osQA57x22oXQ/AQ6OgOT4VM2sijJRgMZzpphcWKxSFXOXz+FaLsrMhmVU7q/jkkbuZ/0+dE1L2LZ7AQwrISQSmobUvrc8Ys4F+ziS2oLyu+g7cx/t/WsebG4CBjC+DyOmhF8toD30DZpraXTi3CSZcttHnoBVUcbJGYpIS4xqyF5VcTFFJCoXaNcsR1NLJ3oXYQrOY3Dv8AhPTqaeWsZY2U2RojY689OXrFZzUyzxMBq1LqwK1dlaveRxoZDCpjZnPgvU1y5VVE5jBuzWaa8IDrkrCg5NnmfMDNDm1hWEO1zEsysNUZJywqjid6jW8U1rlIhEYVTqMcj7fOl5LzFXlfCRKD3djmpJUiauhldt2k80kUbsI7dw+OSilsdybhULDTDqwrMOu2f4r0jzRuLh4miTtNMiHO4GNWfiKsay0cIuY1B1Ws6ugB/FqH7CmSrTCnRvrNkELGTGliAcn18amxdYXAyFXvAjpQUjxLOLWKQs7rqxjb15UUs7NblRjRKMac88HHwzyrzkmTSIorMV73eYA4/OqHDSZkWQB86VOfzqxGzdxaCcnPl09e2hzpiV2znUhbOOW/QePlWQK2cnjLWrPIoZ2fSpA/SqIDrkQgAE+HWi5Gf7iYwxB06lpNDMYeILqBZe0GoDwp+NjUM2kkbsSHGkHmT0oiW4ktrZ5P6RnD5iLc0LfxQ4lhjkRVGpS2IwDguSenuqPEFNvfzduNOyqQ/wD6QRisotdAS9oos5WFxNFKmmRMuxPj+vjVfFLoHsrS2zhY1PiSxNU3UDniA0TaSQrajy/06T470PkLemNnVZZO5IjH8PvqyjseKCbqTtfs1MscqmZWOoj21i4L10ncOQI4jgBl/DmtdZ9gn2auY45BKdZ/qLy3xWOvMhGd/wCl2j9/AzkDrXXgqLKY3VjjhMSSSy/1BiKUOuB3cEdfhTe74hJJavKjIexdUIC7HzzWf4TfyT3DWtvCxhaMs6puxVf7jTp7o2PEJZhAtxalAWRuQb/UfOuxK1ZdSCZrsT21v2PeukGXKrjf3VUOJth445ZNMvdKEagKUTOZ+JLdxkRK3ewOQo+3e2lheSMzB/7gcYPs8KC12UYOt4YWkVmRA22GYFW9lRZop1Z2Kqy457Zzy5be+qBw43cmIe1VFyDtnFEGR+GpCsVsX0A/1mP4s9PZ7adIWweC4+5yaNeIi/dPh5e+n8U6I7iRFKMvPOTn9RSy7t47+1a5gQ5yAU1br7vChre8W00bKzL3WV1I736UW6COJuG9nrEbMRpVtB8fbSm+sI9COqkZbSTitB20dzCZrVymV1OhOrA8jXfuXb2bqsgbJDA+O35UqlyDdmMN1d8JucQzNobofwtWg4b9tpEZY5kJTqvMUNc2SSpFr2I5+/nSe64bHbWTyu3e1/0x5VpSSVMFLs+l2nHuH3h1ZZW6g7Uwmms5E7RZEPd2xXy7h0yQQhrzWQfwaT+LFaPhHFoYJRElkAD3l7R871O4vpAuSdGhtowttl5MKx5mrknj7R4zuByaujjbz2p7OOEMF8OVIeIcTlkK6CFlI5jlVFKPsH3foZ3VzJHOGKEgn+0VyO7EtwFEUmo7asVn4uPTJOsc7MDyLeFN4OMLc2MsfaxiZDqTB7zCulNJWRk2NOIm6V00qSv4jQaXKx3ALvuNylehu04zbGIOwlj/AN/4vZSaWRIbx4Zsq5OnHWk+RJP9NDemOTcPdXDzMNSt3gPKmXDImNy4B0n8ODS2+Cr2C2ksYMKKsuf7mO5oCTiHErU9pbo+puRxSRzQUabHlFt2jTXME9qzSFiynrQ8NwYJGdydXIUBa3HG7m1P3iZYUb/UKAveIvbBoJJ9b+QqyywcaRJwkNJpWcE76l/DUJWBshMWOqM9/ek9peXKlpJHLLjlmkfEuLyT6lTWiO/ex4VGc4xdIMU2zUwcXhSQ9rq0sefnTm84laparGSV1r8Kwl/wya2s4LxLhnhkGQCeVFY7exXtnJbbBJ2FD5Yqiyjy2grt7ZptTXGFJ/1c6IF3AxZFbVjr661kLmJ7W4ABDedetrxjPjk75wuKu/IVaJvG12au5vIFi1xtqK9MgGhbPjlvJcPG4K4BCljjBpLHYdoXkuZCBH15E+FCRIkCsNn1HZn5iuaWe9IrGNuzZWE0M1q8UrZmDanYncn20wTilrErxgb6BsfhWDgunM3bAEFRp7vWo397JHKhTdZB3Rmo/JJNBlFctmpk4xbJHMXXBHhS171Z9cdsMMNwTyNDLfW0KJavZr2khGuVzqPjgeHtqp3nd5Etz/Xjbu93GR0NU/kt9kXjV6PXHGeJWUYtkfDONOMb1mbsSPCZpyxlMpXJPlR3E3kXjizOdJbS/s8aq4tP22kKumMysVXHIaVH1oKblTGvSSFKLqO5A9tFWsKm7gMwzC0gDeYGMijEsnFmJo4WZdILMeQya5KGThVs7BFPbF9hvjl+lZy/DOqB7mf7zxR5OzWMau7GoAAA5CpJFm9VY8ay2wPI1GW2K3mSSA5LAnYEZpnwu2j/AMwjkZ8sjgop/uUEZPwoOSWwXWw7i5Fv20COB20iiTu/hA8PLNV2MTTZa01ySRsFwOtG8St4Lm/SeZn1zkPHAm2fb4UBc8XSzZLeGJVVDgx6sp5sccz5UkZ2qRlO+hjPYxwxKz6DeEd2NeWaFlWW5hiEkgIUaEVBjTjy99ekvbbiEXdEkc6rqjkQ6lY55EcxVxtDLFFdBGZs6XjU7+t6aLrTDdaYZxWN4eBWCqmI8sdR6mgeGyTQzRSQvodSd26jr8qMlupLvhIsw+Vjk7RVx+GlyTJE2IQH/tyPA8/l86CacWkGLuLDp8skV7A5+5TKfasnVWoizu0LRpHFGzMdIXRmoWzRRs0PdW2uF7wc7K3Rvj+dXWMfZXCs6YKSBM8t/Kt8vBOzKSUdh9rbW0UclzLbRLpTAZ1GxIwKtlXEEcVtbRKkyZZ3AXI6L767fxxy9jHJIvZibU6j+49F/Laggs1zeukQXLKSrEHC/X9KlCXNXInBqbtkI7K2ignSU6VfOnByAfLyqjhkFlFa8T/zEh9VnIlsVTVpkxs3l7fOp3Eum3keRwUD6V/1E9WoZ7gOsobsVYxlFRE+ZPWlTu6BJrdFb/8AmBZz3hY25te8itglvb0J7tHfZyNZb+3u3X+kCEYMudSg8/Pag2iiuLL7v2gEzuJu5y0ciPXhRXDbjt7vdNFtFGRGHHQjGfbvzpJfVO/RCXWhw9hcrcpczH7ugJBZufLpjn5VfHM0TJxQPMsEZKrpXS7MOYA/CM9fDNdvrR7mxh4jDcOwC6lR8KGByG26EMAMVTFbSSG3tpJUaSIFoTGQUZWwWUkes1zVxHa/CcXEre8jjuNEaZleKWNNWx2KsDnfIO/splxC0e14bF2eCdRDN13XK0k/y+Gy4gR2pVEkXuZwckePjT3jF0IoeGWr9ti6iOMLt2nQfEcvOg0m3oRqzOGee0WOZ2eRTgpp5ksPDxop7T+tHc47MOCoRhghvZ5Cg5ke64WrW8jt2T6CEjbBU/7hy38auitntODywuSCi68kc8nfzPuoNNJP2F7VnIrNf8yBOQioDEwyVRtQ5+XM+2ruKzrccTH3iEzZCOVzjJGw3FEW8hg4C8pVZBKRGi5wQwAPx5bVRFIbi2juXgQuuzMRhI+o5eO/nTrVMwFxe8SO+iVIShjAZ9B2Ax3sD34PtpHLruuJShiVWO6wukbIu5PurSSWkF3MXmeOEyz6e0Ybsu5OkDkM4+FBcUsYllVLTtMtcdnMQeTZx8/M1SDDFoA4MyPwLiMSorhMtu34jppVx61iez4YlrDL2zKzyNrLd1mwi46bD50/4IEW9vYHha2ctqWIxnlvzBqg30C3sqnZ7d0TlzRef61fG6yUNF/ZgHAuEcStONW/EUEcSq3/AE2OSyjmMUxk/pT3iy6izsT2RGMDNUX3G4ZpmWBXUfh2X9aFurx+IXiPKJDOqnEgP4iMbsPHau9uKVIulZyB/us7Q3MOFYlWJ5+6mFyq8OMbo+EZcqwX+2h7hjerqiXWdAc4Oce2uW1795uo7a+lnAiXSuQO6KWSspFjWBriRB92nUK/Mnu5/iibmSOSQWc0ZZwd9OMH3/rU+FyRLKyK6tERgnAB/Y0yhNnCjO0PZlTntBuW+NKpeg+xVd8LaHh6okSFNWeePf7aQNaSTTDEZMj/AIhWrm4sJmIhhklc76SNj5k1Lh8FtdxzSTIsU0MioAGyMt51nJIz0ZDhzywcSMbEK6bEZ/EtaGwl0zlGcIDurAczSS9tE/zWZ1kxNFIRgLs3szVlnfDW0Uir2kLaXDr0z+VBPdoyYzu7VlmdC0bZw6uu450qvreS8mRQMRrsB0AoqXiS9powVf8AC2eRqNjJkltLFF7uhtsedJftgMxxhHS6WNNo41xHjr41fw+9fVHqK5XxptxrhzvbmSNArLlkx1pNBbw30faRMI51/EOntqla0OujSW112YkkYZwvLlmiPvYWyYtHl3XSinmKFvFFtFELl1EYTcryzilpux2Mc25Ukrhv7QKlJ8qFU7K4o2lndZz/AF+lXrFdQ30c/ZAaDtkc6uWVCRcFAM7gipLcyXQyO8qjl4U3yMdwi0NWjhsrkXUbBUm/qKq7aWqriU8ZH+ZSHBC6YRj+7HP3b1TGsU1npk0syHKqD0NFXNrZ8Uhht9YiEYyozzrn5tzJaugLg8rNAYpnY6t8+Vdm4rcQzBIpn0rt5VKJILO7eF5cKqABkqubhbyL2ttKsiMc5bun4U8mn2UtXTG3+fXzWUMjqrDV0GaEmeC81ySxvlsEYXTvVSXclnbxxvBpAHPFFXE/aWFtBrR3kbUzqN0G56e6k58Y6INUrQui1xfeNeBGsZUKT40K1ubxkQ4jGwDE7c6fJGI7efWqOWGktjc0HacJ7K7Wec6bZe+pZgT7l+tIsnJuTNGatsaSyQPGlirAgR4A6aqy/wB6ngdojHgBtPOnr3AjuH+72ile62tzkCh+MJDd2js0ECOzZeYc1psbSVNjQaixTDGLoh2wwB77E8hRP3WFbppER1XOUzgny3pCbvsx2duwaFf9XMnxNERcQa5kSIpuDzHLFVafbKtjDidrchIzHrZpm74zkADpUIbCCKP+vJqmYjnyUe6i2vvvdk0QkGIyP7vA70D98WKy7UthllIDAbkfnSwdLYkZUtld0gGhAHGdgTsPYB+tBcXYCK3tIAXkU6WYbnPUD41fdcTNnMjmDE4G5lOSvu8aL4ebm4VJVIxksxRQMjnRba2yWSfsCvYynDreaR9Dxr2bjmc9OXlV/DbqFpVvEaTRHtPkY1UPGb6JpPvkjRx3Kkxg4ySORx09pq+3kMM1vYSxq0TnVOSNix3Ce7881pL6tE5SdUT+19lre0urePPapkgUu4rGlkllrCSyFMuh5DvE7/GtdxFlubHsLdUR4XESqw2Y4zt4Uu4naWEssTTrI6xuIJQnRtO3uqeHI6SfonCb0mUy8MNzPrDCSLsda+EZxnSaU3luiX0Nu/e0xAlc89yQPftW0tODqb24mtrkGB4SujrkDHx2pEvDSL4sjsL0dlHEunOBjvN7qMcqboaOS9AFzbfeJgkcZmkikPbzAc2wO4vkKK4RcIl6gRoGn7Nlk9urYD4j4U2ks4eHq1nAXIYs0kmMEt5Uu4fwPsJHnEervZTPXn8OdD5U00wOSqji2rLJDEVKXDayCTns1/0il0/DEjsJpjs1uACTvqJP71puE28892jXcLa0lwz8vR5CocStFuOH3MRiWOd5cFQM6iv8VOOVxlQI5HFme0SWq2qzyv2FxGGBHIePvo62BS6Yv/UVh03z4OPyIoninDlh+zUAucCN5NEZJ7ybZBPzBqvgds8Fui3Ualw+mPDA5XFWeS1yC52rBogsFx93l5yZAB3DCruGWN2I7t0VWitVD3AZsE55Y/OhftBFNZ8UEv4YkwwIPL2edPYpWueC3HY93tzlyD+IheVbnX2/R+db/QSykhvXlhlGkHGgDnmmFpdQfcNTgSrauS+eZKjApBw2VVvYta8z2eodSPXOjA8UPDUVc6Lucyu3XT4e0mhP7Ohcm3RoLm5t/wDyzRDJuB2oV+YPOqo1hhuu2jzqdtH/AKR19nsoK+iSTi9tMxKJbx7Y2Hn/ABU7qaW04lC6KDbv+M567YNRi6mqZKIHx2F3swXGHSYg45adX7UuS1nmh4msWWYIhP8AtywH61qeJSRlZEGALgDnj2+jQVsFt4LzLRoLm2b+o3Rlw36U0Z7aHjKxEVZeKC4iZY4beHTl84yowBtR9tK8P3mSV+0HZgxsf9J5D9qAszLccTEelewQFjt06+2vX90zWQSI6g7frRkuVRGkr0OLa5ee3VfvvY20hwIymrP92k789udS4VcXEgurlZon4dGjEK0ZQyMOQGR48/fUhFCUXV+KaRXXK50nkdqB4vLFYr/l1uuoa9ZcHfpuOvOpwny+oyk3of8ADbhry0g7QwrDFmWVFUvpHjnlgbDGelM7m4tZF4fqdmCsXiZx16YyfPnWetrhUsIYbWR2muO7r0aS2nmf3ppG7Hg8BcYXDJLhc4bP4hn8q58jalZJ3dlYVbS9+7iQHEwul0EYBI35eX5VdxHiDr2OEWSOQOC+nZABuFPP65pfYNHNxAwAvapbg6yu8cozt/8AcfjTp+31xwz5ls9u0iOMeRBxsdgM/GqWuWwlVjeQtYCOaaO0iVWdkPebHXC/3CgDxCYcKuhapmBbiGQAMCxXS4b379KLn4bLc20vdSAAgQPKAMkHO/hXrWzjS1MkK2uqXvdxtQVupAB8+XnQU4rZq0K+ITvFIERVdNo9CDBydyfLrTC4cP2bTuUgkhZTq/AW6a/lvzG9HWtgkNrNcSIVKrnKjUfHfy86W/aC3aTXbrrZpY0lQu2QGI+XOjB8qa6Al7JWcF5/mhhulhZViAUBc6McgGG3zrOcWtr43M1wE7RQwVzHHiQryJPiPZWp4DHMkEHbW6RFFZBpG+kY5+PXahOO3MUv2hht0R9SrowPA5zv1G+fbVMc18jQE/toS/ZKacy/dpbW2uNOdUkq5K5/D7eRqjiv2ib7lNngltaSSNiOSInVs3Ly5U5SE2FnM0+000mElXZ2UHY+ftqHFuGdpxaO8lhWTh4BeQJ//d5gbk8qvDyXza9FFP7CPgyPBYQ3dsCXmR1lydjv8jULnh97IzIVX+l30CsO0x10jr7KjNa3tpZmGFXhBlZVWQbuN9xTninCb+54bw+6+8LI0MYJmTukdPlVvmr2WUyrhfE5HtHhmRZQB/1NGCMeNaLh5iueHSSXTK8EaYC/7vXWl3DoI7RWszL2t52TO8vLH70sj4k/DbFZYiGZpDpIGoHFS5vloLm/QbccVtkkRlmmOgkDtE3Ippw6+sm+zfEdY7JWukClcsWBArPxC34veIXuEaVjyRce6rb6f7vJ9ysbYW5ifL4OrWw6mqyauvY72ih57S1k7EO7NI+vPIkZ6eJptxHhVrawveWCtdrMmlldcGLI399LLSCGTiLJfAXEusmIdEB/ubH5UxbiIsOJNaLbkI/OQn8TY6eVQcnaUSLk70Ibq2uLe0DSaRnupnYkeyjLSf71w4ap0D2eBJnmUPL4HaldjiXjgu+0Z7Ryzydr/Z5Vbw8RyfaGa2t1GiQHO34hjmPH9qo5NafoPP8AR1Z8SF9ILPtNR16QARt0zSHiPA57PioNuMKGwcHFE3Q4fwqZGs1kaZnaJ+9+FvZ4Vbh4rayExd7m4lLRuOi+JovLSoPyV0D/AGk4gr3K2TDQscY3HjRs8EEXDeFwTIO1kjJLKMHypfxzgSw3wldmlLEMxDfiGOXtoz7TXS21xw+2+9PGqRqSg/DU001FREclpI5czR29nYwyRaUkZtR6geNU2cM8HEZ9EqGBVOXDAhh0qvj5mLW0qJr7OLUdIyu/Ko23apFbx3UJiM0mo5IXbwxzoxlcLGWR8RnwSG8W7ugYo2g7FwTjr0rkllNBwXVNKI7hn/GTtj1ij7S4nt450UhcZRQu+9WcS4fcX9siOY0mxnDtgedc3zfbZP5Xy2ZSw4n2E80McAllY4Wd8t8KX393ePcgTNI3gCeVa7g3Bks5JrmaTVpGVUL1pLdQXTXjRWtupuJCSSzDOPfXVHLFypFflVhNte8QEEUfad1sHS++aN4dcLe8R0SJGCo3YHFW8PtzHw+ITaVmZu9nqBRPDODyzQ3i6Y4FbZZGbORXM5Rdoi8ieihb1FvpYluEmZzjSn4V9leiuHa4lJmZiCVIY/AUjmhtrDjMUVjHczSROO2mcYHuHStA0f8A/kGcqvZlC2fMUMkVBiZFT0Lb69uZWudQOlMAe2hIXkkjltX3SX+8eOPjR6t9+tZy6aLcgjIPXNI7XhT/AHuKWG3bsklVe0Rs5361fHKPGmi8ZXGgngvAY+Iy3NjLI8VypBjlHIgcxj2UdafZ+OC8u55WZLeFWC6juPbTz7lLZXr3qxyO7sNESALy8fDereOWt5fcIZYrZ0kuGUTCPp4+6pvM26T7JvK+jIcBtFaW4uVbFrGwXU39wLc/hvVF42iW8uWZmh1BoAfHOw9lOrngUx4XPDa4RJJUyXOkaVB2HjREHAJ+IXFnbQpGyQZEhZ1I5f3dBnaqc03ZuduzBlLq6k7Vss8hy0kh5n31q7G4fh1hIcO7/wDSDOcqx/2iuW/BnWS7jvHBks01pGD+J2pjY8Ljn4ZGjwtJ2MgIy3dD88GjlyJpL0bI9FNxNNJxN42gjlghiQ6nXct0x4+ymi8PiuRazTxYmiOsp4HzoM29zFxZbmQ4jVe073VuQA9gFHcKuWnmfWhDt3jluprnyN1o55PQLHbhuINc5OgPqC9NeMZ91BWlwnEZZ7e6V8u7aTjYsoyDTWOEpbTHIjKuW5cqruEa3i1x7alzkcjtSRnRlJk+AdrDYwC6kPayEoFXpvnNHz6LWUmdO+O6JAMlfOhrCSKW4tZe4zxxnWR0c86Oiufvdw6svcBIpcruRnqQnvIXhu+1ncFAo3J3NWm4ZFyM6QN/dyxUeJWP3q6gtlUpAzcx0oVoJYIZbV2y6OQrZ3IHI0ErSbGavbGHC0W1up9iFI1E89THc1MOtyxlLY3zuBtVFrKsVmqk6umrxqSgkaQN2OxFC92I9sF4+TdwJaKhaJ1Uso2yNWQfI0Jw028cUdukT6U/CXycez6UxkSaUwRRRrgEqxb1uKOe2FvFEioCFbJbxNU5VHiNy+tGY45ZG/jhdpGTS2G7vQ9Kt4cYURrYs/N373d0rTC6lQFpHbQATgNy1UHDbSSRPLLvMYtGPKqKVwpjr+tCyZIcRCCLAjuNETA+KnP6VobG0jSO2iZVeOFMZxkZFI0hSI6JThFOvA5aulWcNu5IIZUbZckDHjTSbcdBa0S48bl2iRO8k8hVtO+3T+adoxW5mR+Zwo1dDjn7aACvOkbrswPSuszNdypMPxyKVPLapOVxSAugjiFkbmKMI+TG2pQP0oa/ttNu9tKSEmAYHxxTjUBKoYdP4oW+EizHLI0JXCMeaP5UsJOzR7EcFiLIvOGZnnGSM7KM0tilllaRZUjAmLGLP9pXly8eXvrQyxFkdN8FFj28KBS0dkhUorGJiuojGV8fyq8Z+2Ope2NobO4iuUkupgS+CnRccl9eVen4fZ3g7aWVfvKgoRpdcb8/byqy9vJG4nFEI0dpE/pHT3YivJceVNOHXEs1oDerEZlJfWqjGPP1tXNycPsB62LA0E8kK3MOmFT2UeD0A6Y8TTBownCbMRIIoix3lbY78v3ogpZXgF0XjtLxfxNjIbAwCG5r7RVa8MF0AwkQup1Kx3GfH9qWclpmk+iqyP3aaWKXLAgFUXB7x88jFFNNbQA627KKEFm7R8nOegx78edLjbXSXLSrIjK577KPw45EeVWRQi64h94nVJo0XA1f6h1JpU0KFssd1I8zIs6oMxo8jKvswozXpLCKQrN2AhlZQHjExAHs86IhiCxxPGVZW56KreIx4LynCjVn/V5ftQU5VxDyfQRPbrc2KLHOy6MAAf3DqprKcQc3PGbopbRvJNIQqMrHQDnp1ArRTS3EFzAuzRyKqBjyxjFHQlDqlSNe11aQSNx76MMjggp0AWMD2zRo+vScY193HdHh7KW8Rlif7SiLs3imG4ccn8Qae3TSNeQaZBojByAOvrpXXt0u/wCqFDSRDKkb4H6ilU6bZNdlUsMVxJHLLGNUWyY8Tz2/SlK2Ub8WmR5mCyyrcIoY4BX9DTuK37aNdPjuT4+dTMcPDtQd1/Fu43NaM5JGQn4ybeN0nmQMVbbI31fWirO5t7pJYJUVos6tSctXX3VbN/l/fTDXEpG2fwr13FdDxWNs9w+jsgn9p6/SqU+KXsdIy/HJbuS7u2tLaOKBoQpkJxq8qVR2rL9m5WeMv2ZLbbe01rLxmm4YsscfaGVsEdV86NuPs8j/AGbigeZxG28oRd5N86f2q8MnSY6bZ8ht7pLO/Wa0Ltp3BYY38q1kF797iTiKQBpWXvaea+dRvfs/wuHiBneeSGNZVSKEjIIxzHlmtHwvhlpw+4jlV5FhmGjRKBnJ65/KujLkhotJ6swV7cQ57G1vJI5nky4K7s3/AKhWqhke74bBEtz2lxFtufxYpLf/AGWmj43MLY6gHJyw5NmnfDeFtw+1W4vJB2kSkggZ260maceK4sSbVWmXS8LtL6wmjdyrMuGZdgtJOHcMfh/FLdJSH0KdM6brp8M1onKtZydmyvDOuSDyIrnDbXRbG3nMc0ZBCFWyEHhUFklTVkuTpg6cARLqa+uArrKMuM4r3HOFNJecOudAWCIYCkEYH1pyz9pGIWTMSYINee5+8XEiDv4bCjVnYVP5Zdipy9iG94b2yx61btA2pUMh5Z6mucW4GnEuJxySLEnZhRqeTAbyxTmdFV4+7qZtmGndaz00lxbXzx3KuElk/phznT5j6U+Kck7Q8bsLkidrSS3V2TUNLGEDBHlmkEX3Sbjqdu7MV7qllyF251poNdvCXm04UZ8j+1THB7bi9mZraKGK4yGlULgSfSnxSq0GH4JbtZbe0lNrK8rdsveHdLezyo97C84n2TxqZEYDtQTnHxpoll2hjQ6cR74xsp8KnLrsrRooGIdh+Ll8Kk8gjYotuHm3t5YEkkXB23o6wFtEZrgr/W/ArNyx5VTHcuCtq5y+nnUbeJ5brQ1rup1Bs4HwoW3diK22U8YtdU8LtJL3cAJHzO9PbUYgRRpHj5GglkSW4ljeMkjyohzFHbqO27ORzk5Gdq1XURoxvRRNw2Rop/xSaiCpAwxqb8NIkjUSan06nXy8KZtdwx8PScamxjJrsM1v+OLAMg5itJtdg77FR4TbwWZa7XWzONESnAWho7T7rJHHZWpAZhkj+0++nS2SjUzS6mZs5oq3EcEuj8Tv8hQjN2N7KBbiCY5fU7AbeFWPODF2QXLk869xgJbov3dtUp3Y0NaOrASY3xzpZP2hJ6kWX5d7H+pCGRmCg43BxQKWsVvZG3TuhQC4Ubt4UWjPJIw1PpzyztVscCzzHcspAJONh4VlJ9B5AXD+Hxx8NvLoxF+6QQ2NfLwoHh0CXUEdxb26RjJYIXIBbxNPJYmgVzGWLHPI1G2jitoANiW5notW+VNGc01SM/f2sksvaMSOyP4PGqLVkhZH33bPPmKb3sYW6ZmyQRnFLTbtOQQhGltsULtErvQdM+XwoyW51O5t+2t4w/dC1YNMMiF8aevtq8lJu+RlE8Kj0boXx2ENnDGyyquSdh/dRESCN8889cUuubeSa/WXOY15eVGRtMjMBvv7KZu0M6L7iMsEYDBXLZ60qsLR7y6mDM39Ru6Dz/amPaSAjP4T16V77yIVYRhdfjjpQTpUNFr2SbhCWUZZ3ByO6oGwoDTnQ6Dc1ezieHtJXZnB8a4W/pR9N+Q55+tE0qfRVJK1tiUoW0+G1Me1F1ahgNMfP2eNDhe2hK6dhzGM0M5ZY5rdDzwMU0XoVbFrMhDa0MgVuY3oG84w0VxKqRgKi6QeppnJEljbqus6jvvSsRmcSyFVK884q8KKqjqk39tIyRjtVXZRzJqpUaJbeGRcOBnA5edUW97NFI/cCI3IjrTO3m/8xumSw5n603FrQUqGPC3S6DxKNBA/E3X141b2SF01fiVufjVMSNawws+7vnJArzXHaszDZUGyiueSt6Fe7oukJa6168Z2Cj18qq4hCZ40CYwOYpdeXkaSoruysTkeNXx3jSsqqcjPWjxemCn2HzW8sSx63LFUAHjmgxHO0KQqh1aj/UPjRn3xPvEascnlkURdXCOq6cdwZPs+lMtDJ0CytPbI9zLICGwqALkKCPH9aIt5DaWKO0RWT8O25omVFjggRGCA7YxkeyrFtw0AjcglVwrD8JH0rn58uwyqiktG7oYdIVjyQHl66UU8afdlETEMo58vdQhvBGrQwKgZSFYsd8/WmKzj7opU6pG5kDmfXShPoWXRK31nQrJp01TMGRnJRVDHmo5+P8VZBdpqC5wcb59cq5dzFlYqcjrSrsmSwiwxx2wVQRkmr42L2b9ogK+J+R/elcUpkUZ3A6jYrUpL6OG7WGNy8WMYxnf10pqvoo9hUzdtFAiyaLmE5wp6/WqredxdNGzEFenQ1CeNtpOg7wNdhmW7UsCQw5/ShWgOSovlkS4DOhBZDhhnf3/WrIS8c8cjvpZ10lV6H9DS9IpPvDOjYwd1xRodSw2wxHSgkCOmT/zB42W2iOV1ZAxyNWXM4gKytH2hU5A5j+KEhgSK9ebOVO+fCrJZo5O6xYjwGx/mmemmPLTQNbStfXAQhBLLJ3lzinF7w+ztmEOdWn8QffOfEfpSPhNraWfHjfszSSf25PdB9lGy3VxPfyyXbrHGT3Ex06b1dSio/wClV1Y4nS3htUljRCVUd1F2x448KiL9JDFGzBQp1Pq5Mvh+9JrRpf8AMyUeRueR0FRtOIGaNUWEswkKuTzG/OhuuSMlYZNaQ3jTPJCrx6soCPlQccQ4gjwrjsY2xpK9R4U2FzKkTxAIEK4Vhvt7KDsw8QZUCgn8XSouVgb1oplRUOp3GMbseZNKpbgyyBIWyX6SDb+ac3WlQTsWJ/CR6+FIeJXFx99s4LW2xCBnWnT9qbFsSNWd0PJKIZZi8mNONOn4UdZWP3G3l7hACbDmTXrmKTQr9mcrjvdcVYeJyEIjA5558qNuzdsOtLSN7fSsx1PuySc80MLZOHXStGqLjIIPMUxtoI5IVdco4ztnOasmZXws2l26ORvQcgv/AEWs8Szo3aA/6hVq2NvPcJ20Xao3JsZ059c6En4aXkLo5A8KJtQ6MuhyMHlSKVbFUq2KLnhtzbcdktY0L2xXuZ338PbR1vAOH3aR6jkrhschTlbcvOJe0wcY3oGW2YzSO76gTzqjnqxpNVaKuyT73/TbIOWIFCLbPfcRdWOmCMj30RA0cF53QcedWzQf1HdXILbbfOlUkKqSFfErW1SZbu2OoY73jVf31UXUjgK2+aK7AQuyatQfmT0FDz8Mjmz3SoXlvVdMfTRaEkEqyJgbfGiprcyKXIDE/nUojClusf8Ad416Wd+z7GJBuOdRv7Eq32Dw4NhLCzDqPZQsMsUSJEshLA4JxXbaOWNn6b71XdRJJE6QH+qarfpjLvYdHdp2/ZhicdaYpcxQ2cmhQZpf7uvlWZtLG5cq8h0sNs0Y8mUMTDONt6F8XoTJS6JMZg+51IRRVu4VDsNuhpe8sgXfOF386KtN41YkkkUr6IP9C8oY9ge91q6JmihRV3xnSBQ6qwOdsc6uD5XSaQaMmRFxthzn2UPNqkVlzsfjV0sfcyp3/WhoFLIeZpl+ga3aBjqSRTIcAdQKuiukVcFSE8qKSJRqZhnO/soT7uzyldwPCnuzXXR2Zllj1YKoor0F3FhYxyPnVpTEJjfJz0x1oJbSODLL7s0B3+h3ZxtpZTgA8hyNWyShI27v9vWqYdSx+zxqqWbXsc+JpBUyUeG77HGKoZVIZs/izyqxyDEVANCJqR9ByRTDIJs7cPNpLZHhU7myZySjBVUVXHL2RzjDnoTVk1yGVsNvzreysaKrNCJezZj5g8/5qEuhJyRv02ob72IpMEnON6lKwMZKnvGmcdizohxKCO6ttWMkchQMNvosxBJzY5wdqsgnZJir509M0VcQJcYl3zy25VRNrTNDTqQou7NnmiihxgcwalA9wLgRGJdIGOWaNjiaMag3dUda8GeNS7/3HO53+NO5+joc4rRK5mMiRRkYVPXo1Vft2VqXRcsTv7audtSB8bctqlJCulVIBGM5xtSJkm09gKWqyxdvPG2sKSM+vlUIhJHbdsU3YcsdKZysjKI8Dl8vXWo3MqiyKqCfZsabnejRl6Zn76VwRpPeGM0fb3KtB2bvlyMevOl0dzCyMpI1Z68q9DIiM8sn/pUVVR1RZws+xt/h3xB0Gqe0JI2y7bf9tXv9hOJBEUXFqdByCZGz/wDbXq9XJxRP0B3X+HPEndXW5tFI7uA7Af8A21R/+nHGYZQYr200nYhpH5D/ANter1MkqF9BY/w+4m8Qf7zaAjc99t/+2oxfYPiwOlrmzI3Ozt/xr1epaQjRdH/h9xJcr94s8NkHvtz/APjyoC9/wy4myARXNmjg5La33/7a9XqeCVjxDU/w/wCKyRKGu7UbDkzf8a5D/hzxO0Pdu7RgSeZb/jXq9QpUZrRYPsLxVTqW4s9x1dv+NSH2D4mxaR7m1LDGMM3/ABr1epFFCxLU+wnELe2kIntSzNtl2wP+35Unb/D/AI/KXH3ywVCCMB3/AONer1WaVIt7DrP7CcSiu0JntCjKMr2jH/8AGmcv2Hvi347MgcgWb/jXq9SOKCweH7BcQizJHNaqxOk/1XP/AOPKuv8AYS/kQES2iFTk6Wbf/tr1erUTXZ2T7E8RERVZrXI3BLt/xqNt9gL+NS73FsxYY2Zv+Ner1GEI30OipPsPxM3G81noIJ0h26f+2p3H2Cvy2pJrQYOd3b/jXq9U2lyFl2dX7FcUNtgz2e+34m/41BP8PL8umue0Oo/6m2/7a9XqelZktlyfYjiMUjMs1rg741t0/wDbXT9juJknVNaHB/1t/wAa9XqSUVYr7OSfYviUg09raDbH42/41yL7E8Tjz/XtDjc/1G3/AO2vV6mUI/gaCv8AwfxIL3ZrUbZ/G3/Gg5vsVxYggXFmMn/W3/GvV6hSAwL/AMC8XEykXNlj/wBbZ/8Atq+L7C8UadtU9mVxn8bZ/wDtr1eqihGuhktFV99geKlCYriyVg2ASzcv/jVC/wCH/GSgAurLcb5kc/8A416vUIxVDeiT/YLjKlCtxY9Ocj+/+2pv9huLMCPvFn/82/47V6vUeEfwk+yEH+HvF0lJNzZH/wB7/wDGrJf8Ob8yKyzWYzz77f8AGvV6s0qB6Lm+wnFEQgXFnkcjrb/jQh/w+4oW1febPOf9bf8AGvV6kSQrRxv8POKOjIbiyyOR1N/xqUH2A4qiAfebPHP8bf8AGvV6i0qEpBp+w3FFUZuLM5599v8AjVY+wvFRIf8AzFnz/wBbf8a9XqZQj+GomfsNxQrjt7Pf/e3/ABqofYXii5Ans8kAk62/416vUqig0WD7C8UA/wCvZ8yPxt/xqafYXiPPtrTfY99j/wDjXq9W4oVJFU/2C4owGm4sx7Xb/jQr/wCH3FSpH3izx/8A9H/416vUUkNRbF9geLCMI1xZHp+N/wDjUf8AwDxMuCZ7P/5t/wAa9XqDigtKyw/YDiICgTWeP/W3L/41W3+HnE1fP3izzno7D/8AGvV6iooKRV/+nXFnIIubIb4/G/8AxquT/DviuQBcWWN+bN/xr1eo0iiRVP8A4ZcWOrTc2IO2+t/+NWW/+G/FwpV7mxODgYd+v/tr1ep2kZnJP8M+KByy3FiCOffffH/tro/w74yMZubE4wf+o/8Axr1epWlQDk/+HPFW5XNkNwT3m3/7ajL/AIacVZMfebHbxkf/AI16vVq0H0dT/DjiyRKBPYf/ADf/AI11v8POMDc3Fie7n/qPy/8Ajzr1eo0hfQOP8NeMtK+q54fnfcO//Ghk/wAMuPa9Bu+HkEY/6j/8K9XqdJWUXQCP8HeMGVpRd8PBByMSOP8A8Ksj/wAJuNIjl7nhzYOQe0fP/wBler1dD6K3o//Z",
             "text/plain": [
               "<IPython.core.display.Image object>"
             ]
           },
+          "execution_count": 2,
           "metadata": {},
-          "execution_count": 2
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "from IPython.display import Image\n",
+        "Image('cat.jpg')"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Building Clip.cpp repo from source (not required)"
-      ],
       "metadata": {
         "id": "D3MQHKeixw4b"
-      }
+      },
+      "source": [
+        "## Building Clip.cpp repo from source (not required)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!git clone --recurse-submodules https://github.com/monatis/clip.cpp.git"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "sZ9i_hR9YzD7",
-        "outputId": "cca7e28b-2ff2-4d2a-949c-a189eae5bfa1",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "sZ9i_hR9YzD7",
+        "outputId": "cca7e28b-2ff2-4d2a-949c-a189eae5bfa1"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Cloning into 'clip.cpp'...\n",
             "remote: Enumerating objects: 610, done.\u001b[K\n",
@@ -2200,52 +123,51 @@
             "Submodule path 'ggml': checked out 'dd1d575956e54c5bdc07632f25506b3b1884dbd2'\n"
           ]
         }
+      ],
+      "source": [
+        "!git clone --recurse-submodules https://github.com/monatis/clip.cpp.git"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "%cd clip.cpp\n",
-        "!mkdir build\n",
-        "%cd build"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "dOUvI0VCh9Da",
-        "outputId": "d6fc6481-cfb4-4e89-8ff3-48bef0f8f147",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "dOUvI0VCh9Da",
+        "outputId": "d6fc6481-cfb4-4e89-8ff3-48bef0f8f147"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "/content/clip.cpp\n",
             "/content/clip.cpp/build\n"
           ]
         }
+      ],
+      "source": [
+        "%cd clip.cpp\n",
+        "!mkdir build\n",
+        "%cd build"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!cmake -DCLIP_NATIVE=ON -DCLIP_BUILD_IMAGE_SEARCH=ON ..\n",
-        "!make"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "1-I40r-BYzA9",
-        "outputId": "6cb79e08-77ea-470c-9f87-4d44d714287e",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "1-I40r-BYzA9",
+        "outputId": "6cb79e08-77ea-470c-9f87-4d44d714287e"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "-- CMAKE_SYSTEM_PROCESSOR: x86_64\n",
             "-- x86 detected\n",
@@ -2317,10 +239,17 @@
             "[100%] Built target benchmark\n"
           ]
         }
+      ],
+      "source": [
+        "!cmake -DCLIP_NATIVE=ON -DCLIP_BUILD_IMAGE_SEARCH=ON ..\n",
+        "!make"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "h3VwlTRY2lD0"
+      },
       "source": [
         "### Usage\n",
         "- first download a quantized ggml model or build it your self using the information provided in the repository\n",
@@ -2336,18 +265,11 @@
         "  --image <path>: Path to an image file. At least one image path should be specified                                    \n",
         "  -v <level>, --verbose <level>: Control the level of verbosity. 0 = minimum, 2 = maximum. Default: 1                    \n",
         "  ```"
-      ],
-      "metadata": {
-        "id": "h3VwlTRY2lD0"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# downloading pre-trained quantized GGML models from HF\n",
-        "!mkdir clip_models\n",
-        "!git clone https://huggingface.co/Green-Sky/ggml_laion_clip-vit-b-32-laion2b-s34b-b79k/ ./clip_models/"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -2355,11 +277,10 @@
         "id": "83U-xBVV4a4f",
         "outputId": "c2cb3692-bc6a-4b1e-c620-9036a1b25aa9"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Cloning into './clip_models'...\n",
             "remote: Enumerating objects: 32, done.\u001b[K\n",
@@ -2368,16 +289,16 @@
             "Filtering content: 100% (3/3), 469.74 MiB | 46.56 MiB/s, done.\n"
           ]
         }
+      ],
+      "source": [
+        "# downloading pre-trained quantized GGML models from HF\n",
+        "!mkdir clip_models\n",
+        "!git clone https://huggingface.co/Green-Sky/ggml_laion_clip-vit-b-32-laion2b-s34b-b79k/ ./clip_models/"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!./bin/main \\\n",
-        " --model './clip_models/laion_clip-vit-b-32-laion2b-s34b-b79k.ggmlv0.q4_1.bin' \\\n",
-        " --image '/content/cat.jpg' \\\n",
-        " --text 'cat on a Turtle'"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -2385,11 +306,10 @@
         "id": "PXoULIhz2qJK",
         "outputId": "3305089b-6754-4c29-9bb9-affd10d20f47"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "clip_model_load: loading model from './clip_models/laion_clip-vit-b-32-laion2b-s34b-b79k.ggmlv0.q4_1.bin' - please wait....................................................clip_model_load: model size =    93.92 MB / num tensors = 397\n",
             "clip_model_load: model loaded\n",
@@ -2404,34 +324,37 @@
             "main: Total time:   343.50 ms\n"
           ]
         }
+      ],
+      "source": [
+        "!./bin/main \\\n",
+        " --model './clip_models/laion_clip-vit-b-32-laion2b-s34b-b79k.ggmlv0.q4_1.bin' \\\n",
+        " --image '/content/cat.jpg' \\\n",
+        " --text 'cat on a Turtle'"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Using the Python Bindings"
-      ],
       "metadata": {
         "id": "kKGzNLDQyPfc"
-      }
+      },
+      "source": [
+        "## Using the Python Bindings"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install -U clip_cpp"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "QK9_j5SuYy3Q",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "QK9_j5SuYy3Q",
         "outputId": "46ff0edc-a498-4e46-bedc-9d25fe14a69f"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Collecting clip_cpp\n",
             "  Downloading clip_cpp-0.3.5-py3-none-any.whl (349 kB)\n",
@@ -2440,36 +363,34 @@
             "Successfully installed clip_cpp-0.3.5\n"
           ]
         }
+      ],
+      "source": [
+        "!pip install -U clip_cpp"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### downloading pre-trained quantized GGML models from HF"
-      ],
       "metadata": {
         "id": "qKXPrZjWyllm"
-      }
+      },
+      "source": [
+        "### downloading pre-trained quantized GGML models from HF"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "%cd /content/\n",
-        "!git clone https://huggingface.co/Green-Sky/ggml_laion_clip-vit-b-32-laion2b-s34b-b79k/\n",
-        "!mv ./ggml_laion_clip-vit-b-32-laion2b-s34b-b79k clip_models/"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "Q3Hqux91ZlDk",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "Q3Hqux91ZlDk",
         "outputId": "0bc40416-8ae7-42ed-b6a8-512fea262aa5"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "/content\n",
             "Cloning into 'ggml_laion_clip-vit-b-32-laion2b-s34b-b79k'...\n",
@@ -2481,10 +402,20 @@
             "Filtering content: 100% (3/3), 469.74 MiB | 41.28 MiB/s, done.\n"
           ]
         }
+      ],
+      "source": [
+        "%cd /content/\n",
+        "!git clone https://huggingface.co/Green-Sky/ggml_laion_clip-vit-b-32-laion2b-s34b-b79k/\n",
+        "!mv ./ggml_laion_clip-vit-b-32-laion2b-s34b-b79k clip_models/"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "dBL2G6A1nDUz"
+      },
+      "outputs": [],
       "source": [
         "from clip_cpp import Clip\n",
         "\n",
@@ -2493,43 +424,55 @@
         "    model_file='./clip_models/laion_clip-vit-b-32-laion2b-s34b-b79k.ggmlv0.q4_1.bin',\n",
         "    verbosity=2,\n",
         ")"
-      ],
-      "metadata": {
-        "id": "dBL2G6A1nDUz"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "WHRejjjGo8qy"
+      },
+      "outputs": [],
       "source": [
         "\n",
         "text_2encode = 'cat on a Turtle'\n",
         "\n",
         "tokens = model.tokenize(text_2encode)\n",
         "text_embed = model.encode_text(tokens)"
-      ],
-      "metadata": {
-        "id": "WHRejjjGo8qy"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "RVc_e19aq1Ku"
+      },
+      "outputs": [],
       "source": [
         "## load and extract embedings of an image from the disk\n",
         "image_2encode = '/content/cat.jpg'\n",
         "image_embed = model.load_preprocess_encode_image(image_2encode)"
-      ],
-      "metadata": {
-        "id": "RVc_e19aq1Ku"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "P0m3XMv6Ygb2",
+        "outputId": "653d3624-3e58-42aa-b872-a9c363a6fb0a"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Similarity score: 0.2775198221206665\n"
+          ]
+        }
+      ],
       "source": [
         "## perform similarity search between the image and the text\n",
         "score = model.calculate_similarity(text_embed, image_embed)\n",
@@ -2538,64 +481,45 @@
         "# score = model.compare_text_and_image(text, image_path)\n",
         "\n",
         "print(f\"Similarity score: {score}\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "P0m3XMv6Ygb2",
-        "outputId": "653d3624-3e58-42aa-b872-a9c363a6fb0a"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Similarity score: 0.2775198221206665\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "text = 'dog eats a banana' ## unreleavant text compare to the image to see the score\n",
-        "score = model.compare_text_and_image(text, image_2encode);\n",
-        "print(f\"Similarity score: {score}\") # should be lower than the prev score"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "pV6m561DxVsr",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "pV6m561DxVsr",
         "outputId": "c7367a3e-12f5-4790-a103-ad9303d04aa5"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Similarity score: 0.10214703530073166\n"
           ]
         }
+      ],
+      "source": [
+        "text = 'dog eats a banana' ## unreleavant text compare to the image to see the score\n",
+        "score = model.compare_text_and_image(text, image_2encode);\n",
+        "print(f\"Similarity score: {score}\") # should be lower than the prev score"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## More Real world Use-case example with fashion image dataset"
-      ],
       "metadata": {
         "id": "DJSf9d6xJOvP"
-      }
+      },
+      "source": [
+        "## More Real world Use-case example with fashion image dataset"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install -q -U datasets"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -2603,11 +527,10 @@
         "id": "kipYEwmdZWNU",
         "outputId": "bcdfbc8f-379c-4660-f336-3647d9aedc4e"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m519.6/519.6 kB\u001b[0m \u001b[31m5.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
             "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m115.3/115.3 kB\u001b[0m \u001b[31m5.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
@@ -2617,18 +540,14 @@
             "\u001b[?25h"
           ]
         }
+      ],
+      "source": [
+        "!pip install -q -U datasets"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "from datasets import load_dataset\n",
-        "\n",
-        "data = load_dataset(\n",
-        "    \"ashraq/fashion-product-images-small\",\n",
-        "    split=\"train\"\n",
-        ")"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -2705,121 +624,133 @@
         "id": "YIr29y9sZa38",
         "outputId": "f0552157-bd24-437c-f5d6-ae49acd5165b"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "4ae67bba152f4240adbe501402f70e8e",
+              "version_major": 2,
+              "version_minor": 0
+            },
             "text/plain": [
               "Downloading readme:   0%|          | 0.00/867 [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "4ae67bba152f4240adbe501402f70e8e"
-            }
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "eca90f32fc9248769e710913f60b9b7c",
+              "version_major": 2,
+              "version_minor": 0
+            },
             "text/plain": [
               "Downloading data files:   0%|          | 0/1 [00:00<?, ?it/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "eca90f32fc9248769e710913f60b9b7c"
-            }
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "6632fa54917a4a66949ac64be2405eae",
+              "version_major": 2,
+              "version_minor": 0
+            },
             "text/plain": [
               "Downloading data:   0%|          | 0.00/136M [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "6632fa54917a4a66949ac64be2405eae"
-            }
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "a58c4bf3ff87443bb130154914fd6d30",
+              "version_major": 2,
+              "version_minor": 0
+            },
             "text/plain": [
               "Downloading data:   0%|          | 0.00/135M [00:00<?, ?B/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "a58c4bf3ff87443bb130154914fd6d30"
-            }
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "1a4295168897427eb269166acf54b014",
+              "version_major": 2,
+              "version_minor": 0
+            },
             "text/plain": [
               "Extracting data files:   0%|          | 0/1 [00:00<?, ?it/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "1a4295168897427eb269166acf54b014"
-            }
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "dfc716ebacef49e1aeb4de6a22303aa2",
+              "version_major": 2,
+              "version_minor": 0
+            },
             "text/plain": [
               "Generating train split:   0%|          | 0/44072 [00:00<?, ? examples/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "dfc716ebacef49e1aeb4de6a22303aa2"
-            }
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "from datasets import load_dataset\n",
+        "\n",
+        "data = load_dataset(\n",
+        "    \"ashraq/fashion-product-images-small\",\n",
+        "    split=\"train\"\n",
+        ")"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Qns73g2CZh6w"
+      },
+      "outputs": [],
       "source": [
         "images = data[\"image\"]\n",
         "\n",
         "data = data.remove_columns(\"image\")\n",
         "product_frame = data.to_pandas()"
-      ],
-      "metadata": {
-        "id": "Qns73g2CZh6w"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "product_data = product_frame.reset_index(drop=True).to_dict(orient='index') # remove pandas default index and convert it to dict"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "stF7ehVFZm0X"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "product_data = product_frame.reset_index(drop=True).to_dict(orient='index') # remove pandas default index and convert it to dict"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "lUafnezDauhy"
+      },
+      "outputs": [],
       "source": [
         "from pathlib import Path\n",
         "\n",
@@ -2827,15 +758,15 @@
         "## ⚠️⚠️ currently clip Model it only Support loading images from disk not as PIL or numpy array for example\n",
         "images_dir = Path('images')\n",
         "images_dir.mkdir(exist_ok=True)"
-      ],
-      "metadata": {
-        "id": "lUafnezDauhy"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "mHvrsGWKZ4Y5"
+      },
+      "outputs": [],
       "source": [
         "image_files = []\n",
         "\n",
@@ -2845,31 +776,11 @@
         "    file_n = f'images/image_{idx}.jpeg'\n",
         "    im.save(file_n, \"JPEG\")\n",
         "    image_files.append(file_n)"
-      ],
-      "metadata": {
-        "id": "mHvrsGWKZ4Y5"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "from tqdm import tqdm\n",
-        "import numpy as np\n",
-        "\n",
-        "##⚠️it take about ~30 min to embed 5000 images of fashion dataset\n",
-        "# image_embeddings = [model.load_preprocess_encode_image(im) for im in tqdm(image_files)]\n",
-        "# image_embeddings = np.array(image_embeddings, dtype=np.float16)\n",
-        "\n",
-        "# if you had already embedding saved as npy you can load it like this:\n",
-        "# image_embeddings = np.load('data.npy')\n",
-        "\n",
-        "## 💡💡download & load already emded 5000 images from fashion dataset\n",
-        "## if you had already embedding saved as npy you can load it like this:\n",
-        "!wget \"https://drive.google.com/uc?export=download&id=1kiewhrTHokuR7uuIYscOd3tGRVISXETF&confirm=yes\" -O ./data.npy\n",
-        "image_embeddings = np.load('data.npy')"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -2877,11 +788,10 @@
         "id": "UwJ3ox4ab5R7",
         "outputId": "4c75e599-e81b-4a2b-8646-d8385b2f53fb"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "--2023-09-13 20:37:26--  https://drive.google.com/uc?export=download&id=1kiewhrTHokuR7uuIYscOd3tGRVISXETF&confirm=yes\n",
             "Resolving drive.google.com (drive.google.com)... 142.251.2.102, 142.251.2.139, 142.251.2.113, ...\n",
@@ -2902,65 +812,79 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "from tqdm import tqdm\n",
+        "import numpy as np\n",
+        "\n",
+        "##⚠️it take about ~30 min to embed 5000 images of fashion dataset\n",
+        "# image_embeddings = [model.load_preprocess_encode_image(im) for im in tqdm(image_files)]\n",
+        "# image_embeddings = np.array(image_embeddings, dtype=np.float16)\n",
+        "\n",
+        "# if you had already embedding saved as npy you can load it like this:\n",
+        "# image_embeddings = np.load('data.npy')\n",
+        "\n",
+        "## 💡💡download & load already emded 5000 images from fashion dataset\n",
+        "## if you had already embedding saved as npy you can load it like this:\n",
+        "!wget \"https://drive.google.com/uc?export=download&id=1kiewhrTHokuR7uuIYscOd3tGRVISXETF&confirm=yes\" -O ./data.npy\n",
+        "image_embeddings = np.load('data.npy')"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### saving the imbeddings to disk for faster retrieval"
-      ],
       "metadata": {
         "id": "GQCPpfSmF-y8"
-      }
+      },
+      "source": [
+        "### saving the imbeddings to disk for faster retrieval"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "np.save('data.npy', image_embeddings)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "HpUc39sN9DHw"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "np.save('data.npy', image_embeddings)"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## USearch Vector Store for faster lookup"
-      ],
       "metadata": {
         "id": "XZKYIKr-F-OF"
-      }
+      },
+      "source": [
+        "## USearch Vector Store for faster lookup"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install -q -U usearch"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "kGgOvX5K7Lpv"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "!pip install -q -U usearch"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "import numpy as np\n",
-        "from usearch.index import Index"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "vy_zR_117RUg"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "from usearch.index import Index"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "image_embeddings.shape # ndim is -> 512"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -2968,41 +892,40 @@
         "id": "OkyrldQoRCg_",
         "outputId": "abedc107-1ed3-492e-d285-baac198c16ab"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(5000, 512)"
             ]
           },
+          "execution_count": 62,
           "metadata": {},
-          "execution_count": 62
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "image_embeddings.shape # ndim is -> 512"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cRNqCxYa7RQo"
+      },
+      "outputs": [],
       "source": [
         "index = Index(\n",
         "    ndim=512, # Define the number of dimensions in input vectors\n",
         "    metric='l2sq', # Choose 'cos', 'l2sq', 'haversine' or other metric, default = 'ip'\n",
         "    dtype='f16', # Quantize to 'f16' or 'i8' if needed, default = 'f32'\n",
         ")"
-      ],
-      "metadata": {
-        "id": "cRNqCxYa7RQo"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "## each vector should have corrsponding key hence range(...)\n",
-        "index.add(range(len(image_embeddings)), image_embeddings)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -3010,22 +933,30 @@
         "id": "U3KFXC3Y9zuv",
         "outputId": "ac007afa-9fb4-4473-a738-21438cdf7465"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "array([   0,    1,    2, ..., 4997, 4998, 4999], dtype=uint64)"
             ]
           },
+          "execution_count": 64,
           "metadata": {},
-          "execution_count": 64
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "## each vector should have corrsponding key hence range(...)\n",
+        "index.add(range(len(image_embeddings)), image_embeddings)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "zvAi4CAg7RNx"
+      },
+      "outputs": [],
       "source": [
         "def search_images_vecstore(query: str, index: Index) -> list:\n",
         "    \"\"\"\n",
@@ -3037,24 +968,11 @@
         "\n",
         "    matches = index.search(query_embedded, count=10)\n",
         "    return matches.to_list()\n"
-      ],
-      "metadata": {
-        "id": "zvAi4CAg7RNx"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "from IPython.display import display\n",
-        "\n",
-        "\n",
-        "results = search_images_vecstore('blue bag', index)\n",
-        "\n",
-        "for (img_idx, dist) in results:\n",
-        "    display(images[img_idx])"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -3063,121 +981,134 @@
         "id": "4ga4d4LSBGB2",
         "outputId": "0331998d-4eaa-4c0d-c4ff-d9b4470d7d75"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXtUlEQVR4nO16eYyd13Xf75x7v+0ts3KGy5AUd3HTZkqWrN22ZEt2G8Wt7TpOHBSJ26BxW6BLUBhFgSBAGwRJi7ZogcANnBpd4LhF4Ra1jMSyHDuVtdkWKVIUF5EUOZzhcPhm5s285Vvuvef0jzckh5TkOmmgxIDOH+99775v+d3znfs7555zSFXx0yb8Fw3gzyLvgX635D3Q75a8B/rdkvdAv1vyHuh3S94D/W7Je6DfLXkP9Lslq6B/uvYvq6CJ6C8Wx59KfprN46dLrKpesw0RGfy8NvKX02zobZegqg7G107gL48wIJBViBenL3/tq08fO3yOiJiYmCEqIkFF9epM/t80I+84otc+cNN9rulu8CUiXsI7cRqpKAghBGPM73/pf3776y+eXHjxk5/98FNPfKYZjUztGLvx2QxAEFSVlAEoiSqRQgmkAESVAGG2YFVVCqRGAWaBEhQMDT/m7ZEiULAcXZ/MW862SqCrthsja+fL/Wi2r2d/77/85isvnfvbf/Mf3nv/AULUaNTSzBqyaZoyDAhYvRPjhluaNao1IMBe/4euHenVy68dXD8WC/P97x0+/+bcRz/+wNh4M6g3dO0uAGAJgCgxQxFWzOzSqX/wxS9+/lO/eKU9/cSnf+bXfu2fjIwMLRULQ82xZq2ZRHFWT4eyoaxRS7K40WhYjsoq7+c5k4IV0I0bN0+sG10/uWHT1HpjqKjKyKRZlhARyECDtVaVajbuFTkRG8MA9fLckh1q1gXS7Ze/9S++9K2jv/9v6Lf/1i/8XYZRBXCdMOzgFRPMhfMLx189Eix/9OHHwDIxtuVTH/rVf/vav7amlpIWK77bbmUm6VTLCdVE1GuIjY1M5L0QEbMNWqmqc5WKkEGjPuTVO583szFlOFfW42EvBVmbcGoQixYA9yUPUhnhLGpQROpdHNVCqY898gnTnP/jF75x+96HR0frBL5GdFYBiFHWmdfe/FHPx/d+ZMvkOgkMhjXUq7rz7YtV8KxsFCvacSwwSiA2tlFrEBlAIAQ2LkDh0iyznBhEqhqTmKThxSeSxhQFVxHBlCbYKgQPZnWVhoINw2hRdvNOwZGte7/c7v3OF/5dqz/zqc//7K88+Zu/8Vv/mMwa8wDgGRHpD8cmvjW65efu2wwTuyAJsfooMjb3BQVRRCBjbZKKsrKIxCYhz8oI6jkQs0gIQVXgPWCMJyJVFUNGENATVVU1ZD31NCA1mQ95xNYF550zEsVUJyJyQQ0V2qs3bTa6xy9vPP/a4uGXj7/vvv3XNU0QowDxV2cKFP2Rsq2qRgXAQmtZEVuVLE4jm1m2IuKCMxSZOBLxToKIc8GRUmZTQmSYYkotWRFRdQFqhCR4S8xk2bDhLEhJpAAIEdRADRN57xLrgpSeTBTKqvKvnjz5xOMf2b1n22RzLMsyrKFFBsBgCCTv05FvjZ45ilUy4fbCRSmXVZzzhYTS+SJ4Z4lN8N51VUrn++pKVhF1Hp5VVCmIG5j4wDGRMrERGAreh1JDHsFGhIjYaBSzqdt6IxpOuOahqmSZXagWu7NvnD67eOVio+F9xIQb2QNgR4gIH8rmr/Tbr79+TgnGqANOjU21mxNNG1SoUFFxliwFIo69iuWaMZGGkpmNVKUPDv0ap7m4yvdFYCJbSaAk8WVBiAGBBqPKTAQl9FRMLVAFGBUnZRTIqfOVCIKg3LZzd78/f2BzFBa68A5rYgoLhVEPsp+cGvqToebhc6e+9txLn3ng3pmV7pF0Anse7fiiAwMEGCYYJQIi1BuAobynLEiHKM9JCtiIJWiUKgt8STAhjljtwCtpFKkI4hgUk4iJNXQ7IIuiYJ9r6BvHIYLCm35houHNW3dcmTt7+KV0397hfrN2A2glgAxE99559+TU5Obk5Pkf/Hs8cO/pdlh88xKrIdsILGRTsFFOiBOlYOJIlNUmJo4krVPcBZFAJW4OnAsRibHwTsTDGhIlIthESdg5jWNvLEXjcH1qmBAcqkJtpMFDScPpUBv63qnTx77+jO/UdMckbZ640TxUGSSscWY+9/f/2nPfPuVbZ//gm//xWb0HrgcmTZpMTkAEZksaPBkjykqCJAKnsEzNIQ0liTBBELTM2dZC6BEzub4EA2OULUIJDQpBsESV+tJy5lGRMqKUbKLGU1WpajQ59j/+0zeq40fHp0af3Dt3V41uNA8iVWUQIE985MPL7uzCy1/69T/4k5P1hm3WQmuebRYiw1KprYkwJ7FQxAYW7IhEPEoTIk8UETsh1aAAAntSq3BkU7Jg51Ug1lNkNRiCoHAQBNNjRGKZi1IBzmI4FfiUcHnucve2x/NN3SxbGlDHNdBMECICREBW8bmP//L2Ax8ZrnlV9pSqlqKOtFKwWjbECiYrGhkfxQSBKiIiJBS8lgEizGxsSogUjigVa+F8UCgJM8gkTKQqJssIXilSw6QiiUUUifPaaXFiXDzc3vtI9cBT/ZFbjM0AXhvxsa5uXphApB7gDz70BYNbYDUOaC5c1F6LPDiwURILqIcyopqyKpOqauk0eJSlphGRwoUQQdkTImIleE0Sii2yVASKIJYpSQMBNoJhWAYbcEpxRgi6comNcel6sUPozO+cnt61+4O4UZiuhrAEIbZBZWjDpp/7q08hjquZ83vKYvPKoi4vQn3o91QJcaRlgTInRIhiiqyJmDTARqzQICwOPhBZjSLxQQMTWfIgz8RWg5AynCoiTlMA6gLYssvRa9OVOc6v+GwkQ+e+oVef6nz57jjevvf9AJiv7wwtBvGgAkpKKmADLO/e/9DFN83s/MLZ+kZXLOt0p2u5XkfeAYYH/KCqg7gt1FL0e6ReyCCxPomp9EqAOkQKMMAaEaRAEI4yKXOyMYyVAGILCkqBAO13eOlcCGHvSOvJsZN37Gz2lrN1ex4HWETWgh4E9QoCmIjIqEBxajFfeW32qbvT9ZNVr5r//AOdB3dfkryjGkBBYwsjpI6EoAowcUxBEISUSaGGqXAkBEo4kMJBlWILV4rPqVaDsSRQy0gjxJYjSypatKXbGh4xj48dG2vqXNgkd/7ypz/5BOEGxKtRHl2Pw4WIlFACJ+b7vx7et+XApnDkhQztn93dvtgZeXN+yfgcJpVGDckIEkMmQdljlWAjGNayhAU4ZkbQAFVhJiZVowFo1IkZIhx8YEPw5EpBUBeiciUszSmjyfmrP+wYWf/cPe9/ZP+hL6iuxXfdpq/tIa4aNy6XZa0ed+3oMd51etfHprEt9FbiRHnn/VprivRReeoto7sieU5QKDEJMxtSqpQlqLUQJQkQr8QgouCvPTUQg1VhhQ0Fx8G53pLJW4htb7o3f36D0a0lzJkLl7wSgcON+86ralcodMAhUPS85aSJyhnti7XPLO6bXgkIbYGh5nqA0G8j9MkXpqrUi5Q9rbqad4MSEWlZinikCallZhN04DJYrJoYXqBkjIEqQZSM9Lu0shxYDVvbW0yH+WMfXXp0s7+46JaDQG/Ozthr2uVB6EdUqpYCI1BlLQpic0k2fv/Ewdhfot3eSzxalJUv+spic64ZtlAbcVUJPEQhYBfElVpGGhxYJalR2TcQJQOpqY1YWaqcgqN+jtKhfYXyJUobWpad3Q+9cvcHH0+/uSvu/3Ff+04RQYVpDfBV81ACwCACUAnyoi8i2mxwLaMkoiQ6PnTHwpWsOfs8vJPL07ta02nRhmRa9KTM0V5Q57hfUOU0rHILayBLIEN5j8WHKFIKJMLMakBEKB3AXK6gXFKjWpWSNd32uzC264Vi/0zLo9KOdwDkRlWvxqkD1hOCATyIvTdxAkhQJWNVfZVFl3bd/770+OT4d8+MlTIfbVs5TxtXTnU2+R7YIpSlUahVioOKkga1EUgIiTonRlEGjpLAjMpTnksWwQfkK+QKVYIqyh41NgQXx7PPF5dbZzcfwnh/uXqbZMOaKVz9NxDEB5BRMqtESEaglNV+hEOhoof3tmAW+yvzd2XHfum2kzW5EPKSfCGslrwGp75QceQrVE7LJahX57kq0S+59BoqTSJjLIJn1xPXRSioysFMMd2Xfuc3tn3rTpphnyJLjHoARt8J9FVxglBWwhYiliyKkpaXEAjekfpn3jz49Yt72zt2X0JUSLwhWvrswUU0akoGVd+7nCWoCMPAO3UVeSbnyJUIFUIfrsfdvqqIBK6qQEZDABvOhhCP3Df++sc2vLGxkS5S1B5uIE0NMSA3cd71bYxenUEAUFWqit6KrrQkiqn07EohMSJqZKHaugDGlpFjy28MzZ2t1WXElO3xLbRwTjstjRKCaFSnoqBaKk6IBRxBSGoxTKyGEQQKGKVKECVadQMiY3q7Rgui2rfbtz679e5uxLGlemwBVsXaLNN10NeCEGakijYbJKy1GgdIpJqXbJPgK3K5kUp7Jak7eSHjdjwZz+TJEtW3yZb9dOIlLXLElqAwrN6RjbVyFBlopaWSjYktEGtZEBMbBFVDJiCwtW9c8JcPx60DO5b2rqfC1erJkF2TOngr6GtiACNeNSBpKrU0Ti3VBSR5Tuhr6IU8hzioY+mdurL+8vIVN/GGrhtDurUWazpzYWF4k/aWTTIkYI4qFaPqJYERiAtKbCKPKAlqjKlT7KXsQuFgjp2JdnodK5fj+dly3ZYGUxYPeFjWWvI10NdHSQHxrpaQL2EjFHnodbVXoLwClyNUJErkNZCCJYmWarc2i0uxOdN67YK0ToyGwNa0TBxcYFOEokakqkp5U+OUXKkwmjU1ilB1pHTQHKGgMieOo15HN23bu2P2yKwpRzcONZOmIbo5w3qjpgUwABFIBWS0LDkv0O9rewH5CoqO+h6BVR2RJROJiaCVNkdWStqvZ3Zs6F8q8sX5aKxmH76v9sKl6NIZz1lfbMpaalkpjymDjEFvSeMIwaMqVEoS1WSIQl5M3XH4wZ8/uL21udtZUDNVs5YGBs3vCJohAJg5Lbu+KKlfSL9DeQ5XUP+KVn1SUfXMEdir64MFwVBCsNnxC7x5XNLhcnHJtbszO4a3bhm98pWVZGlBUfXVNsGqriAJiDKxlrxX5zRUYNJQwpAOb83X70SaPu+2NxrTqm6qZggSAIO3B81XPyWCxGXwAg0FeYEvUbRVAkSVGapCFhAmoxCQwJdEhixfXBwjSXWsXpbL33/98p4N0aE9u5/tPoHeBb14VE2dCLCRIhixwVgyqhIolGpqAKthdeD2hXJoouJRCrQxSyCDUsSNNr12wwhAVTMyDYYnpjLnbkfKJeRXEIShYhJSQWzBkVQFYEBBvVdWQ5aigNCgquspOjFLHLpdnNShB7Fln6YJTr+MOCMp4UOwOfsIGsgXYgxzrDZRtg+PPf/YVO/kzF1/OHqfSr4lBpigwM2aJhpksxVCgMBEwITrctdTtyPFCsplDqpk1HpECShiMkETcG5EBF5JoAhMDAKpRMMI/YX+5Otvnle6jPgZ9O/HUHODUFn5Jd/mKENRiIkJpOoRJWosNPrApukPjZ/dko6daphO8I3UbFuXAlCIgte6F7tGyQSQKhShxoVUufV9ljJA1cbQAB4CQFGM4AklURzUsfeklShQeTWJEiCOyMBmC+VGXjmjfASc4JyPi4XJaCJKZD4sk8kAUYBMpMzKUZLpremlvKy91Lvl6cVh31zeyLUdzVQhDKa1BYOrSfXrFQwoiIxJGAYUvIhD2UfoIxsyloLEWokQkYH4inxXXa5ERglSqgaAyBdKIEQSZyFd30xWbt385sJi0Z72RYF92+M7tzb/6EUHidkaEYEyKWVF58hz0abm9pfufnBxZYGsrB/2U7WIIIob/eH1jS0EOoioBTA7xkaRt5w4uC5v2IqxKQnJWHX63pHXrI1Pni4vXQAsuqHwUQ1stN8WYUgOw6oBsdVQIVjESUfXnZ2WDaOaD+Vzs2cfu2Xv/QfchTl36nwd1jPFQhT5/mTrsnFxb7Tuqh65ZdXGznrSAALYEG5eiDewBxMpATh0+zZ8781GK52oDS/BLs/NcZJeWfKn5mYObKZ1ppxzJiub6tzK7Q/q+Ba9+OrttcPB2NayXW5r0fMRSaiP6dBuXb601F9yvteNtkfbo+FM/9fM/unICh01GBMK8D1r0st7P3BlvPngxFznwowxdd/pR5WCARWA8Q48LUpMAIih4a7bDn5hxw8unD16bPZsuVzpgXvVNSKWzpVNRxc4GwpPPSWpSZbbxdPtcjmOdMsdsjJ3z8QKbzezM+2Xf1CFkBXV5ZKaNLwzS098aE84caJ6Y2Hpa6fuWBi9A5Mpzrwi84c1bmBoS3/nk7RpQ7pjvDz3H8KRF7Hj4G0PP/J3Pv0IBrWzt0TUdmDHOpiKYpD58FfO7tows3JPoz0z84FPfOzD9236vW/MnnMjl6u5ervlZ7nf00cf2tysmdrM8WWaMnHtdHv70tEfJs0ajW554NFLTY6rfueZcxeWagf76/d8w2b16tlx/5pr18bM+ZWQ/PVf/ext69Nmlv7v//PisL76hjsv7Q237dy2+x/ddc++/R++/Z7NY8O6utIEekPhb1D8lGvhnweMhqd/+J3PfrcMM4vJC1/++feHmOTbz1Lbj4Ywe2lqk8cwLVcbJ+ae3NxKk2GfDL30XGt2Om3Yyng3M3UbHdw3xq2R4fpwfiYpOmprNjFzx1u9E/3M5gt5MbZj5F/9zj83GH3xe8+UnW/v32WnZyna+jN/5RMfn6iNNGxCGPCcvG3Eb0EYsOAgMGGASF+niZXpc4de/dG43378+Pna6Ew2MlJ2lpbDOtPcG8b2kfPt7vwPzj1967rezq162/58pT3dxn6d2JGRa9FEv6Urr12qm9pWf/jRh2ppZKtD+lXlo/xQvGF7O/W/+MUvxyeO1OpbNq0bOXH5YjMZ/6Wn7t88tN76AFVPYvVmU34rewz0DgI08OXvnEZvvl4ve3NFu8j/xkO3pHeaVle/MruvDDvZFyLl0NFvdZ195dxIq9X9wH0Tn/vUxLF2+vXOPp9upXJJ6hnPH876K7Nm8vlXVh68z/ign3mk8Z8Pz0yX2yrb6O/9EPqXdi0enfd3fLf/+G8/tvfAvm1GhY0RUgsDlmvQbnLbFgqQABDQwHACuNk99892H0k29/5wtjN3du7pZ6YfuWe9in4wnP5vL9jQ2Itt98/VMDR3OE6mLr6weKVdfPjeW3bHrXvnfve5xbtpYrciXWzUkL+WqX/55SvtIn3/geZ4yB9IX/+v3z9qbn8qhN4Dt2e3RcO/e3LyV37h0S88+T6oMWCl1cL1dX+iuImnaVCAv06Eokq4MPv6f//qFy9enH329eap7sayPn5o+PymcGT2Is/PpnkROqPmzoP1HVn72IneicVJP3lwy9jyjvT0ueO9Tkv6Q0Pj28f2jyysr4dnXwkz8V1obFpHb24sXm63rO9klIUde7oP3ja5MPHw6MFP/tPH7qnFDWtudHy6io6uBhrXNU2DKs4g56uB2EB1amr/Bx/7e//yq195deoQNMNS90fHZl6fKYazKWjgZOHh7cXu9X65p2dlvBq/i2r185dWLp4vU8+58beOXrxjbFmz7Ngcz9hdGNoA+IWFTutcdzjbPLZu9MCdtUOHpvYcfPSu2x/ft2kj1A40t1afSiAwSAC9ybjfvkllMM+LKwt/9NrJbz5//Mz5+Xj2iG3nHkVUi7Ztx9T4SNaol/Fky22KYrOuTo3M5K0VVxVZM56YGI4B5cxHaSlWqmpyZGS0kVHlDWF8fHz9+o1DSaOWpPQWe/1J5B1Bi8ggv+rFtV3pXOmr4KExm0FoEZk4MTBWiSgoGUUURQpWIlIyRApE7/xgDzUg/OkR/zjQUASCBgUJQxWW1BGMQFeL3kqqCvKqyhSDhK72k1yv6DCreF3TQACAiaE3BZtXn/mTzeGdQa91RHrDClYIga/SDq+euzpyfc7A6s+b9xkQhZLyn7k76se1uPFgdQwSPCS6Cg40uIqwWnRSQBkQXT1n0MMzaP55az8ToMQw/z/9XD9O02ses9qoc02dejXns6bOBFWsDg2mN3hPa1T+5yU/BrQAWGMgGCyamzBctYg1QYJC17Tu6DsA/jOQxk8AWtfo7CdolLwZhCjobaLKPxf5v5UEEgSH728wAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXtUlEQVR4nO16eYyd13Xf75x7v+0ts3KGy5AUd3HTZkqWrN22ZEt2G8Wt7TpOHBSJ26BxW6BLUBhFgSBAGwRJi7ZogcANnBpd4LhF4Ra1jMSyHDuVtdkWKVIUF5EUOZzhcPhm5s285Vvuvef0jzckh5TkOmmgxIDOH+99775v+d3znfs7555zSFXx0yb8Fw3gzyLvgX635D3Q75a8B/rdkvdAv1vyHuh3S94D/W7Je6DfLXkP9Lslq6B/uvYvq6CJ6C8Wx59KfprN46dLrKpesw0RGfy8NvKX02zobZegqg7G107gL48wIJBViBenL3/tq08fO3yOiJiYmCEqIkFF9epM/t80I+84otc+cNN9rulu8CUiXsI7cRqpKAghBGPM73/pf3776y+eXHjxk5/98FNPfKYZjUztGLvx2QxAEFSVlAEoiSqRQgmkAESVAGG2YFVVCqRGAWaBEhQMDT/m7ZEiULAcXZ/MW862SqCrthsja+fL/Wi2r2d/77/85isvnfvbf/Mf3nv/AULUaNTSzBqyaZoyDAhYvRPjhluaNao1IMBe/4euHenVy68dXD8WC/P97x0+/+bcRz/+wNh4M6g3dO0uAGAJgCgxQxFWzOzSqX/wxS9+/lO/eKU9/cSnf+bXfu2fjIwMLRULQ82xZq2ZRHFWT4eyoaxRS7K40WhYjsoq7+c5k4IV0I0bN0+sG10/uWHT1HpjqKjKyKRZlhARyECDtVaVajbuFTkRG8MA9fLckh1q1gXS7Ze/9S++9K2jv/9v6Lf/1i/8XYZRBXCdMOzgFRPMhfMLx189Eix/9OHHwDIxtuVTH/rVf/vav7amlpIWK77bbmUm6VTLCdVE1GuIjY1M5L0QEbMNWqmqc5WKkEGjPuTVO583szFlOFfW42EvBVmbcGoQixYA9yUPUhnhLGpQROpdHNVCqY898gnTnP/jF75x+96HR0frBL5GdFYBiFHWmdfe/FHPx/d+ZMvkOgkMhjXUq7rz7YtV8KxsFCvacSwwSiA2tlFrEBlAIAQ2LkDh0iyznBhEqhqTmKThxSeSxhQFVxHBlCbYKgQPZnWVhoINw2hRdvNOwZGte7/c7v3OF/5dqz/zqc//7K88+Zu/8Vv/mMwa8wDgGRHpD8cmvjW65efu2wwTuyAJsfooMjb3BQVRRCBjbZKKsrKIxCYhz8oI6jkQs0gIQVXgPWCMJyJVFUNGENATVVU1ZD31NCA1mQ95xNYF550zEsVUJyJyQQ0V2qs3bTa6xy9vPP/a4uGXj7/vvv3XNU0QowDxV2cKFP2Rsq2qRgXAQmtZEVuVLE4jm1m2IuKCMxSZOBLxToKIc8GRUmZTQmSYYkotWRFRdQFqhCR4S8xk2bDhLEhJpAAIEdRADRN57xLrgpSeTBTKqvKvnjz5xOMf2b1n22RzLMsyrKFFBsBgCCTv05FvjZ45ilUy4fbCRSmXVZzzhYTS+SJ4Z4lN8N51VUrn++pKVhF1Hp5VVCmIG5j4wDGRMrERGAreh1JDHsFGhIjYaBSzqdt6IxpOuOahqmSZXagWu7NvnD67eOVio+F9xIQb2QNgR4gIH8rmr/Tbr79+TgnGqANOjU21mxNNG1SoUFFxliwFIo69iuWaMZGGkpmNVKUPDv0ap7m4yvdFYCJbSaAk8WVBiAGBBqPKTAQl9FRMLVAFGBUnZRTIqfOVCIKg3LZzd78/f2BzFBa68A5rYgoLhVEPsp+cGvqToebhc6e+9txLn3ng3pmV7pF0Anse7fiiAwMEGCYYJQIi1BuAobynLEiHKM9JCtiIJWiUKgt8STAhjljtwCtpFKkI4hgUk4iJNXQ7IIuiYJ9r6BvHIYLCm35houHNW3dcmTt7+KV0397hfrN2A2glgAxE99559+TU5Obk5Pkf/Hs8cO/pdlh88xKrIdsILGRTsFFOiBOlYOJIlNUmJo4krVPcBZFAJW4OnAsRibHwTsTDGhIlIthESdg5jWNvLEXjcH1qmBAcqkJtpMFDScPpUBv63qnTx77+jO/UdMckbZ640TxUGSSscWY+9/f/2nPfPuVbZ//gm//xWb0HrgcmTZpMTkAEZksaPBkjykqCJAKnsEzNIQ0liTBBELTM2dZC6BEzub4EA2OULUIJDQpBsESV+tJy5lGRMqKUbKLGU1WpajQ59j/+0zeq40fHp0af3Dt3V41uNA8iVWUQIE985MPL7uzCy1/69T/4k5P1hm3WQmuebRYiw1KprYkwJ7FQxAYW7IhEPEoTIk8UETsh1aAAAntSq3BkU7Jg51Ug1lNkNRiCoHAQBNNjRGKZi1IBzmI4FfiUcHnucve2x/NN3SxbGlDHNdBMECICREBW8bmP//L2Ax8ZrnlV9pSqlqKOtFKwWjbECiYrGhkfxQSBKiIiJBS8lgEizGxsSogUjigVa+F8UCgJM8gkTKQqJssIXilSw6QiiUUUifPaaXFiXDzc3vtI9cBT/ZFbjM0AXhvxsa5uXphApB7gDz70BYNbYDUOaC5c1F6LPDiwURILqIcyopqyKpOqauk0eJSlphGRwoUQQdkTImIleE0Sii2yVASKIJYpSQMBNoJhWAYbcEpxRgi6comNcel6sUPozO+cnt61+4O4UZiuhrAEIbZBZWjDpp/7q08hjquZ83vKYvPKoi4vQn3o91QJcaRlgTInRIhiiqyJmDTARqzQICwOPhBZjSLxQQMTWfIgz8RWg5AynCoiTlMA6gLYssvRa9OVOc6v+GwkQ+e+oVef6nz57jjevvf9AJiv7wwtBvGgAkpKKmADLO/e/9DFN83s/MLZ+kZXLOt0p2u5XkfeAYYH/KCqg7gt1FL0e6ReyCCxPomp9EqAOkQKMMAaEaRAEI4yKXOyMYyVAGILCkqBAO13eOlcCGHvSOvJsZN37Gz2lrN1ex4HWETWgh4E9QoCmIjIqEBxajFfeW32qbvT9ZNVr5r//AOdB3dfkryjGkBBYwsjpI6EoAowcUxBEISUSaGGqXAkBEo4kMJBlWILV4rPqVaDsSRQy0gjxJYjSypatKXbGh4xj48dG2vqXNgkd/7ypz/5BOEGxKtRHl2Pw4WIlFACJ+b7vx7et+XApnDkhQztn93dvtgZeXN+yfgcJpVGDckIEkMmQdljlWAjGNayhAU4ZkbQAFVhJiZVowFo1IkZIhx8YEPw5EpBUBeiciUszSmjyfmrP+wYWf/cPe9/ZP+hL6iuxXfdpq/tIa4aNy6XZa0ed+3oMd51etfHprEt9FbiRHnn/VprivRReeoto7sieU5QKDEJMxtSqpQlqLUQJQkQr8QgouCvPTUQg1VhhQ0Fx8G53pLJW4htb7o3f36D0a0lzJkLl7wSgcON+86ralcodMAhUPS85aSJyhnti7XPLO6bXgkIbYGh5nqA0G8j9MkXpqrUi5Q9rbqad4MSEWlZinikCallZhN04DJYrJoYXqBkjIEqQZSM9Lu0shxYDVvbW0yH+WMfXXp0s7+46JaDQG/Ozthr2uVB6EdUqpYCI1BlLQpic0k2fv/Ewdhfot3eSzxalJUv+spic64ZtlAbcVUJPEQhYBfElVpGGhxYJalR2TcQJQOpqY1YWaqcgqN+jtKhfYXyJUobWpad3Q+9cvcHH0+/uSvu/3Ff+04RQYVpDfBV81ACwCACUAnyoi8i2mxwLaMkoiQ6PnTHwpWsOfs8vJPL07ta02nRhmRa9KTM0V5Q57hfUOU0rHILayBLIEN5j8WHKFIKJMLMakBEKB3AXK6gXFKjWpWSNd32uzC264Vi/0zLo9KOdwDkRlWvxqkD1hOCATyIvTdxAkhQJWNVfZVFl3bd/770+OT4d8+MlTIfbVs5TxtXTnU2+R7YIpSlUahVioOKkga1EUgIiTonRlEGjpLAjMpTnksWwQfkK+QKVYIqyh41NgQXx7PPF5dbZzcfwnh/uXqbZMOaKVz9NxDEB5BRMqtESEaglNV+hEOhoof3tmAW+yvzd2XHfum2kzW5EPKSfCGslrwGp75QceQrVE7LJahX57kq0S+59BoqTSJjLIJn1xPXRSioysFMMd2Xfuc3tn3rTpphnyJLjHoARt8J9FVxglBWwhYiliyKkpaXEAjekfpn3jz49Yt72zt2X0JUSLwhWvrswUU0akoGVd+7nCWoCMPAO3UVeSbnyJUIFUIfrsfdvqqIBK6qQEZDABvOhhCP3Df++sc2vLGxkS5S1B5uIE0NMSA3cd71bYxenUEAUFWqit6KrrQkiqn07EohMSJqZKHaugDGlpFjy28MzZ2t1WXElO3xLbRwTjstjRKCaFSnoqBaKk6IBRxBSGoxTKyGEQQKGKVKECVadQMiY3q7Rgui2rfbtz679e5uxLGlemwBVsXaLNN10NeCEGakijYbJKy1GgdIpJqXbJPgK3K5kUp7Jak7eSHjdjwZz+TJEtW3yZb9dOIlLXLElqAwrN6RjbVyFBlopaWSjYktEGtZEBMbBFVDJiCwtW9c8JcPx60DO5b2rqfC1erJkF2TOngr6GtiACNeNSBpKrU0Ti3VBSR5Tuhr6IU8hzioY+mdurL+8vIVN/GGrhtDurUWazpzYWF4k/aWTTIkYI4qFaPqJYERiAtKbCKPKAlqjKlT7KXsQuFgjp2JdnodK5fj+dly3ZYGUxYPeFjWWvI10NdHSQHxrpaQL2EjFHnodbVXoLwClyNUJErkNZCCJYmWarc2i0uxOdN67YK0ToyGwNa0TBxcYFOEokakqkp5U+OUXKkwmjU1ilB1pHTQHKGgMieOo15HN23bu2P2yKwpRzcONZOmIbo5w3qjpgUwABFIBWS0LDkv0O9rewH5CoqO+h6BVR2RJROJiaCVNkdWStqvZ3Zs6F8q8sX5aKxmH76v9sKl6NIZz1lfbMpaalkpjymDjEFvSeMIwaMqVEoS1WSIQl5M3XH4wZ8/uL21udtZUDNVs5YGBs3vCJohAJg5Lbu+KKlfSL9DeQ5XUP+KVn1SUfXMEdir64MFwVBCsNnxC7x5XNLhcnHJtbszO4a3bhm98pWVZGlBUfXVNsGqriAJiDKxlrxX5zRUYNJQwpAOb83X70SaPu+2NxrTqm6qZggSAIO3B81XPyWCxGXwAg0FeYEvUbRVAkSVGapCFhAmoxCQwJdEhixfXBwjSXWsXpbL33/98p4N0aE9u5/tPoHeBb14VE2dCLCRIhixwVgyqhIolGpqAKthdeD2hXJoouJRCrQxSyCDUsSNNr12wwhAVTMyDYYnpjLnbkfKJeRXEIShYhJSQWzBkVQFYEBBvVdWQ5aigNCgquspOjFLHLpdnNShB7Fln6YJTr+MOCMp4UOwOfsIGsgXYgxzrDZRtg+PPf/YVO/kzF1/OHqfSr4lBpigwM2aJhpksxVCgMBEwITrctdTtyPFCsplDqpk1HpECShiMkETcG5EBF5JoAhMDAKpRMMI/YX+5Otvnle6jPgZ9O/HUHODUFn5Jd/mKENRiIkJpOoRJWosNPrApukPjZ/dko6daphO8I3UbFuXAlCIgte6F7tGyQSQKhShxoVUufV9ljJA1cbQAB4CQFGM4AklURzUsfeklShQeTWJEiCOyMBmC+VGXjmjfASc4JyPi4XJaCJKZD4sk8kAUYBMpMzKUZLpremlvKy91Lvl6cVh31zeyLUdzVQhDKa1BYOrSfXrFQwoiIxJGAYUvIhD2UfoIxsyloLEWokQkYH4inxXXa5ERglSqgaAyBdKIEQSZyFd30xWbt385sJi0Z72RYF92+M7tzb/6EUHidkaEYEyKWVF58hz0abm9pfufnBxZYGsrB/2U7WIIIob/eH1jS0EOoioBTA7xkaRt5w4uC5v2IqxKQnJWHX63pHXrI1Pni4vXQAsuqHwUQ1stN8WYUgOw6oBsdVQIVjESUfXnZ2WDaOaD+Vzs2cfu2Xv/QfchTl36nwd1jPFQhT5/mTrsnFxb7Tuqh65ZdXGznrSAALYEG5eiDewBxMpATh0+zZ8781GK52oDS/BLs/NcZJeWfKn5mYObKZ1ppxzJiub6tzK7Q/q+Ba9+OrttcPB2NayXW5r0fMRSaiP6dBuXb601F9yvteNtkfbo+FM/9fM/unICh01GBMK8D1r0st7P3BlvPngxFznwowxdd/pR5WCARWA8Q48LUpMAIih4a7bDn5hxw8unD16bPZsuVzpgXvVNSKWzpVNRxc4GwpPPSWpSZbbxdPtcjmOdMsdsjJ3z8QKbzezM+2Xf1CFkBXV5ZKaNLwzS098aE84caJ6Y2Hpa6fuWBi9A5Mpzrwi84c1bmBoS3/nk7RpQ7pjvDz3H8KRF7Hj4G0PP/J3Pv0IBrWzt0TUdmDHOpiKYpD58FfO7tows3JPoz0z84FPfOzD9236vW/MnnMjl6u5ervlZ7nf00cf2tysmdrM8WWaMnHtdHv70tEfJs0ajW554NFLTY6rfueZcxeWagf76/d8w2b16tlx/5pr18bM+ZWQ/PVf/ext69Nmlv7v//PisL76hjsv7Q237dy2+x/ddc++/R++/Z7NY8O6utIEekPhb1D8lGvhnweMhqd/+J3PfrcMM4vJC1/++feHmOTbz1Lbj4Ywe2lqk8cwLVcbJ+ae3NxKk2GfDL30XGt2Om3Yyng3M3UbHdw3xq2R4fpwfiYpOmprNjFzx1u9E/3M5gt5MbZj5F/9zj83GH3xe8+UnW/v32WnZyna+jN/5RMfn6iNNGxCGPCcvG3Eb0EYsOAgMGGASF+niZXpc4de/dG43378+Pna6Ew2MlJ2lpbDOtPcG8b2kfPt7vwPzj1967rezq162/58pT3dxn6d2JGRa9FEv6Urr12qm9pWf/jRh2ppZKtD+lXlo/xQvGF7O/W/+MUvxyeO1OpbNq0bOXH5YjMZ/6Wn7t88tN76AFVPYvVmU34rewz0DgI08OXvnEZvvl4ve3NFu8j/xkO3pHeaVle/MruvDDvZFyLl0NFvdZ195dxIq9X9wH0Tn/vUxLF2+vXOPp9upXJJ6hnPH876K7Nm8vlXVh68z/ign3mk8Z8Pz0yX2yrb6O/9EPqXdi0enfd3fLf/+G8/tvfAvm1GhY0RUgsDlmvQbnLbFgqQABDQwHACuNk99892H0k29/5wtjN3du7pZ6YfuWe9in4wnP5vL9jQ2Itt98/VMDR3OE6mLr6weKVdfPjeW3bHrXvnfve5xbtpYrciXWzUkL+WqX/55SvtIn3/geZ4yB9IX/+v3z9qbn8qhN4Dt2e3RcO/e3LyV37h0S88+T6oMWCl1cL1dX+iuImnaVCAv06Eokq4MPv6f//qFy9enH329eap7sayPn5o+PymcGT2Is/PpnkROqPmzoP1HVn72IneicVJP3lwy9jyjvT0ueO9Tkv6Q0Pj28f2jyysr4dnXwkz8V1obFpHb24sXm63rO9klIUde7oP3ja5MPHw6MFP/tPH7qnFDWtudHy6io6uBhrXNU2DKs4g56uB2EB1amr/Bx/7e//yq195deoQNMNS90fHZl6fKYazKWjgZOHh7cXu9X65p2dlvBq/i2r185dWLp4vU8+58beOXrxjbFmz7Ngcz9hdGNoA+IWFTutcdzjbPLZu9MCdtUOHpvYcfPSu2x/ft2kj1A40t1afSiAwSAC9ybjfvkllMM+LKwt/9NrJbz5//Mz5+Xj2iG3nHkVUi7Ztx9T4SNaol/Fky22KYrOuTo3M5K0VVxVZM56YGI4B5cxHaSlWqmpyZGS0kVHlDWF8fHz9+o1DSaOWpPQWe/1J5B1Bi8ggv+rFtV3pXOmr4KExm0FoEZk4MTBWiSgoGUUURQpWIlIyRApE7/xgDzUg/OkR/zjQUASCBgUJQxWW1BGMQFeL3kqqCvKqyhSDhK72k1yv6DCreF3TQACAiaE3BZtXn/mTzeGdQa91RHrDClYIga/SDq+euzpyfc7A6s+b9xkQhZLyn7k76se1uPFgdQwSPCS6Cg40uIqwWnRSQBkQXT1n0MMzaP55az8ToMQw/z/9XD9O02ses9qoc02dejXns6bOBFWsDg2mN3hPa1T+5yU/BrQAWGMgGCyamzBctYg1QYJC17Tu6DsA/jOQxk8AWtfo7CdolLwZhCjobaLKPxf5v5UEEgSH728wAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAVIklEQVR4nO16eXCd13Xf75x7v+Wt2AiAACESpExtlOWIai3blBRrkjh20jZxYmfsuk2cthPPdOpJO81Ml0zbZNKmk0zT1GnaaZJx7Thum5Hs2LXa2I4j2akoRZIlWQspiaK4AiABYnl4+7fce07/+B7ARVwgDaNOpjp/AA94793vd88953e2S6qKv2zC/68BvBl5G/RbJW+DfqvkbdBvlVw30KoKhUJwnvdFB295Vb0gIMj5b0E2/7/1iHH9NE2kBAKDRAERURFRAUBkABCR9wUuBqAAFKRMoM19bhH1dQNNENpYU0WYmdgaYgCZy0VJFWRAAEQFSgolKBQEJQBCRNiasu31Ag0wFCCIgBm9fv7aqdUXXl544omTc8v9PJdtI9F77tz1Yx+4dceOGgMeykpEg50qmK6+/AVC1zv3EA9+5pnjB58+Or1t5Mnnl5994dTYeHm0HB07tba40rv9lm0f/bG7PvzBfYE1HmKIVT2RAQTgjZ9vCehiESIF+Hc++52vfOulofrYi0cWep1WORQbSLVardXKcVxh5qTX3b1r4lf+6YdGR6pKwjAXrrOp+79w0CICJgb9l88f/L3/8XS/l0Vh+p7bh9991+zUjuEoCPs9N3dm9dVja70s6Lro6MunpqaGvvif/la5FCuUQEoorHwrRnIdQBd0xsQP/K8X/sWvPzJU6vzMT97xtz96oD46NvgAQBAFk+Lp7736H3//iTQvL86f2L9/z2/80k/CCwzT1gzjoke+MRFV9bLx0nuvqg987aU7fuC3PvrJf3/s2IniLecy55z33jmXO3HOOZep6OHDx9771z7zkZ/74n0/8q+/8cgrqppJQeR+i89/M5SnUBTOrvAuY+avP/LqH3z5z7//zurnfvvn9uyZldypFzYBMzOzMWSMGjbGBM7Lbbft+dmP3XFqoT06UnvwqwcBBMQXOOK15Q2D1s1foqKwJnz52PL//pNXKrb9iY+9r1SJXabGWjARsOlVBC6s1VoWcX/nY/fumKo6DM3NL7740gIU6gGI6pZ47w2DJoBAICgTkYLclx96OfedyODuu25mMTYkJeA8AV/6FFUyxtxz545mL1GPp587DoJAFbwV6ngzoKF+4OEKIn3su2dXGp2FudP3HbhNAa8eG9FRAZwPkxdsm0iBfTdNCDiI7LHjiwoQma0Hlzdh00YLyxMA/M3vvNZtt9fXmj94/20AmHlzWVIMwuRAzudGpNg2UTEmEE+rKw0ApKLqt4jgDYdxJZCyQsnQ6lrr1ROraefc1ERt5w07AAExMCC5TcodxDxlItGN/8ZxyEZcz+d5ThCYN6C+N2PToIHHPHd4Kc1cp72+c3ZSdaApVd3M2xQAgcgUL6CDBENJJBd4BDHV6jFwUUZ7/UEXPl4c9AuvnBPNmo3W3tntBFJi3WCMCw1UVQlQBUgAKBjgRrPrlCG6bawKocsZ/3UErUxEzATI3HyjHKHT6czumQJB1RfkrRu7IwggREVmAihDvcIT0Ow5o5r088mJMWUSFAb9F8PTG0evee6bnXx8JCTOd0yOYZOVaYM6WKEM8OZTlKBkCt9cW21DNfPJbTfPEMACDA7h2vLG8+lBPNRmq5d5FySJJR7fVlVVIoUCNEisFawqUFYSAhOUSEVZ1QBYXkurVQ7j+jv2bAeEjAG2lC29GdBaWAC43c1EpNFar5RLtVqFiERIIQATFeGCwUwQVSISVRWwSlEs0uJyIuLuPXDz+Piw6kYs0i0Bf8OgCVLUSVnqyuXyoe89Vx+OKuVYASbeyC0l6aVLa51uq53BUqWe5jwR+53TQ8YwBL0sV5/XYv++u/YR4LxYw4otJdNvBjSUHRCwzJ9pJ/1sYf7QU48d+sxvvvvv/4OfPrnUOr3qzi735xZXTp5aXVpYiTUp79xlhidEZNQ14yTZOTv+gfv3xsaXI8MkX/qjr979nl+wlgXKW9TzmwFNQqIgk2S5aBoP33aDHfrCN0+eqh9u9blzbjmG77T98nK3EkYZEZ1Z17m1kM1yiViTQ6+dePLo2cjYPcPxre9613/9z7+zvPKLn//sv4XS1qvEa4Ie5OYeMBAFQ4kHPu7SXnrr7fdMz07kUe3ZR4/Zfq8S4VQziaxVwlorDwLuNNpJDoaBOCanySJ3V862699F9AMHbnr3gR9++tk/+z+PPXffPd+XO1i74QyEgWcPnnVRiXCNymVQtCkUnsjooMrAwccP/4fPPb7/jr2PPz13dv54yZTXO8nU9Gg/V3EaRXa9m9+6Z/TY6XWXeQVy8QGbJElitOojw4srqZpgteE/+IFb9r5jvLe6+MmP3XPr3qkNwJdiwAVZ7rVBD3apDIKDNzDi/e/+/sNff/ilV453J6anfS5Z48Wf+MgPHzmRP33obByFXvrWUaOf3bKnnEs0f6ZlOFRVpzxa9rNT9MT3zt0yOxTHnCSy2m2+6527aqWRuTOrP/Wj7/zIj9+pIMJ5gJctda9M5oqNvhaDRJy3oLlTS7/0a1974KuvvHJsfbgarCwvrzV6i0srh1449p7927udtF4xztNqs8WEV48sz82tekGaCcSruE5z/fhC99Y9tVJZXJ6Uw16y3jt9bI78+u4dY5974Ilv/OkhUhR9qQsVfIlmr6Lp82YkIkz85ItH//RbL3/7qaXOetMrJoaRZby4rp21hV5fdt24pysBiQHQ7+dRAJXEeYKx4tUyK5m0v7ytFo6OlOAlBwJ1pxfWuDJ6z/7JTuJmpsd73fav/vOfGKqXNg16oyuyRU1veIBXx8SnTy994YtPejP08vFGKRDDUTcvNzpUr/HMzMyN75hprXdc5jMvIgBrKbb3H7iRiERZQE7Eq1glp+HJRTq6yPOLWFoPTGmk3TePPtc58trK+nrrHbsnDz5xBJBilQGM12n1iqA3PskMo4Rf+XcPPfXi2oMPHR6KuVSvt72uNKlUiYmD7ZO12V1TvTRjFQMVOCZJUj+3uK5M4nJVVWIRB6Z+RkFgI+tNwJmyOAmtyVKfudKLh0/nSodOrHa6uTFmYAKXa/BdRdMCiPeeiL758HPfeuz42nqWps4Y02hnrSZGa/72m7dFYYUDvu+9N1erZVV1otAAiFOvh4+0cs/WhpYNRAG2xGwp864UsXoSdURERGzhyTbW+4vLLR+Wjx9fwaC3AcC9nr+vah7Kho2I++3ffdgYE4ZqDDggCG0fD265aTrzplRBkvCBu3f93U8cEM3E5cga5Nfhe5DUas7wRZIKUSFYNpbMep/BYtlkYjJx3jmXe2Y++dpCeXjbuWSj7iIQ7OvN44rBhQAvno35428dev7lM9WhMecckw2MVGIbBOFwtbRtON57Q3Tw2aWdE9V//KkDD3zlkWNHvl0OAmOMQAFOcwkr25wZCcq7RD3Bl03a8lINjDKVWSuWKvVyHFIvN61m6fRcY3113d68p8gWN8qcS5n7yhFRwcxQ//n//pRV9nnmvBjWdtckvVzQXltbmZ0ZavX6Nho+vtj6vd98ZHEtqo3dCQopNIEHVEJmT4FFrPDMLFo+18wqkb1xVyWOKEtSa20YWi9uVLOF3C6tdk4cmbv/fbNahOArdPeuCFpUmPnQq0t//syxoQqqtfDcakc0oazSD2IyWOnS4gtdtVov937m0w8urfbqlUiwXYhBhMCSikDhRSQnr9Dcs1GujG6zQ6M1l2X1Uk017XfdateLhGMjwUqjtzjXyFttonG5cnPviqBVvUC/99xJZniyvZyYIiKIZt4ziQmCgI0xijR1ictr5cCBIE6IDVSKxhyg/ry2VDWy/syKP7u66p0YQhixgJNU4ojuunNm/uxap9NfPNfcaJhcvjF5edCqSmQYfPZcc3g4dt12UOHhkUqeZTkogEIFcMxWfK7wpZCNCFgMAWTVC0TAUFUYUSViFjKWQBCDQODfe9fsvluGllf6jz49Z1WE3bPPn858pl5OnOkIiLlwwMskTFcEzcxffnz+4cONieHyQr+j3sOAjdk7WVMDVjS6ebcnnhEIWwMTsHMiHpAM1uTeswF7EjZBSIbEMhHEBBaimbNLK8tji76bOnWOIaSqPi56p+fW8kaiYxErFKQEvmS4cUXQAFabXYpLHFhjUY5du5165TMrpGycQJ2muRSNTu/BTkTUWHhiOOfViIiSGnHO23JMu3ZUmVkd0tw50dMLyYPHTobWlKIoE5LMq/YDa1ymvV6/1ZfRmD3IQhVCF1vI5UEXacqeYYzE+Yl2nmUcBWZm90gnS4+e7CYaMVsVgJmJAEmFUZhwShtfFyICmAznSd7LqO/7UK3H0fgIR4Znp6Lh4aDZVQBjsa2Vo4WVrs9Qq/u03XKtJo2MsUhRZW7JpgEIVCDbg84JzZntiYXs9JmzNrRZ5tkwjBCHKNqjbFQLilRVOZ8tkIp3zEEURSJueS0FsIT+erc0vS0shTpedyNVhZogINig3Ct1sl4/5VJIC6cX9u4aIy2869KC94oRkUHHzvZ33TAUBJG1dsf2GBRlCSsMsZKQqg46kUpQYagKQ82GgZEKE5GqipJlUysFQ/XKUKW23ndHF/Mj89nCCuVUMVHZO3L9/o3TdrQeGPZT4+WTx+f6aUKmODQWuqg3eWXzUMyMDZ/tYHqcllZ0vaPG2jCUKAx3TQ8tNrK5M504jj2EBIOG1wBvMZ+VotMAdSrq2Yoz+28d/YVP3fvdF+bPLHbvvXv3v/nMt598YWX7aLxrOiCltRXX6ttalQPrMkGj2S1NxEURQLgoO70yT0N/9Pt3P36w9bVvvCYuiePy5GhUK9kgtNbSbFRxuZxdS4IgIDIqhU432l8QFH8qQRnwAAnj+ZdWHnr4yKvHVt+3f8eH3r/rr+77+Je+efixpxYOPvNaZDh1oTGqkqy3pLF86gffv3+Q6InSxTnT5c2jgMBKU1Pjna5WQrNnIh6pWmXvXJZkae7Tm3fX9u6sk6iIELvzR7RhMwQGq2WA2Kuo886nn/3DZx59dv7BPz706JNz28aDT33izj/4rb/+0x/+KyvNdGIY48OBiChh//59O3dMUlF5vYFyCwChXI9KkQkrw82Ec0eloGRNZMjCUd5Ld45Fe3ZWHJTkkgHFRmIm5OFIUY4wXGfyXImj4dgsLHX/4S9//Qt/9NL8uSTL8S9//t5f/Wc/FJcoCm2lWsozhEHVBoEUKxH0YgK5miMCqIZxrR63+v7Mmjl+JltZT/ouM8aYkHKSTpJMjUWz0xUhDcIiAyYbkA2Kwo6YwRQws7WWmWFgrBMRa7Dc6P3ir/3JT33qvz3w0PMmwCd+/Pt279y579YZQm4tcp8pCQZDNGyJpwEIC4PK1SgMwyzJt43IiYXewoqM1IKRUjo+Ua6VLTPneb5zPB6qxfDIcy9AVAp7SdpYT3s9TXPnxDNMq02CJLb2hslKEJhmJxdBr5/Nn239q9/4zjcePXLD9rHlZmtuue9yVEo8NFQhMMnl26hXBM0wqmpMENjyLTdt//iH7w5NcPi1xS985ZnlTr7SadSrUTmgamzGJ23ZhN5oHAOAeAnKwXDFZk7yjNbaWb+XZ7l3YjLnTy/0JsfC4VJsA1ojVi/dRB959JTPTleqdnK8bCMFUC1HgEgx18OlPH21DpMSSJQI7VZ3Zmao08xeOr4Eim1o2KWddtr0umOyZsjm4pTg8+J7g5Egq0aBnx4jnqglzq828m4v7SZ6rpnnkG1htH08mhgL+pm0ui5N3Z7pWuJxeq6RJM45p0pcuODrsuqrUB5YCSxpmi6vNj/583/YaObVSqVai7y3jsWCrfFD9RAQj2L2rCJCRCLFmEIkdwCslcDYmYkSuJLn2k9yEHkEAIxBrcS1uBSXTGDoxefXJeek50NjCwYDXaaTejWeBmm7l642eqUw3jlZAczCYr/d7dsoYLZeTJr2V5rp8EjN+0S1mHnCiycFAAMmY7zPxadW4LxIEESBKddDT6xOlVVBcEysKnz4eCPNszLnvaQfl4wCg4sVeinpXblGVCKixlon7SbbJyqjQwHAQ5Xh+XPJ/HKXFUQ0NlbaOT2cdjNVJZEiNqpXEKlqEFj15KGkKpyKBMgpFZeztdZaJqbAq7L1qpymebUaTE/Vuk0yAU9ODA9oQzd/bM08is9VarbRps6yMOVj9eDGmfJIPer280rNDJUCyaTjMyixyGB6oUXaBLJk2TgBoEJErCSZipEAeUZiyQrYGhAxs/fZaN3WylG3jR2T9Z1TkyhmwgPsF8mVeZqg4nbNjN9+047llebCcn9+sdNoeq8YHQ5vmKoMxVGeaZI7FgMvDnBQpyIENsSGnMuJyJggVy9Q771XqKpm4nzinMtc7rLceyWV0IbitZv0xcld+3aSEa+Oi6kvNi/LXUvTAETJAB/4oX0Hnzw6NTMiqXKg4rMsE5/Bq0ihXSrG5Nj0GoExhkxgDNkAJnO5SkZgFVKIqidvvVUhckzWGbE2iEIbWvZwWbp377QqkTJUiVXBl+QeVwPNxkBx/4F9s7v/bG2tXauUkyTJMud8CggNpm5EZASeBcRhEcE8eYFRYrJSqlbY+PVGzwYGlKgyhKBd1pK3TLkjNuyi1OW1Snmt273jlpmbbpqkwW2HIju/1BOv1hYrukIg+ief/pF+r7my1nA+9a6vXrxXr7ChYUNs1DBRwGy9d4loxkjJ9Vy/2e+2Wu1GWIqrtRHvxDAHQQAmMkycs3hjjHPOa26strrNteUzf+9n388w3ivRoJh9PeddsdW7MRdkVQe2L708/8u//sCrR88x1AShuFw0i0uRIfbeB0y55N57VjYmKMp/FaiqV4nCSq0+kuROXFoph3maKYGZSYWD2EOJqNfuBEz/6NMf/Bsfuktk8zYDLnvp7dqTAAW85JYDiH774KEv/c+DZ86uiDe5uDi0hkVcX3zS7bT6nWXnExvVjS3HQTkM436WElHR+oCJBRGTdT5TIYYoGUPEZEslPfDed/7Nj993w9SEiDBf3QSu2VQvmE+hImQ2bhqJgkTVq5KCiVRJoEpEKgT1RFAYIuIB/6k4p96LSK4qnkVQXM4qDj4Mba1WA+BVTHEr4Kp6vNagCCCcH9848cx8wSinmDNQEXIvN7q85HAFUuT1g7cUKPxMRbBxx2VzKVVf1IhbBn3x4y7Y/QUnsDkZAYFEissgRUF+wQWKzUdcvDEZlH8QUi52srGqQFWLC0KXU/t1v2v6Vsj/3zfV30p5G/RbJW+DfqvkLyXo/wutSRJJoQjKIQAAAABJRU5ErkJggg==",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAVIklEQVR4nO16eXCd13Xf75x7v+Wt2AiAACESpExtlOWIai3blBRrkjh20jZxYmfsuk2cthPPdOpJO81Ml0zbZNKmk0zT1GnaaZJx7Thum5Hs2LXa2I4j2akoRZIlWQspiaK4AiABYnl4+7fce07/+B7ARVwgDaNOpjp/AA94793vd88953e2S6qKv2zC/68BvBl5G/RbJW+DfqvkbdBvlVw30KoKhUJwnvdFB295Vb0gIMj5b0E2/7/1iHH9NE2kBAKDRAERURFRAUBkABCR9wUuBqAAFKRMoM19bhH1dQNNENpYU0WYmdgaYgCZy0VJFWRAAEQFSgolKBQEJQBCRNiasu31Ag0wFCCIgBm9fv7aqdUXXl544omTc8v9PJdtI9F77tz1Yx+4dceOGgMeykpEg50qmK6+/AVC1zv3EA9+5pnjB58+Or1t5Mnnl5994dTYeHm0HB07tba40rv9lm0f/bG7PvzBfYE1HmKIVT2RAQTgjZ9vCehiESIF+Hc++52vfOulofrYi0cWep1WORQbSLVardXKcVxh5qTX3b1r4lf+6YdGR6pKwjAXrrOp+79w0CICJgb9l88f/L3/8XS/l0Vh+p7bh9991+zUjuEoCPs9N3dm9dVja70s6Lro6MunpqaGvvif/la5FCuUQEoorHwrRnIdQBd0xsQP/K8X/sWvPzJU6vzMT97xtz96oD46NvgAQBAFk+Lp7736H3//iTQvL86f2L9/z2/80k/CCwzT1gzjoke+MRFV9bLx0nuvqg987aU7fuC3PvrJf3/s2IniLecy55z33jmXO3HOOZep6OHDx9771z7zkZ/74n0/8q+/8cgrqppJQeR+i89/M5SnUBTOrvAuY+avP/LqH3z5z7//zurnfvvn9uyZldypFzYBMzOzMWSMGjbGBM7Lbbft+dmP3XFqoT06UnvwqwcBBMQXOOK15Q2D1s1foqKwJnz52PL//pNXKrb9iY+9r1SJXabGWjARsOlVBC6s1VoWcX/nY/fumKo6DM3NL7740gIU6gGI6pZ47w2DJoBAICgTkYLclx96OfedyODuu25mMTYkJeA8AV/6FFUyxtxz545mL1GPp587DoJAFbwV6ngzoKF+4OEKIn3su2dXGp2FudP3HbhNAa8eG9FRAZwPkxdsm0iBfTdNCDiI7LHjiwoQma0Hlzdh00YLyxMA/M3vvNZtt9fXmj94/20AmHlzWVIMwuRAzudGpNg2UTEmEE+rKw0ApKLqt4jgDYdxJZCyQsnQ6lrr1ROraefc1ERt5w07AAExMCC5TcodxDxlItGN/8ZxyEZcz+d5ThCYN6C+N2PToIHHPHd4Kc1cp72+c3ZSdaApVd3M2xQAgcgUL6CDBENJJBd4BDHV6jFwUUZ7/UEXPl4c9AuvnBPNmo3W3tntBFJi3WCMCw1UVQlQBUgAKBjgRrPrlCG6bawKocsZ/3UErUxEzATI3HyjHKHT6czumQJB1RfkrRu7IwggREVmAihDvcIT0Ow5o5r088mJMWUSFAb9F8PTG0evee6bnXx8JCTOd0yOYZOVaYM6WKEM8OZTlKBkCt9cW21DNfPJbTfPEMACDA7h2vLG8+lBPNRmq5d5FySJJR7fVlVVIoUCNEisFawqUFYSAhOUSEVZ1QBYXkurVQ7j+jv2bAeEjAG2lC29GdBaWAC43c1EpNFar5RLtVqFiERIIQATFeGCwUwQVSISVRWwSlEs0uJyIuLuPXDz+Piw6kYs0i0Bf8OgCVLUSVnqyuXyoe89Vx+OKuVYASbeyC0l6aVLa51uq53BUqWe5jwR+53TQ8YwBL0sV5/XYv++u/YR4LxYw4otJdNvBjSUHRCwzJ9pJ/1sYf7QU48d+sxvvvvv/4OfPrnUOr3qzi735xZXTp5aXVpYiTUp79xlhidEZNQ14yTZOTv+gfv3xsaXI8MkX/qjr979nl+wlgXKW9TzmwFNQqIgk2S5aBoP33aDHfrCN0+eqh9u9blzbjmG77T98nK3EkYZEZ1Z17m1kM1yiViTQ6+dePLo2cjYPcPxre9613/9z7+zvPKLn//sv4XS1qvEa4Ie5OYeMBAFQ4kHPu7SXnrr7fdMz07kUe3ZR4/Zfq8S4VQziaxVwlorDwLuNNpJDoaBOCanySJ3V862699F9AMHbnr3gR9++tk/+z+PPXffPd+XO1i74QyEgWcPnnVRiXCNymVQtCkUnsjooMrAwccP/4fPPb7/jr2PPz13dv54yZTXO8nU9Gg/V3EaRXa9m9+6Z/TY6XWXeQVy8QGbJElitOojw4srqZpgteE/+IFb9r5jvLe6+MmP3XPr3qkNwJdiwAVZ7rVBD3apDIKDNzDi/e/+/sNff/ilV453J6anfS5Z48Wf+MgPHzmRP33obByFXvrWUaOf3bKnnEs0f6ZlOFRVpzxa9rNT9MT3zt0yOxTHnCSy2m2+6527aqWRuTOrP/Wj7/zIj9+pIMJ5gJctda9M5oqNvhaDRJy3oLlTS7/0a1974KuvvHJsfbgarCwvrzV6i0srh1449p7927udtF4xztNqs8WEV48sz82tekGaCcSruE5z/fhC99Y9tVJZXJ6Uw16y3jt9bI78+u4dY5974Ilv/OkhUhR9qQsVfIlmr6Lp82YkIkz85ItH//RbL3/7qaXOetMrJoaRZby4rp21hV5fdt24pysBiQHQ7+dRAJXEeYKx4tUyK5m0v7ytFo6OlOAlBwJ1pxfWuDJ6z/7JTuJmpsd73fav/vOfGKqXNg16oyuyRU1veIBXx8SnTy994YtPejP08vFGKRDDUTcvNzpUr/HMzMyN75hprXdc5jMvIgBrKbb3H7iRiERZQE7Eq1glp+HJRTq6yPOLWFoPTGmk3TePPtc58trK+nrrHbsnDz5xBJBilQGM12n1iqA3PskMo4Rf+XcPPfXi2oMPHR6KuVSvt72uNKlUiYmD7ZO12V1TvTRjFQMVOCZJUj+3uK5M4nJVVWIRB6Z+RkFgI+tNwJmyOAmtyVKfudKLh0/nSodOrHa6uTFmYAKXa/BdRdMCiPeeiL758HPfeuz42nqWps4Y02hnrSZGa/72m7dFYYUDvu+9N1erZVV1otAAiFOvh4+0cs/WhpYNRAG2xGwp864UsXoSdURERGzhyTbW+4vLLR+Wjx9fwaC3AcC9nr+vah7Kho2I++3ffdgYE4ZqDDggCG0fD265aTrzplRBkvCBu3f93U8cEM3E5cga5Nfhe5DUas7wRZIKUSFYNpbMep/BYtlkYjJx3jmXe2Y++dpCeXjbuWSj7iIQ7OvN44rBhQAvno35428dev7lM9WhMecckw2MVGIbBOFwtbRtON57Q3Tw2aWdE9V//KkDD3zlkWNHvl0OAmOMQAFOcwkr25wZCcq7RD3Bl03a8lINjDKVWSuWKvVyHFIvN61m6fRcY3113d68p8gWN8qcS5n7yhFRwcxQ//n//pRV9nnmvBjWdtckvVzQXltbmZ0ZavX6Nho+vtj6vd98ZHEtqo3dCQopNIEHVEJmT4FFrPDMLFo+18wqkb1xVyWOKEtSa20YWi9uVLOF3C6tdk4cmbv/fbNahOArdPeuCFpUmPnQq0t//syxoQqqtfDcakc0oazSD2IyWOnS4gtdtVov937m0w8urfbqlUiwXYhBhMCSikDhRSQnr9Dcs1GujG6zQ6M1l2X1Uk017XfdateLhGMjwUqjtzjXyFttonG5cnPviqBVvUC/99xJZniyvZyYIiKIZt4ziQmCgI0xijR1ictr5cCBIE6IDVSKxhyg/ry2VDWy/syKP7u66p0YQhixgJNU4ojuunNm/uxap9NfPNfcaJhcvjF5edCqSmQYfPZcc3g4dt12UOHhkUqeZTkogEIFcMxWfK7wpZCNCFgMAWTVC0TAUFUYUSViFjKWQBCDQODfe9fsvluGllf6jz49Z1WE3bPPn858pl5OnOkIiLlwwMskTFcEzcxffnz+4cONieHyQr+j3sOAjdk7WVMDVjS6ebcnnhEIWwMTsHMiHpAM1uTeswF7EjZBSIbEMhHEBBaimbNLK8tji76bOnWOIaSqPi56p+fW8kaiYxErFKQEvmS4cUXQAFabXYpLHFhjUY5du5165TMrpGycQJ2muRSNTu/BTkTUWHhiOOfViIiSGnHO23JMu3ZUmVkd0tw50dMLyYPHTobWlKIoE5LMq/YDa1ymvV6/1ZfRmD3IQhVCF1vI5UEXacqeYYzE+Yl2nmUcBWZm90gnS4+e7CYaMVsVgJmJAEmFUZhwShtfFyICmAznSd7LqO/7UK3H0fgIR4Znp6Lh4aDZVQBjsa2Vo4WVrs9Qq/u03XKtJo2MsUhRZW7JpgEIVCDbg84JzZntiYXs9JmzNrRZ5tkwjBCHKNqjbFQLilRVOZ8tkIp3zEEURSJueS0FsIT+erc0vS0shTpedyNVhZogINig3Ct1sl4/5VJIC6cX9u4aIy2869KC94oRkUHHzvZ33TAUBJG1dsf2GBRlCSsMsZKQqg46kUpQYagKQ82GgZEKE5GqipJlUysFQ/XKUKW23ndHF/Mj89nCCuVUMVHZO3L9/o3TdrQeGPZT4+WTx+f6aUKmODQWuqg3eWXzUMyMDZ/tYHqcllZ0vaPG2jCUKAx3TQ8tNrK5M504jj2EBIOG1wBvMZ+VotMAdSrq2Yoz+28d/YVP3fvdF+bPLHbvvXv3v/nMt598YWX7aLxrOiCltRXX6ttalQPrMkGj2S1NxEURQLgoO70yT0N/9Pt3P36w9bVvvCYuiePy5GhUK9kgtNbSbFRxuZxdS4IgIDIqhU432l8QFH8qQRnwAAnj+ZdWHnr4yKvHVt+3f8eH3r/rr+77+Je+efixpxYOPvNaZDh1oTGqkqy3pLF86gffv3+Q6InSxTnT5c2jgMBKU1Pjna5WQrNnIh6pWmXvXJZkae7Tm3fX9u6sk6iIELvzR7RhMwQGq2WA2Kuo886nn/3DZx59dv7BPz706JNz28aDT33izj/4rb/+0x/+KyvNdGIY48OBiChh//59O3dMUlF5vYFyCwChXI9KkQkrw82Ec0eloGRNZMjCUd5Ld45Fe3ZWHJTkkgHFRmIm5OFIUY4wXGfyXImj4dgsLHX/4S9//Qt/9NL8uSTL8S9//t5f/Wc/FJcoCm2lWsozhEHVBoEUKxH0YgK5miMCqIZxrR63+v7Mmjl+JltZT/ouM8aYkHKSTpJMjUWz0xUhDcIiAyYbkA2Kwo6YwRQws7WWmWFgrBMRa7Dc6P3ir/3JT33qvz3w0PMmwCd+/Pt279y579YZQm4tcp8pCQZDNGyJpwEIC4PK1SgMwyzJt43IiYXewoqM1IKRUjo+Ua6VLTPneb5zPB6qxfDIcy9AVAp7SdpYT3s9TXPnxDNMq02CJLb2hslKEJhmJxdBr5/Nn239q9/4zjcePXLD9rHlZmtuue9yVEo8NFQhMMnl26hXBM0wqmpMENjyLTdt//iH7w5NcPi1xS985ZnlTr7SadSrUTmgamzGJ23ZhN5oHAOAeAnKwXDFZk7yjNbaWb+XZ7l3YjLnTy/0JsfC4VJsA1ojVi/dRB959JTPTleqdnK8bCMFUC1HgEgx18OlPH21DpMSSJQI7VZ3Zmao08xeOr4Eim1o2KWddtr0umOyZsjm4pTg8+J7g5Egq0aBnx4jnqglzq828m4v7SZ6rpnnkG1htH08mhgL+pm0ui5N3Z7pWuJxeq6RJM45p0pcuODrsuqrUB5YCSxpmi6vNj/583/YaObVSqVai7y3jsWCrfFD9RAQj2L2rCJCRCLFmEIkdwCslcDYmYkSuJLn2k9yEHkEAIxBrcS1uBSXTGDoxefXJeek50NjCwYDXaaTejWeBmm7l642eqUw3jlZAczCYr/d7dsoYLZeTJr2V5rp8EjN+0S1mHnCiycFAAMmY7zPxadW4LxIEESBKddDT6xOlVVBcEysKnz4eCPNszLnvaQfl4wCg4sVeinpXblGVCKixlon7SbbJyqjQwHAQ5Xh+XPJ/HKXFUQ0NlbaOT2cdjNVJZEiNqpXEKlqEFj15KGkKpyKBMgpFZeztdZaJqbAq7L1qpymebUaTE/Vuk0yAU9ODA9oQzd/bM08is9VarbRps6yMOVj9eDGmfJIPer280rNDJUCyaTjMyixyGB6oUXaBLJk2TgBoEJErCSZipEAeUZiyQrYGhAxs/fZaN3WylG3jR2T9Z1TkyhmwgPsF8mVeZqg4nbNjN9+047llebCcn9+sdNoeq8YHQ5vmKoMxVGeaZI7FgMvDnBQpyIENsSGnMuJyJggVy9Q771XqKpm4nzinMtc7rLceyWV0IbitZv0xcld+3aSEa+Oi6kvNi/LXUvTAETJAB/4oX0Hnzw6NTMiqXKg4rMsE5/Bq0ihXSrG5Nj0GoExhkxgDNkAJnO5SkZgFVKIqidvvVUhckzWGbE2iEIbWvZwWbp377QqkTJUiVXBl+QeVwPNxkBx/4F9s7v/bG2tXauUkyTJMud8CggNpm5EZASeBcRhEcE8eYFRYrJSqlbY+PVGzwYGlKgyhKBd1pK3TLkjNuyi1OW1Snmt273jlpmbbpqkwW2HIju/1BOv1hYrukIg+ief/pF+r7my1nA+9a6vXrxXr7ChYUNs1DBRwGy9d4loxkjJ9Vy/2e+2Wu1GWIqrtRHvxDAHQQAmMkycs3hjjHPOa26strrNteUzf+9n388w3ivRoJh9PeddsdW7MRdkVQe2L708/8u//sCrR88x1AShuFw0i0uRIfbeB0y55N57VjYmKMp/FaiqV4nCSq0+kuROXFoph3maKYGZSYWD2EOJqNfuBEz/6NMf/Bsfuktk8zYDLnvp7dqTAAW85JYDiH774KEv/c+DZ86uiDe5uDi0hkVcX3zS7bT6nWXnExvVjS3HQTkM436WElHR+oCJBRGTdT5TIYYoGUPEZEslPfDed/7Nj993w9SEiDBf3QSu2VQvmE+hImQ2bhqJgkTVq5KCiVRJoEpEKgT1RFAYIuIB/6k4p96LSK4qnkVQXM4qDj4Mba1WA+BVTHEr4Kp6vNagCCCcH9848cx8wSinmDNQEXIvN7q85HAFUuT1g7cUKPxMRbBxx2VzKVVf1IhbBn3x4y7Y/QUnsDkZAYFEissgRUF+wQWKzUdcvDEZlH8QUi52srGqQFWLC0KXU/t1v2v6Vsj/3zfV30p5G/RbJW+DfqvkLyXo/wutSRJJoQjKIQAAAABJRU5ErkJggg==\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAU80lEQVR4nO16WY9l13Xet9aezrlDjWxKphpiaAW0BGtI7AQG5Ey2BDkJDCcIHCMPAWLkIS/5L37MPzBg+8VG7NhW5ACCkygGNFC2WiRFhZObza4eqqvqDmfYe6+18nCqmtWUulliI3ICaOGibt177r3nO9/+9hoPmRn+fzP+mwbwYewnoH9c9hPQPy77Cegflz0WdMVgKGJV9PwdMwGKoYiOMGgBBFDkXA2AAqgiAlRASzagQmFmQBnyMdADVQ0GFIXU859VVRhgMFFY/eFoHjV6bHCpAF08AJiZEREAiAI8Oh5FlWzOHEQGdQ0MfImEYZCQiquNqobIIgDABOICUkMCABQABiY4AGrVkf/woC2rmXFgEBnMTGhCZCMRG5ICpVrw2cQ8NWCFMahDaeEIXKQ4FwqQDMgVzkENkQFRKCSMDBYFIU3rLQYmfDDkJ4AWqEHUxBEBDDiAS0FDAKMwOpGXXz5987Xu2rXlzm73sWvL5Z7tzALgCa7oWMXlke6e3f/ejeGtN93pqnv+Bf6nv/LiwQIOBiUwxIxdJZCBSy3BB7rCNnss6FF7Ih8owGAKMzgnIIWFgbY372x/93e/990b9OYb999992h//3DeHix3808989z15+vqbHv/zk5XV0MfxjO9d3ZLqMZmef2jH3n+4/Tv/8OnP/liXdhStbADgDpUH1oQYAr3FKAheq5QM0xaNoPJ2yf8X/7gta9+9Z1b9ze7zxxs+rpa98MwQHzylrf86//22bfffufrfz5Pi2Lek/jQ+CK5naVPfOITN998vY32xV/6R5//e0ef+cz1NkF0SOxhXobiYoD7QMxPkJAxDEq5UAHN7z7Ajb88efvts2+/sn7nnXdW64F9UK3zGdanufH784UFopPtBn2c0/4i0nzRCNtQKzN0tOV85/j+nd3DGaN+7Vtf/1//M33qZ/MXv/TCZz7dSLRI1bVuGIbGNR+e6YwNYfH6m+NLNx68eavcvNPffdAbcdNg+yA/uLMOvnabe/v7+2yL4/vdWtn0xBXO5b53zXx2vbixaoyWASyW89RQLn1MyXFz7SPXiz8bu63043PP7Hz2k8/97Z9On/iE+/j1mb+KptUyWYCNoASC2siawNoR/87v3/rTr7y72moTAwm6rgNXpjQOQ99vVZWZnQvOOWLfb0ZVnSgwO3eQzMzMTdPEGGutY8lENJvN2rZVdj5KijysrYxxNuODj/T/6jc+9w//Dua6gu7AI1uJFmBZzbF/TzdUbXCWQApAlYmVwFrx23/0zh//6Stn/e6YdRZD4jTkerY5gRUiYgYbVFVATN45Z8oTaKL3Vo+ZUxMBwAgAEZFjERGR2WLPkEvtZ2lWizmmECW1+KV/cP3f/etnvW4Fc7A6YTCMzqPFZJ7sQsHIhGggwbDeNF//ZvfO7RyaTFbymBVaxPq+lzpE50MIzpEZwRSkxuycc869F4EmSqYLMCLCxDqRA5EB3fakSW3kduiLmjSpHccgtfnj/3rvmb3FF7/I3uAhRqwCcYiXUHsmNgUAYiGDCKmTt26NpyP2ntm/f3w3sQ9hluu2Wp0tLK+TaBmGwRFPwiBnVk2cPAQ6KWR6KSLMPKEXsekDzAzrB7UYWlAMzhOcWiGWba5/8Idv/MIvfvpwBsJATCDA/GWq+SJMYzoLMyrab924m+s2NNYmqKKqE5ha8R7L5XLWLmKMzrmJPIDtkuklExFHpLWWcZRSGOrIHBm0kjWSy2Z70s4cBzcMY9uGB6e3fFgfH6c33hjVtiwJ6h2JvywOgE0BBhgqBAURbh2Vb7x0xESrB8fP7n8k8rwUMucNrgyhmjJzim1qZj6kiUWwe7jtLvMNgPDeIeeYmQADzGrLFHzQIT8gNxDXvu8dIuWuVn3l1fueBBJRYSCmzSOgYZOrro4bswroSy/de/3NDYsd3zmSmmfLxs+QZpZSirYoRaqpwIiIiIwd3HtYLxbNLuOedioziZSSh1p60+xiYWbi2bbXpmlC5Du3j2SE9GGUk5df2RbM4IAAkQiER0ATQ00FGQChGuqrL9852xir5rE7Obm9ux+W+/BtL9oBHFJk9mb2CHSCPWoPTzDpxMycc7O23d1dHh7uX7t2mOZrjmR13oSPlpFPT08Xs3YxW3an1Td24zvrN97cwKHSihwg6VF5EJyxt8YKLHQ3j+mV7zRWbp9sHsTm2q17d1ZDt9jfn+9ca+PHzNZai3M0UcvMqlrLtIOl1lprnRA/dH/OiXdtHTxK97eu29/9tP/Ys8MsdZGWKNHHMlty5SMFzXfb47NbwqKjdBv52l9sC8SPO06Q3fGj8oAKnQFGwTLmL31zdXTvtkvtyd2ja3s7ZbtFGZAH2DA/gN8VIlLVi9Xnc6btnPLL/m6yru/NabNszPmju91rrz+4dadfb12vnXlql3E2a5weNHRwcnSPa100u5vtan6w+9++evLmuy6ne3Aa7fAR0LUOjnZRnXEW8Fe+/H3zMdfZvXfvyFA40+03bubNcLi7t9hJ5pvJGQM8iYTA0zuO6H0PBhiYLXcUJaMX8kUWYznohp2TLdR7oZCaudim1uOhv2k6RCzW65658aneX8uX/+z7hmuSGY+mGhx4BmxGEUX6H3+Wb/zlKjZ0ePBcnC3vHd+bzePx8c2jm6/fufXWbOFmi2dDdJPHIPAkac/MeI/p95kpi1aQkOOc/dCHagkcgWa2SCmlWRs327N1d1JV1/kozXlv2ZzeOZVT5TIDYFzx6Pp5MGqNsRkK6gsv7rz44vzbNx7sHOzt7l+/+db3ou+KnNy+1d28/a0vPBP2lj/9YMtVUYuZGsBEMCIl8A8I45wVdaQU2DFc7YuakGffwrv5znIB4bG/f/fea4x5qR+fzz7Wb8tybr/6yy/88hfSz39u4QBjL8gO8RJog/cRoID5xz8+/tZ/+tzv/c7b//n3jk6Oy6I9cC6V4ax0crK+/eqNv/i5n/vsZnZczatUMQU7IjZTIgL/cNCJY83ZBErqPHuCOWXPi3liHmaR3nrr+92xLRonrtvbm/+zL734T76w8+Lzc48KcSAIPSBqH2WaRlgCghUEnyLzb/6bn/3nX9r/o9+nP/yTP/nGt14dh22i+ere/bdev/GLv8DtPKhZKbUO5LxnkBncpJYLu7wdx9qxdxQ8RBWFidjHdrZwUbwb9g/He7fvDLf9p//+c7/269d/9Tc+dbhgAjwqtIMLZq3HwXkEfPj7aiY1excBgHpoU0YKDUA4Wes3vnXzK1/+2n//6o3FPv7xr/382dlnjtdjv80P7ndDr8G1RASp7EgvdPc+B+I8SjVYNKnBmXcMH5vZjp/1qex/6pMnv/Kl8Fd/vvkX//Kze/tb0wWkEnk4EXNgGOAURB1o9h7ox1bjouoYUhyHUWty9s4d/1u//eqD+30e6eidMxU/S21Rcc7lnC9vvgn6ZCIy/cPM3vspysQYeZZY6+c/e/Qff/Pz1eANBFSI5w+utx5bbv2gx621qmrOWcQzM8GZmch5chdjnBLl8yTuIhZOWJ1zD99xzoUQigyO9JM/8wKh1uJCJJRC4QoV4pNqRAA49wnMDGjJVZRm86bfgtikqkCmo0Q0jqNzbuJyij4hhJTSedSsdUI/sV5rhRtCdC88/1PASEwAgQ3Qq3TqHg/6EtNsDMLZqtv0w95yNw+biTYjm0g1oxDCFMadcykl7z0AEZnIvviYqepEvKoQCAqYJJ9ExJGvWq/QQfigy5pEIiI1y+lq1W0zkakqETlPD4+WUmqtIYT5fN40jaqO4ygiIQQzNTsP+xf1AZkRwQ19Xp2upkpsyo/p0WzuRwdN56gBMLNzrhY4n8xMrTITADUxM2ZOKTVNAqyUrCoxhqZJzDSOQwgBQK3lQs2JiEopzrmu64pUGJlNUQruMc7+ffZYeUz19FTPTGGbfWznS+/dRfJJZsZu2mehlGEqEzE1QgHnXNM0IuK9DyEAJCIi1XsfY/QJ5Ji9h0NVRAaKwD3dRrycsKmCGWbmXJj6uRPBwQf2YXIpTZPe1zmYrjylNG1EIp5KgckPusBNE51nwJihWtmxQXCFFtMT+tPmDCDC1IUlVE8ueO99KaVt2+nCch6JEKPvuo6IYowT0yGEpmmIaBiGpmli0xihqhjgQ1AzZzU07bXWQ1tCYfJi7KCPw3Ml0A4X/buLmtd775kAxBiJTLVOWp/25e7urqoOw5BSWiwWfd+fnZ3FGBeLRdd1w9C3bZtSmras934oNYTQNAmGqhUAM66k6A/005ctBheieWeAEvnJx5FzMcZSaim5aZopOo7jOJ/PvfeTD5nP593QD8MQY4zJn1dfPvoIjsC0caZOwYUrebJ9sFe0i6eYODhMIMws5xyjd85NYaVt21KKiMxmsxBC13XjOLZtG2MchsF7P5vNJkfuvVfV4BvVOuYNCMElmMFAV8L8eNAGAc5dHhFAGgN7Z977WisRpZRyzmo1pZTzWGtdLpeqenJyEkLY39+fWPeBm6bJOXfddj6fLxaLMfciUoqBqmq+gKGgRyLahwFNl/IoIgAao48euQxt204OIaVERH3fT/Hv9PR0Nps9++yzm83m7OxsNpvNZrOcs0EODg7m8/lqtZr2pQ+cR93ZWS53GkyLaQZ6Ep7L9oQwrrBHvE+bQoxu7LnWCiClVGtVgg88qWI+n2+3WwCHh4dmtlqt2rZdLBbDMKzXawD7+3siul6vQwhadXdnZzlL5/pjNgD2g3naD7HHM/1ouwww7zl4ngKbQcxkInjKN7bb7TiOi8UipbRarczs4OCAmbfbbUrp4OCAiFar1dTqVVXJAqhBYVNHdTrr08ljOmRQhgprRbi+iwgMA4nmEFiECD55V0pfa13uzA3SDduQ/M7ecsj92fq0nTeLnXk/DJvNarGYzefzvu9qrW3b+mB33+qPx2jVXDWDKnqSq2B+0ka8+ICCwQ4IjmfN1BrAlBMDIKIQAvHkTGJKqe/7zWYzn8+Xy+VqtZJqi8UihNB1g6rOZrPzZall2+e/fqc3NoAMplceH3+Q9wBDGdMQ1Enb0nbTM3kRyTkzs4gMYzehL6WUUpqmmRSyWq2miLPZbJh5Z2cHQM45pbRcLtVsPegrL6/FnZeXjAS+EtWPB23vcU3nOVBNkUUs5+J9aJqm1qpWp1xUVacYvl6vRWRnZ6dpmvV6HWOzXO6KWNd1KaWUmr7vu65j72p1r762HoVAF6ejK42ZHwua6eIQAZcSt/WqS3FuRiVLSgnAMAwhBMdhs+6cC/v7h6XI6enKjFJqJ/c3VQbb7TbnPOXc3ntz7q9vDcdnFQSo4yvfTPXEMG4wMgIpjNkDNuYx59p1A4xDcOM4llKmIdBgw97e3rbvNpvN4eHh5L+JqJm1ZjaMI4za2VxENtutmTlnMcaz9fbo9vj8YThf0KctAsCqmAKVqhIDFu7f3wxDjjFNbcgY4yTrEAIzr9frpml2d3dPT0+7rpvP5znnzXqbx5JiA2Cz2RDRcrl0zrFKTMEMR7czUJkIULvaXnyCn57+GqBKqkAVvXe8KlmmNGhKP0opZjYFdudc3/ellOVyaWZnZ2dTbZtznoJLSmkYhslbS6mOYGRnJ/k8JqLiagp5EtPsK8EX0mjBmd4b8/FxCp5LFufbmGYUYtHiiVhsLLmqEJGIjmP2LqU423bj+nRNSo58GauINc2saWYiNnIbxuPWL156s1QEMpA5fWrQ50cJZIBIXa+G1WpzMQOqD93L9Do4X3OZir+pUMg5e3aTuCd9A5hcBwByqILY2L07m6PjDgaQuqsl1FfREJuBya/XZRhHKE3awDRcI28GMZ2CuSPOOeecpz7B1HmahgRmZqI55yl1IaKxWGpw+mB85eUzMKB2xSrgiaDtUk/R8emplQpTVhGDEptzzrkAYMpDzuHyOdMT62o21YYl55wz2fnQQ1WzCRGzd9/+q60xyLyhPBVoOy/XFCCQmuLoaLsZBoBFRLWaKbN3LojRw5H4w/E48N7oaCJ7GIah72utWqXWaqJG2m+xtxe/+2q/GgBju9o9TE8AbTCYGU0TUcXR7U1RA7jWqlJEipkx+QnZJA9mzjnXXLw/L4HB5/KAqFXJ45hzVlUynW4DSA3unun/fmMNgtHTuTw8UhhrKfXByRhT6+BUoFpVFeBptKKkU931sKNXSymlTLnrOQuPznPZquNZGXOtEhb+O985A0Hsaf00AZjuThCt4zhuN9nHAKNHhoXkABCRlDI1a8oF3OB9LWWq1Zl5Qjz5kForWWG0hpxH3dmPb781gNT0Ss2ax4MWB0IpxVk15tdObEv7ruvM83a9psreGqvO++hc0IE9eVbTWsmUCKpVVH1IKkW0EJlPPgTnYFyrdn2vAXpkbdpumXLufB4tJ+b3zU5/NNBwVQgxNDAPid2pbE/GYVXA1bx0dVVsM8iZoA+Jm52ojsw5IypmVXWsMpY6jIVdYpfgoporBiUWZmHmfvbctZS8SQ9Tkuq3m4CnLAIUUk0ARhYSnJ1sSu0VUkf22uqA5IMDaeEy0LjVmkeoAIAq1Dy76EPwPg/FBAwy0UnopOYJTewPDtcxQPK837phYMUW/kou7/G9PDRMAiiiMruT9QqRuPUuR6DtN6eYC7FFSuQZpIqBmBkEJasCCIxUS+JARICCGeSICKalFGn3z7adi6HZk4Ju281dSKZ6lfjyeNCCafzDDAFWG3JxF2RhMShZ7rsRp+wq0bzUUZHNzDsPYiOYZwQiwIGlVlU1EzDczHt2pZRSu1UZ7txtkRbtcjv2XAcaB6B9/3D2RwMNAkNL8Z74+GxYPejLVoazvFErI85O2AUNCc75MoppqVW812n+4H1lrlMX/XwS4Mhs6l6riOQs+/FBWR1q2mI8Cy555tMj/ehuMvpg1E+6QVb8qJoCoR/rN7+b7z7Iw1n2c869HN8/4qCCRLRbxiGEzlRijFPvuWmaGH0ILoTQzuKFK6zr9XocRwBE1M7bjy4WcW/gAuF6urGf+QgOD1vQeb38oUAbhHpY66CgrmIBqEcBHNSjVkQBkimkwscK9e/7OkhABCrQqWVM5/GKHIBK7LWCO+QdRAxAU4BQzPxTgH549ou8Aper3ae2x8F63006P/y7V8FxOQe6yo/+37Yrgf5/zf7mafsQ9hPQPy77Cegfl/0fYbQLGpke+5oAAAAASUVORK5CYII=",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAU80lEQVR4nO16WY9l13Xet9aezrlDjWxKphpiaAW0BGtI7AQG5Ey2BDkJDCcIHCMPAWLkIS/5L37MPzBg+8VG7NhW5ACCkygGNFC2WiRFhZObza4eqqvqDmfYe6+18nCqmtWUulliI3ICaOGibt177r3nO9/+9hoPmRn+fzP+mwbwYewnoH9c9hPQPy77Cegflz0WdMVgKGJV9PwdMwGKoYiOMGgBBFDkXA2AAqgiAlRASzagQmFmQBnyMdADVQ0GFIXU859VVRhgMFFY/eFoHjV6bHCpAF08AJiZEREAiAI8Oh5FlWzOHEQGdQ0MfImEYZCQiquNqobIIgDABOICUkMCABQABiY4AGrVkf/woC2rmXFgEBnMTGhCZCMRG5ICpVrw2cQ8NWCFMahDaeEIXKQ4FwqQDMgVzkENkQFRKCSMDBYFIU3rLQYmfDDkJ4AWqEHUxBEBDDiAS0FDAKMwOpGXXz5987Xu2rXlzm73sWvL5Z7tzALgCa7oWMXlke6e3f/ejeGtN93pqnv+Bf6nv/LiwQIOBiUwxIxdJZCBSy3BB7rCNnss6FF7Ih8owGAKMzgnIIWFgbY372x/93e/990b9OYb999992h//3DeHix3808989z15+vqbHv/zk5XV0MfxjO9d3ZLqMZmef2jH3n+4/Tv/8OnP/liXdhStbADgDpUH1oQYAr3FKAheq5QM0xaNoPJ2yf8X/7gta9+9Z1b9ze7zxxs+rpa98MwQHzylrf86//22bfffufrfz5Pi2Lek/jQ+CK5naVPfOITN998vY32xV/6R5//e0ef+cz1NkF0SOxhXobiYoD7QMxPkJAxDEq5UAHN7z7Ajb88efvts2+/sn7nnXdW64F9UK3zGdanufH784UFopPtBn2c0/4i0nzRCNtQKzN0tOV85/j+nd3DGaN+7Vtf/1//M33qZ/MXv/TCZz7dSLRI1bVuGIbGNR+e6YwNYfH6m+NLNx68eavcvNPffdAbcdNg+yA/uLMOvnabe/v7+2yL4/vdWtn0xBXO5b53zXx2vbixaoyWASyW89RQLn1MyXFz7SPXiz8bu63043PP7Hz2k8/97Z9On/iE+/j1mb+KptUyWYCNoASC2siawNoR/87v3/rTr7y72moTAwm6rgNXpjQOQ99vVZWZnQvOOWLfb0ZVnSgwO3eQzMzMTdPEGGutY8lENJvN2rZVdj5KijysrYxxNuODj/T/6jc+9w//Dua6gu7AI1uJFmBZzbF/TzdUbXCWQApAlYmVwFrx23/0zh//6Stn/e6YdRZD4jTkerY5gRUiYgYbVFVATN45Z8oTaKL3Vo+ZUxMBwAgAEZFjERGR2WLPkEvtZ2lWizmmECW1+KV/cP3f/etnvW4Fc7A6YTCMzqPFZJ7sQsHIhGggwbDeNF//ZvfO7RyaTFbymBVaxPq+lzpE50MIzpEZwRSkxuycc869F4EmSqYLMCLCxDqRA5EB3fakSW3kduiLmjSpHccgtfnj/3rvmb3FF7/I3uAhRqwCcYiXUHsmNgUAYiGDCKmTt26NpyP2ntm/f3w3sQ9hluu2Wp0tLK+TaBmGwRFPwiBnVk2cPAQ6KWR6KSLMPKEXsekDzAzrB7UYWlAMzhOcWiGWba5/8Idv/MIvfvpwBsJATCDA/GWq+SJMYzoLMyrab924m+s2NNYmqKKqE5ha8R7L5XLWLmKMzrmJPIDtkuklExFHpLWWcZRSGOrIHBm0kjWSy2Z70s4cBzcMY9uGB6e3fFgfH6c33hjVtiwJ6h2JvywOgE0BBhgqBAURbh2Vb7x0xESrB8fP7n8k8rwUMucNrgyhmjJzim1qZj6kiUWwe7jtLvMNgPDeIeeYmQADzGrLFHzQIT8gNxDXvu8dIuWuVn3l1fueBBJRYSCmzSOgYZOrro4bswroSy/de/3NDYsd3zmSmmfLxs+QZpZSirYoRaqpwIiIiIwd3HtYLxbNLuOedioziZSSh1p60+xiYWbi2bbXpmlC5Du3j2SE9GGUk5df2RbM4IAAkQiER0ATQ00FGQChGuqrL9852xir5rE7Obm9ux+W+/BtL9oBHFJk9mb2CHSCPWoPTzDpxMycc7O23d1dHh7uX7t2mOZrjmR13oSPlpFPT08Xs3YxW3an1Td24zvrN97cwKHSihwg6VF5EJyxt8YKLHQ3j+mV7zRWbp9sHsTm2q17d1ZDt9jfn+9ca+PHzNZai3M0UcvMqlrLtIOl1lprnRA/dH/OiXdtHTxK97eu29/9tP/Ys8MsdZGWKNHHMlty5SMFzXfb47NbwqKjdBv52l9sC8SPO06Q3fGj8oAKnQFGwTLmL31zdXTvtkvtyd2ja3s7ZbtFGZAH2DA/gN8VIlLVi9Xnc6btnPLL/m6yru/NabNszPmju91rrz+4dadfb12vnXlql3E2a5weNHRwcnSPa100u5vtan6w+9++evLmuy6ne3Aa7fAR0LUOjnZRnXEW8Fe+/H3zMdfZvXfvyFA40+03bubNcLi7t9hJ5pvJGQM8iYTA0zuO6H0PBhiYLXcUJaMX8kUWYznohp2TLdR7oZCaudim1uOhv2k6RCzW65658aneX8uX/+z7hmuSGY+mGhx4BmxGEUX6H3+Wb/zlKjZ0ePBcnC3vHd+bzePx8c2jm6/fufXWbOFmi2dDdJPHIPAkac/MeI/p95kpi1aQkOOc/dCHagkcgWa2SCmlWRs327N1d1JV1/kozXlv2ZzeOZVT5TIDYFzx6Pp5MGqNsRkK6gsv7rz44vzbNx7sHOzt7l+/+db3ou+KnNy+1d28/a0vPBP2lj/9YMtVUYuZGsBEMCIl8A8I45wVdaQU2DFc7YuakGffwrv5znIB4bG/f/fea4x5qR+fzz7Wb8tybr/6yy/88hfSz39u4QBjL8gO8RJog/cRoID5xz8+/tZ/+tzv/c7b//n3jk6Oy6I9cC6V4ax0crK+/eqNv/i5n/vsZnZczatUMQU7IjZTIgL/cNCJY83ZBErqPHuCOWXPi3liHmaR3nrr+92xLRonrtvbm/+zL734T76w8+Lzc48KcSAIPSBqH2WaRlgCghUEnyLzb/6bn/3nX9r/o9+nP/yTP/nGt14dh22i+ere/bdev/GLv8DtPKhZKbUO5LxnkBncpJYLu7wdx9qxdxQ8RBWFidjHdrZwUbwb9g/He7fvDLf9p//+c7/269d/9Tc+dbhgAjwqtIMLZq3HwXkEfPj7aiY1excBgHpoU0YKDUA4Wes3vnXzK1/+2n//6o3FPv7xr/382dlnjtdjv80P7ndDr8G1RASp7EgvdPc+B+I8SjVYNKnBmXcMH5vZjp/1qex/6pMnv/Kl8Fd/vvkX//Kze/tb0wWkEnk4EXNgGOAURB1o9h7ox1bjouoYUhyHUWty9s4d/1u//eqD+30e6eidMxU/S21Rcc7lnC9vvgn6ZCIy/cPM3vspysQYeZZY6+c/e/Qff/Pz1eANBFSI5w+utx5bbv2gx621qmrOWcQzM8GZmch5chdjnBLl8yTuIhZOWJ1zD99xzoUQigyO9JM/8wKh1uJCJJRC4QoV4pNqRAA49wnMDGjJVZRm86bfgtikqkCmo0Q0jqNzbuJyij4hhJTSedSsdUI/sV5rhRtCdC88/1PASEwAgQ3Qq3TqHg/6EtNsDMLZqtv0w95yNw+biTYjm0g1oxDCFMadcykl7z0AEZnIvviYqepEvKoQCAqYJJ9ExJGvWq/QQfigy5pEIiI1y+lq1W0zkakqETlPD4+WUmqtIYT5fN40jaqO4ygiIQQzNTsP+xf1AZkRwQ19Xp2upkpsyo/p0WzuRwdN56gBMLNzrhY4n8xMrTITADUxM2ZOKTVNAqyUrCoxhqZJzDSOQwgBQK3lQs2JiEopzrmu64pUGJlNUQruMc7+ffZYeUz19FTPTGGbfWznS+/dRfJJZsZu2mehlGEqEzE1QgHnXNM0IuK9DyEAJCIi1XsfY/QJ5Ji9h0NVRAaKwD3dRrycsKmCGWbmXJj6uRPBwQf2YXIpTZPe1zmYrjylNG1EIp5KgckPusBNE51nwJihWtmxQXCFFtMT+tPmDCDC1IUlVE8ueO99KaVt2+nCch6JEKPvuo6IYowT0yGEpmmIaBiGpmli0xihqhjgQ1AzZzU07bXWQ1tCYfJi7KCPw3Ml0A4X/buLmtd775kAxBiJTLVOWp/25e7urqoOw5BSWiwWfd+fnZ3FGBeLRdd1w9C3bZtSmras934oNYTQNAmGqhUAM66k6A/005ctBheieWeAEvnJx5FzMcZSaim5aZopOo7jOJ/PvfeTD5nP593QD8MQY4zJn1dfPvoIjsC0caZOwYUrebJ9sFe0i6eYODhMIMws5xyjd85NYaVt21KKiMxmsxBC13XjOLZtG2MchsF7P5vNJkfuvVfV4BvVOuYNCMElmMFAV8L8eNAGAc5dHhFAGgN7Z977WisRpZRyzmo1pZTzWGtdLpeqenJyEkLY39+fWPeBm6bJOXfddj6fLxaLMfciUoqBqmq+gKGgRyLahwFNl/IoIgAao48euQxt204OIaVERH3fT/Hv9PR0Nps9++yzm83m7OxsNpvNZrOcs0EODg7m8/lqtZr2pQ+cR93ZWS53GkyLaQZ6Ep7L9oQwrrBHvE+bQoxu7LnWCiClVGtVgg88qWI+n2+3WwCHh4dmtlqt2rZdLBbDMKzXawD7+3siul6vQwhadXdnZzlL5/pjNgD2g3naD7HHM/1ouwww7zl4ngKbQcxkInjKN7bb7TiOi8UipbRarczs4OCAmbfbbUrp4OCAiFar1dTqVVXJAqhBYVNHdTrr08ljOmRQhgprRbi+iwgMA4nmEFiECD55V0pfa13uzA3SDduQ/M7ecsj92fq0nTeLnXk/DJvNarGYzefzvu9qrW3b+mB33+qPx2jVXDWDKnqSq2B+0ka8+ICCwQ4IjmfN1BrAlBMDIKIQAvHkTGJKqe/7zWYzn8+Xy+VqtZJqi8UihNB1g6rOZrPzZall2+e/fqc3NoAMplceH3+Q9wBDGdMQ1Enb0nbTM3kRyTkzs4gMYzehL6WUUpqmmRSyWq2miLPZbJh5Z2cHQM45pbRcLtVsPegrL6/FnZeXjAS+EtWPB23vcU3nOVBNkUUs5+J9aJqm1qpWp1xUVacYvl6vRWRnZ6dpmvV6HWOzXO6KWNd1KaWUmr7vu65j72p1r762HoVAF6ejK42ZHwua6eIQAZcSt/WqS3FuRiVLSgnAMAwhBMdhs+6cC/v7h6XI6enKjFJqJ/c3VQbb7TbnPOXc3ntz7q9vDcdnFQSo4yvfTPXEMG4wMgIpjNkDNuYx59p1A4xDcOM4llKmIdBgw97e3rbvNpvN4eHh5L+JqJm1ZjaMI4za2VxENtutmTlnMcaz9fbo9vj8YThf0KctAsCqmAKVqhIDFu7f3wxDjjFNbcgY4yTrEAIzr9frpml2d3dPT0+7rpvP5znnzXqbx5JiA2Cz2RDRcrl0zrFKTMEMR7czUJkIULvaXnyCn57+GqBKqkAVvXe8KlmmNGhKP0opZjYFdudc3/ellOVyaWZnZ2dTbZtznoJLSmkYhslbS6mOYGRnJ/k8JqLiagp5EtPsK8EX0mjBmd4b8/FxCp5LFufbmGYUYtHiiVhsLLmqEJGIjmP2LqU423bj+nRNSo58GauINc2saWYiNnIbxuPWL156s1QEMpA5fWrQ50cJZIBIXa+G1WpzMQOqD93L9Do4X3OZir+pUMg5e3aTuCd9A5hcBwByqILY2L07m6PjDgaQuqsl1FfREJuBya/XZRhHKE3awDRcI28GMZ2CuSPOOeecpz7B1HmahgRmZqI55yl1IaKxWGpw+mB85eUzMKB2xSrgiaDtUk/R8emplQpTVhGDEptzzrkAYMpDzuHyOdMT62o21YYl55wz2fnQQ1WzCRGzd9/+q60xyLyhPBVoOy/XFCCQmuLoaLsZBoBFRLWaKbN3LojRw5H4w/E48N7oaCJ7GIah72utWqXWaqJG2m+xtxe/+2q/GgBju9o9TE8AbTCYGU0TUcXR7U1RA7jWqlJEipkx+QnZJA9mzjnXXLw/L4HB5/KAqFXJ45hzVlUynW4DSA3unun/fmMNgtHTuTw8UhhrKfXByRhT6+BUoFpVFeBptKKkU931sKNXSymlTLnrOQuPznPZquNZGXOtEhb+O985A0Hsaf00AZjuThCt4zhuN9nHAKNHhoXkABCRlDI1a8oF3OB9LWWq1Zl5Qjz5kForWWG0hpxH3dmPb781gNT0Ss2ax4MWB0IpxVk15tdObEv7ruvM83a9psreGqvO++hc0IE9eVbTWsmUCKpVVH1IKkW0EJlPPgTnYFyrdn2vAXpkbdpumXLufB4tJ+b3zU5/NNBwVQgxNDAPid2pbE/GYVXA1bx0dVVsM8iZoA+Jm52ojsw5IypmVXWsMpY6jIVdYpfgoporBiUWZmHmfvbctZS8SQ9Tkuq3m4CnLAIUUk0ARhYSnJ1sSu0VUkf22uqA5IMDaeEy0LjVmkeoAIAq1Dy76EPwPg/FBAwy0UnopOYJTewPDtcxQPK837phYMUW/kou7/G9PDRMAiiiMruT9QqRuPUuR6DtN6eYC7FFSuQZpIqBmBkEJasCCIxUS+JARICCGeSICKalFGn3z7adi6HZk4Ju281dSKZ6lfjyeNCCafzDDAFWG3JxF2RhMShZ7rsRp+wq0bzUUZHNzDsPYiOYZwQiwIGlVlU1EzDczHt2pZRSu1UZ7txtkRbtcjv2XAcaB6B9/3D2RwMNAkNL8Z74+GxYPejLVoazvFErI85O2AUNCc75MoppqVW812n+4H1lrlMX/XwS4Mhs6l6riOQs+/FBWR1q2mI8Cy555tMj/ehuMvpg1E+6QVb8qJoCoR/rN7+b7z7Iw1n2c869HN8/4qCCRLRbxiGEzlRijFPvuWmaGH0ILoTQzuKFK6zr9XocRwBE1M7bjy4WcW/gAuF6urGf+QgOD1vQeb38oUAbhHpY66CgrmIBqEcBHNSjVkQBkimkwscK9e/7OkhABCrQqWVM5/GKHIBK7LWCO+QdRAxAU4BQzPxTgH549ou8Aper3ae2x8F63006P/y7V8FxOQe6yo/+37Yrgf5/zf7mafsQ9hPQPy77Cegfl/0fYbQLGpke+5oAAAAASUVORK5CYII=\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAYaUlEQVR4nO16W7AmV3Xet9beuy//5dzmzFWj0YyuCCEBBgwEGwguMDFOsJ34JUWVq3DsKpw8uFJ2HvLkPCRxuWySGMdJsJ3CDhVsY2LZgDFgbrIEWAiwQCA0GjS6jeZ6Zs75r91777VWHvqcM+eMGCEhFeUHdnX91fX/f3d/vfrb3/rW2k1mhhdmKFpuy0kZB1agsVGdFyyAMkAZLkVYob05o54CNcDf+5Wex6FXjCRWAqmIBSZA3QQAEQ0cIjlYzeghJ4eMfppw+3wu5V8gyEBwUZRCQdL85q9/6ALSr7zzHx3bd/PETY36DGTAExWWQNx/fsF6wSI9hZbCPJu967c+sHdp8As/+5Zf++OHTl9oBlYOs/oMywbvQeXMAkn4BwGac5sDfvl/3C2X8EvvetsdN+//2Ttu/eXf+auTFwTCoFz7DNImkyOGPL9rvUCYUbf8X37/Uw8//NB/fNe/bNhzO37bjx198YHD7/mjP5mN8swxAAhKRwUUHJ/PtV64iXh6vPi+3/75n3nj8qGyRgNeErT//I3X7v/bz9Gnv1AAKQGgSEjQ6On5XOoFA33pj3737bdc//a3HKvFCAUc1rK79baDv3Lz/tEnP8LIFAKIPFBEX+j3l9MZwGwuaA1zZEQAcYz1lu96wL3m9lJKYYOg4ekeTy4leuvr7O+P69eOe6DlicMcBRrOyAZDzMkAGLr9Z0ma5wyaNaMXnIjmWhhmG+D+5OH7Lj74lXzuKeTWAsO4yn1D2bowGeX9G5f83Xc30hY2yAlICPAzJCEUPpAaFMhSuFA8OwzPWaczPIAieqnhkApbVMXpD31x/W3/Wm943cOXBo+M5s3aRjCq+v2qN9i3+Or0U2859uTaAWMSeNSNtc6mpV9hs9xGXxTGRs5pTMwez4Lu9FzTeIs5aQ1GkVvM+esjPhObx87ymXPf2PjCvfTle4uzJzXMNzyNMaiHh8Itr1p+w4/2+9cv7gtvXpHlQ+UeX8AnRAfHULNAM2QGV2BKivDdH/5zBo2cR973kJ98jD6+wU9efGR4z+fnn/vo8Ny5sLxPh3uzq2rlRaOm2ZjJ/LyP5elTGPanN1w/O/ZivOTVb7rtth9/UcUENjhGFoMjg7GZA+NZ6MpzB90CZbr7jHzuIYuf/eTKJ97fmq299I5T174q1P1c9qZE83am7bxyutiv63Ue44I99fhrvv3o8rfv1Xrw1Ze99tg7f/Gdrz9YAA4ICsxblCUcGkmV/+7C8j1EGo9O0+987J7+nR8sT5166BVv02tuO9/M9w2kGPSYCp2LV4YasUBTrAd65vxT5jjK0mB6wyMnr3nga2flwRt/7l3v+KWfTw6SpSIHAxjCcM8CwnMG3Sh+7y/ufuC9f8JHbr14x8tqzXE0WywHmkvuM7lIKbmyapgdl4h5Pr64MZsViQZ9Wre45pYOMN/+4BdH99+955W3/tvf+40ZUAKlAYDQ8wSdMfdthUAtt+W01H7kaUb/Lz9z/5//5p+uvOJHZjdd6ybzum1pUCUji2pbA4D3HkCMcXLxIhG54J1zxgRjcuycm8f22IfeU/7wy//db/37QaFTKkuCS5Gehe5dFbQaGDkTc8tctpN56Nf6d/ee+u//+X/O77h19brbyjGpkyYIFCkZGwAQEQAzIyJVbZpG2qYsy7IsOXhmJjgxFZH5qYcq7NfP/6/Db/2xX/vVfyMFSgBIwHfn9FX1xQgg822OJSzZIPDJtcn73vP+VK8MDx9rompsp3muIrWxL6sO7uaxZqoqIiLiihCqMlSl956ZiU0ltc0suirt2Tf4J7944mOf+fU7P1M2mEgD1e+K+JlAEyxphvMKIFSi+K/v/v1LOay88Q2DkQuX2lnfJ7LKuI3ZkjhiBkFNs2gWEyWDZ+e8B5GoxpTm8/l0Op3NZm3bDvYeacPFSVqsXvfPPvXb7/nolx8ZMEXFs5ljzwQ6JI4eIYkCd37m49++99tLP/TytVZyBldFmxrX5JRlpJGbJCJ5a3Qx7kjCzKqac5acU0pt21qWwvnRbKyTDc+TS4MjK/tv+oPf+E+n27LwZfegvlfQChSh1RzYzSI+/YcfOHDdLSP2fpqnrDNKBEApTprCqHEppdTB7a7aMUQ7luScU8o5W06aokgyE6Q5NUmRZxtnF25/E6bzP/yDP96uDZ4Z99VzZtY5YcgFHO6791770oOnJGKmtfdZk8W2X1Tol0bOJ21TY7uHbo+UJabcxjifxRhV1cxSSqzmdbDm5gerpfNujOWX3/eRv7wwSs8c4+8G2nEFbgDV/JH3/9lBC6Gs106fHc9GdVX0vI/r49QkXe5NSBbzpmhsR7aLupl1/M4xpTZqFuec954YJapJSXVe3PBjnrE7eoAvFB/80PueF+jsiCIy5g8/de7EJz473LNo9Z45j0aji7lt4FicBdLQtqXjCWmOM2gkS2SJkUkicovc5hxFEpG54F3wzAyAyWkViqJQN3UjphQ3ZmO65tDpD344gYRILG/iMJiZYZeqPMNEzFAUCJ/667uwcfrc9bf7cnFhcTWpzdoYRY1dUps3MSZRo2xIalG0zRJFxaAgsAM7MSTRbFDibhNQSskxmkujhrKpUra0d+/xk+e+9IUvOYCZzUQVINBONX1m0AKDR6H2N399z3KvXDv60no43L//xl49kGxtk0SRxXJWMwKY2IMcyMEYxgoWo+3NyBGcKWUxURB7aF6/sMY5+34BUUdVu7K3Xj36+c/eRQaoKcxoK8C2C+fVI22FeT1+/4nHv/7NPfuuPZWQ8sy5sG91pQxOc7QUmSx49o5Ms2mGCUwYSiYmSXPMsSGTbuu+V0ndluYtM5aWljhp0zTUr129GJf2nzz+CAyqSmQgVoM9rd9w1colAI3w7/6/j+9de2xw+DWXzI5kl6anTJCamYiwdyEEH4KK5mbekRWAbkmHiZqZZTIzIzDzdpI3M1aEstyIbUihHg5Sr+hZuU6uOX02RfgyqCWQbpFjF0Geodxq739g7c8/9cV3lCkvHrDhAjfu4rmHN8ZkZt77oiiKonDBA0gpEdG23pFhG1zO2XvvvZeUk2QzY2bnHBmPxlOmPMzmFoJCZ2sXhfXJixuPnz5/9NheGMOU4MAENewg9lVBq9qffeSvFp86e8Pqwb9duXYhlJpy09TOGzOTY/Le2GcBEYWiTiqbITR0NwAzmBWhDCEwc84ZIuSdcw6AzOf1cGFYhdGFMUYb4m1jNPMXzk8Ux08+cd2xvUyOTDe9F+/i8VVBnxvHOz9x5+ulCUvXnTtw09GicHvDML+e7WLOuWkaETFCzhlAVVVGRESONh9nl7pVtaqqLnt7rwu9Xq/XizlPJpPKuWp1X5FlsLJfzj7x+GMnUh0WNHHZe+Ls2SahH4iIoDBAcSVoRTQ4B4JwFmhhhRju+eoTvB6P1Pr1O/7pwC2eGp2ZHn+cqpuP3biXHPcG/SQWc4KXHNNk1hBtPnfnXJdimNl7nzQlESFU/UE9GOSUm9nMRPqr1wTv5u04Ty9Omma4sroo6cTCkZX2iS+f5p+RiwOsWGDw1JSIe7s4nQFXOGyad0YWODjCiZOTpVLPHHrxqTpwvOAqCweW3GjjzBkZDAb94aAoihCCiOSQRSSltvNJqootS83MKSUzK8u6C/l8OvPOLS8vT2ZNbGUyGkk7i22LHHulP3L06Pihtcl07cLZuHoEJGidFdTn3aH2zkwJRlCzACfgTJCYn3jsgesWW7nph4r+omkDG15XHpmuTNfnoxgjplMXIzM7F7pJGYJLKXUQu1N3cuGcK8sylBURxRidc8SYzWaxmaU2zqdTkwSzFHNu5v1eXaxc++TXv3pq/PoXmWZhuLLrP+0cTJkd1JkyOzIwhQicPf3E2lOPHF28hVduH8Jny+O2baJpv1lZWqiqopuqAIjMTDRH51wIoaqquq7ruq6qqiiKDvHmzBMBUJbBEU0mozSfzSYjk8SwEEIIoYlpPJnygQMbDx1/4KEHYSwFDI4UT0vjTCKymSkF3lBAR3//zeLx+3jppqdceCpdiDOrjM/4aWgiEZGZ5pRSKynlGHOMKaUs0SDs4AN3m/PkPBXe55zb+SzHtplNR+sXR6P1FBuoQCU4NrMYIzMz83w+n+S0uLr/E+9978QsYV4Jg1R5N+js0DjbjFsGMryIe+DEv3joCa+VrJ+n8XpDftjOefytc/N2Op40TdM5zJxj285TalUVOSEnS1HaZuc2GW3k2EhqUzuX1EqOsZ23s+lkMumUR3KK8ybnyAxmtlmrh4+M7rnvo5/9ZAEPhbIw7crcHoCHgyoYFkBiQO6Pp+tanslpqnl56iPPbnji5E+e+vQHDr321MLhqlf3hoO66oMppZTaqKrz8XpnTbc53cm2L8qq3wu+VFV2ADS1TTObw6gsy5yzmYXCOVM4X/a9ZFxK/LKbbvrTd/+3n37TWxDbFMrSduVE7zO8I2RYIck5OCqgoeSPpScXz54oDhxSkGla9fKTk3P/O+lwOGTvCud9YB/KoihyKFS1X/A2Yu99l19EhEPZkVsJEtvpdOqIl5cXHRdlWc7nc5h69nE2jamty8qFsI967sbDzef+5pvHL73sloECuAK0eQCMYGU0OIxcKqIN9l07euWPfuvz//ea3s2zPcM0at5y/uRdvaO0cqjs1SmllCQI4MiM2IfAIYbCRFQEgDB3k88BwTlmVpPYtDEl8qEqC++9Zck5w9SZShtVldi1OYciT8qljfiSRb5r1jxq9HIfgWKX5rHZ1j0QAxbAzXRWHzn4r37hV3s333jqwj3NPN9YnlvND91/8GY7fCyE0DVics4iaas9I8y8rR5lWXrvu0TDzKq5k8IQQlmWzgVVJaKY03w+n7dNjDFtj2nLsVkPGN94fV0sk32HRognAAYigmcICrhp0uq2G19eL//j6uBds3ZjefXHLzzYn+WHX/yipQH5XBJRzNolavahk7NOkp1zXZtGO66Y5Ry7AgxqztMWbUygWVJWISL2nlUZRCA2XxONe2Vzy+1kfXT+1HYVApdb2EYAwxl81cee1aeOj66xhaWD+/YP5Ce+cv5zg6OP7jl8WCv1FMiBN5PIFZ9dCDs2byvM9gW3vwRg0pXu6pwj21Q0ZvahFwpXON4YHpqMBArPKVOx0yR5AFkyM4jZCKTo9YbR6Wg8mzmaruxfBN29fOCDywtBuA0UBF2vSETEFFCzzd5aJ2HbN3DZqXYuimA7vieDI8B5BjQroMxcFEXLYOQq8iiXG+N1cwfIoHSFnzYok2fqZqga2CFBeLZuTdPW5RpW3vuiH57qZKmd5Wnksu/YsXdG0LzZL+iQde6/A73pToGuOFBVMrDjLt4ikifjzX967qhvpGYmZMlsQbgfKZQZBGS6wox6GMwxuhLHsXmwIYDKqY2ToOgPm/Fa1etxHGf0xpUVtrMjszkPtwK8szbZYsWWchNMHQBTUkGczlVVSbuZ3ZULIuIGfQ+KLMNe2Lu/JgDs/G7J486wAoAoAAU0pQK8b5haG+d2NTsldi7XFGc2SB1fu87G9nzruHGZCVu4scPudbHvPKBzbnlhsa4qqOYYJaVuHjOzT4qMDWtd7ZeXSxiMHV9hmCxolQmZETxh5jFjFzDlabH0jZvfvIdT4znESZvg6qXkS1ZxBjIGGGAixyCCEjkzUoVZVwy4DnFiIe2HXLJxS6NWm1mRfvrC1966/o2juegvH8k+NzF6XaySz4V5XzSenYSDtV9eWWwSFBm0q/PEEJiHeBiMpWBUM5dGfb0gYsMBerUQM9EglCGpb1uAxUxhZqaAqibJMXW1lqjmbjPb/IZlbnYppvGGzpCWD+dL/+HLX1ij3tjwc6c+/Pb274rVZapclAsXWDu5JDYi6vWqylfeA09r7XmAATUAxCCvGWpTH2xtlsrBUuOLnBs248KjTWUowGwqKio7fDMAMnQVrZmBLpuyOq3MC6o5VsLzXnzHN7/9yvgVd/722y49eaFofurECdmb71y5jVV77kIP+9QSEdRsYVA5ckRgMPFuw0QOMPZmAhjDEwZpGB9+4rFHzzFKi7koPEFnmhpKAgp5W7O2tLmbbvlp7QlSAFk2IqqCG7F+0c4/vzw4Ub8GUnx2aXEkS8H3zg+tXOqJlP01ynmD0COYJh0O6q5JYyDaXQV4keQogIjIgGzg9nx6z7s/eOrIjUXVn8wzdUxQreuaneWm3ewBEKuqiHaNRpgHdHsiAjBjAK33So0hD8S5tv/hAy9ZnPWz3/AWxBvratWklE8VWepYPVaOFyMDSVWXlvtk1HEAu2eid86JdnqUPSdQgWuqjWMH19qWe0vIahZJ1KEYUJhP1mGsWws1nTIEZiI2MoDMpBPP7kbNDFgdNGcal2o7q1g4dFE3ipNuNGjDY8BA5Mk0buumn+owL+JiHABmJo7c3tUFJjbLoCtbBh5gJXiA2MFIACW84Sde+fhHHpzP2kAgJsBL0vF4ujFeizHmmFJqoZmZvS+8K+D4cqbRvNNVQ473m3Sul2KRl5oV4sw4g9mhOelKnk97GgJLUUZfl4ZxMV5KA5A6V+xZXiDASBmA0q7CNgOBFKowUvYg9KBvfvG1X7m//dZDj08ltZqVKIKFxA0HxcaGs+zMmYKZmUmklWik7ZYwS1c7beY5m86Wj+zXRltEZtQzx9fX3pfEEqZDkXlvIZOr40YzCAfmveRcl2CrulAFTMHAFWncd8LXtY03uUigcrhgF2djc54tWS7hrPCgWUiDpZyzy9lMHcjMWJMXNSx0nkQt01aTSTVrWKyZjHpUozAzK5g598mTGS3BuCImIiqKXsSUpbAUJRA3p0+NXnHTHhGXCYTWdUt2W/T4ziNJbmJeWFloZ9n5QkhVExOZEpFjR6pZzQzG5M2ZMZla55lAampkIGJiAlFXtXeJvuONwRwFeCZiAGbKIGby5EqEOD+/vFKrKMAE8G5PfVXQbTsv6wquJO/LomcmKWtROZLchdCky+HSPTkiEsmdNSXd9CfOObiuVUbbib37c86ZmNm5zW4qGdTMpE2qqqtL5Q1HDzAHkGZNhrCztL0q6Lqg4bA/EXWhLopCc4I670pybGYiTlhIM9R1UFRSZzEACEQJRGTcmVLqYnz57ERFqBTS3UC3CiMiqgbyNp7cfse1C0OnBoJ51t1tj6s31a87tCpxygTvvYnm1BqkM0k555xjzlGzdOYpxphSVBUz7WonVSNigLaXbrsKYHuAtDNWojnl2PGKnGcfKidvfPXLSlK7ytrcVSN9y5G9nGdFtShtTCmqtC5AcjRL3eogNgVOVdVUSY1gIqIpCSyEwLwj0zxtaEpExESac1Rl9r4IIYR5zjcfXHzlbTc6qDFMAbgs8M+GHtfuHbz01hu++uj6xvpaIeTKkCG5ZZN4+e7NaMvaqaQUJasAcBzYoCkrwWHTqWJH2MyMaVMfVRVg88LMQi6L3PGSY8MKmimRemYYX/HiylVB9zx+5LWvuvdbf7GxdqEwv7SyOG8baX2K006GjS6bZiJimIiYagghlJ7gRMREZQvlFRVDcJZS6irIEErmSmLKWcZNc/TIKgRd554BzYBPOwXkO4DuHmmEv+0o3nTHvv/z4JeePD9qRyt5OkrNZJamzjHzZhnL7ItQh1CKL81UcpPTXCQTcVEUoahgOefc1X9dZUlEIYRGqaqKvvOiWaeph2r//v379qzsHfhbDu8TDzbxMIDJs+2WvKu/7xEvcTG4OE733f+t4yceSe28593CsFbKReGrqvCBYSxiKYkKylAzwxEIGYBzzvnCe89kZtaB7jpPXYeE2AfP3ntmMJH3XJZlFYpUDEsPy8okzlFXauyutp7hzRpJMIMrAIAAE5DCFLadmXZ0fbpz8Fb/ygxGmwdu//od9hVmYN4BSaWz51stJFFxzils52tkV+W0cZAMD6jCYKoIIYgKbVK5k9iuCCdTogDbDIIR03b7bTskO2NjZo66KMJMzTY9LYE1tWB2HAComPMOUFVhvsyQq0Y6AgwQNKdYhAKAggVwl4V+e4cN5jdXsa3LJluR75YxLwdpe18t72jgMmx70U0BwLyKEXWlJmy3zbsqaLHMxLSJjE1gRuy2aohuwQ1dJ2tHJHdQ7/LDf/rYJulOzgAAks6DL3dmvW4lcufRV+e0AoCIusCbJ9WOr4rLseyiYgAUZgSmXT17BjI2Wzmdb9r9I9S61Hj5J7cFN+fo/eabY6q7bv4Z3stTYPM1+CQpOOc2g1sAsK3gEKj7J3Vr7tQd2Vm8rrzZHerNxs1OH3L5imYGcjHmovCAqinDbc6RnUdcHfQ/3PHCvV7/fRw/AP39Gj8A/f0aPwD9/Rr/HwzxAHEEsH4RAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAYaUlEQVR4nO16W7AmV3Xet9beuy//5dzmzFWj0YyuCCEBBgwEGwguMDFOsJ34JUWVq3DsKpw8uFJ2HvLkPCRxuWySGMdJsJ3CDhVsY2LZgDFgbrIEWAiwQCA0GjS6jeZ6Zs75r91777VWHvqcM+eMGCEhFeUHdnX91fX/f3d/vfrb3/rW2k1mhhdmKFpuy0kZB1agsVGdFyyAMkAZLkVYob05o54CNcDf+5Wex6FXjCRWAqmIBSZA3QQAEQ0cIjlYzeghJ4eMfppw+3wu5V8gyEBwUZRCQdL85q9/6ALSr7zzHx3bd/PETY36DGTAExWWQNx/fsF6wSI9hZbCPJu967c+sHdp8As/+5Zf++OHTl9oBlYOs/oMywbvQeXMAkn4BwGac5sDfvl/3C2X8EvvetsdN+//2Ttu/eXf+auTFwTCoFz7DNImkyOGPL9rvUCYUbf8X37/Uw8//NB/fNe/bNhzO37bjx198YHD7/mjP5mN8swxAAhKRwUUHJ/PtV64iXh6vPi+3/75n3nj8qGyRgNeErT//I3X7v/bz9Gnv1AAKQGgSEjQ6On5XOoFA33pj3737bdc//a3HKvFCAUc1rK79baDv3Lz/tEnP8LIFAKIPFBEX+j3l9MZwGwuaA1zZEQAcYz1lu96wL3m9lJKYYOg4ekeTy4leuvr7O+P69eOe6DlicMcBRrOyAZDzMkAGLr9Z0ma5wyaNaMXnIjmWhhmG+D+5OH7Lj74lXzuKeTWAsO4yn1D2bowGeX9G5f83Xc30hY2yAlICPAzJCEUPpAaFMhSuFA8OwzPWaczPIAieqnhkApbVMXpD31x/W3/Wm943cOXBo+M5s3aRjCq+v2qN9i3+Or0U2859uTaAWMSeNSNtc6mpV9hs9xGXxTGRs5pTMwez4Lu9FzTeIs5aQ1GkVvM+esjPhObx87ymXPf2PjCvfTle4uzJzXMNzyNMaiHh8Itr1p+w4/2+9cv7gtvXpHlQ+UeX8AnRAfHULNAM2QGV2BKivDdH/5zBo2cR973kJ98jD6+wU9efGR4z+fnn/vo8Ny5sLxPh3uzq2rlRaOm2ZjJ/LyP5elTGPanN1w/O/ZivOTVb7rtth9/UcUENjhGFoMjg7GZA+NZ6MpzB90CZbr7jHzuIYuf/eTKJ97fmq299I5T174q1P1c9qZE83am7bxyutiv63Ue44I99fhrvv3o8rfv1Xrw1Ze99tg7f/Gdrz9YAA4ICsxblCUcGkmV/+7C8j1EGo9O0+987J7+nR8sT5166BVv02tuO9/M9w2kGPSYCp2LV4YasUBTrAd65vxT5jjK0mB6wyMnr3nga2flwRt/7l3v+KWfTw6SpSIHAxjCcM8CwnMG3Sh+7y/ufuC9f8JHbr14x8tqzXE0WywHmkvuM7lIKbmyapgdl4h5Pr64MZsViQZ9Wre45pYOMN/+4BdH99+955W3/tvf+40ZUAKlAYDQ8wSdMfdthUAtt+W01H7kaUb/Lz9z/5//5p+uvOJHZjdd6ybzum1pUCUji2pbA4D3HkCMcXLxIhG54J1zxgRjcuycm8f22IfeU/7wy//db/37QaFTKkuCS5Gehe5dFbQaGDkTc8tctpN56Nf6d/ee+u//+X/O77h19brbyjGpkyYIFCkZGwAQEQAzIyJVbZpG2qYsy7IsOXhmJjgxFZH5qYcq7NfP/6/Db/2xX/vVfyMFSgBIwHfn9FX1xQgg822OJSzZIPDJtcn73vP+VK8MDx9rompsp3muIrWxL6sO7uaxZqoqIiLiihCqMlSl956ZiU0ltc0suirt2Tf4J7944mOf+fU7P1M2mEgD1e+K+JlAEyxphvMKIFSi+K/v/v1LOay88Q2DkQuX2lnfJ7LKuI3ZkjhiBkFNs2gWEyWDZ+e8B5GoxpTm8/l0Op3NZm3bDvYeacPFSVqsXvfPPvXb7/nolx8ZMEXFs5ljzwQ6JI4eIYkCd37m49++99tLP/TytVZyBldFmxrX5JRlpJGbJCJ5a3Qx7kjCzKqac5acU0pt21qWwvnRbKyTDc+TS4MjK/tv+oPf+E+n27LwZfegvlfQChSh1RzYzSI+/YcfOHDdLSP2fpqnrDNKBEApTprCqHEppdTB7a7aMUQ7luScU8o5W06aokgyE6Q5NUmRZxtnF25/E6bzP/yDP96uDZ4Z99VzZtY5YcgFHO6791770oOnJGKmtfdZk8W2X1Tol0bOJ21TY7uHbo+UJabcxjifxRhV1cxSSqzmdbDm5gerpfNujOWX3/eRv7wwSs8c4+8G2nEFbgDV/JH3/9lBC6Gs106fHc9GdVX0vI/r49QkXe5NSBbzpmhsR7aLupl1/M4xpTZqFuec954YJapJSXVe3PBjnrE7eoAvFB/80PueF+jsiCIy5g8/de7EJz473LNo9Z45j0aji7lt4FicBdLQtqXjCWmOM2gkS2SJkUkicovc5hxFEpG54F3wzAyAyWkViqJQN3UjphQ3ZmO65tDpD344gYRILG/iMJiZYZeqPMNEzFAUCJ/667uwcfrc9bf7cnFhcTWpzdoYRY1dUps3MSZRo2xIalG0zRJFxaAgsAM7MSTRbFDibhNQSskxmkujhrKpUra0d+/xk+e+9IUvOYCZzUQVINBONX1m0AKDR6H2N399z3KvXDv60no43L//xl49kGxtk0SRxXJWMwKY2IMcyMEYxgoWo+3NyBGcKWUxURB7aF6/sMY5+34BUUdVu7K3Xj36+c/eRQaoKcxoK8C2C+fVI22FeT1+/4nHv/7NPfuuPZWQ8sy5sG91pQxOc7QUmSx49o5Ms2mGCUwYSiYmSXPMsSGTbuu+V0ndluYtM5aWljhp0zTUr129GJf2nzz+CAyqSmQgVoM9rd9w1colAI3w7/6/j+9de2xw+DWXzI5kl6anTJCamYiwdyEEH4KK5mbekRWAbkmHiZqZZTIzIzDzdpI3M1aEstyIbUihHg5Sr+hZuU6uOX02RfgyqCWQbpFjF0Geodxq739g7c8/9cV3lCkvHrDhAjfu4rmHN8ZkZt77oiiKonDBA0gpEdG23pFhG1zO2XvvvZeUk2QzY2bnHBmPxlOmPMzmFoJCZ2sXhfXJixuPnz5/9NheGMOU4MAENewg9lVBq9qffeSvFp86e8Pqwb9duXYhlJpy09TOGzOTY/Le2GcBEYWiTiqbITR0NwAzmBWhDCEwc84ZIuSdcw6AzOf1cGFYhdGFMUYb4m1jNPMXzk8Ux08+cd2xvUyOTDe9F+/i8VVBnxvHOz9x5+ulCUvXnTtw09GicHvDML+e7WLOuWkaETFCzhlAVVVGRESONh9nl7pVtaqqLnt7rwu9Xq/XizlPJpPKuWp1X5FlsLJfzj7x+GMnUh0WNHHZe+Ls2SahH4iIoDBAcSVoRTQ4B4JwFmhhhRju+eoTvB6P1Pr1O/7pwC2eGp2ZHn+cqpuP3biXHPcG/SQWc4KXHNNk1hBtPnfnXJdimNl7nzQlESFU/UE9GOSUm9nMRPqr1wTv5u04Ty9Omma4sroo6cTCkZX2iS+f5p+RiwOsWGDw1JSIe7s4nQFXOGyad0YWODjCiZOTpVLPHHrxqTpwvOAqCweW3GjjzBkZDAb94aAoihCCiOSQRSSltvNJqootS83MKSUzK8u6C/l8OvPOLS8vT2ZNbGUyGkk7i22LHHulP3L06Pihtcl07cLZuHoEJGidFdTn3aH2zkwJRlCzACfgTJCYn3jsgesWW7nph4r+omkDG15XHpmuTNfnoxgjplMXIzM7F7pJGYJLKXUQu1N3cuGcK8sylBURxRidc8SYzWaxmaU2zqdTkwSzFHNu5v1eXaxc++TXv3pq/PoXmWZhuLLrP+0cTJkd1JkyOzIwhQicPf3E2lOPHF28hVduH8Jny+O2baJpv1lZWqiqopuqAIjMTDRH51wIoaqquq7ruq6qqiiKDvHmzBMBUJbBEU0mozSfzSYjk8SwEEIIoYlpPJnygQMbDx1/4KEHYSwFDI4UT0vjTCKymSkF3lBAR3//zeLx+3jppqdceCpdiDOrjM/4aWgiEZGZ5pRSKynlGHOMKaUs0SDs4AN3m/PkPBXe55zb+SzHtplNR+sXR6P1FBuoQCU4NrMYIzMz83w+n+S0uLr/E+9978QsYV4Jg1R5N+js0DjbjFsGMryIe+DEv3joCa+VrJ+n8XpDftjOefytc/N2Op40TdM5zJxj285TalUVOSEnS1HaZuc2GW3k2EhqUzuX1EqOsZ23s+lkMumUR3KK8ybnyAxmtlmrh4+M7rnvo5/9ZAEPhbIw7crcHoCHgyoYFkBiQO6Pp+tanslpqnl56iPPbnji5E+e+vQHDr321MLhqlf3hoO66oMppZTaqKrz8XpnTbc53cm2L8qq3wu+VFV2ADS1TTObw6gsy5yzmYXCOVM4X/a9ZFxK/LKbbvrTd/+3n37TWxDbFMrSduVE7zO8I2RYIck5OCqgoeSPpScXz54oDhxSkGla9fKTk3P/O+lwOGTvCud9YB/KoihyKFS1X/A2Yu99l19EhEPZkVsJEtvpdOqIl5cXHRdlWc7nc5h69nE2jamty8qFsI967sbDzef+5pvHL73sloECuAK0eQCMYGU0OIxcKqIN9l07euWPfuvz//ea3s2zPcM0at5y/uRdvaO0cqjs1SmllCQI4MiM2IfAIYbCRFQEgDB3k88BwTlmVpPYtDEl8qEqC++9Zck5w9SZShtVldi1OYciT8qljfiSRb5r1jxq9HIfgWKX5rHZ1j0QAxbAzXRWHzn4r37hV3s333jqwj3NPN9YnlvND91/8GY7fCyE0DVics4iaas9I8y8rR5lWXrvu0TDzKq5k8IQQlmWzgVVJaKY03w+n7dNjDFtj2nLsVkPGN94fV0sk32HRognAAYigmcICrhp0uq2G19eL//j6uBds3ZjefXHLzzYn+WHX/yipQH5XBJRzNolavahk7NOkp1zXZtGO66Y5Ry7AgxqztMWbUygWVJWISL2nlUZRCA2XxONe2Vzy+1kfXT+1HYVApdb2EYAwxl81cee1aeOj66xhaWD+/YP5Ce+cv5zg6OP7jl8WCv1FMiBN5PIFZ9dCDs2byvM9gW3vwRg0pXu6pwj21Q0ZvahFwpXON4YHpqMBArPKVOx0yR5AFkyM4jZCKTo9YbR6Wg8mzmaruxfBN29fOCDywtBuA0UBF2vSETEFFCzzd5aJ2HbN3DZqXYuimA7vieDI8B5BjQroMxcFEXLYOQq8iiXG+N1cwfIoHSFnzYok2fqZqga2CFBeLZuTdPW5RpW3vuiH57qZKmd5Wnksu/YsXdG0LzZL+iQde6/A73pToGuOFBVMrDjLt4ikifjzX967qhvpGYmZMlsQbgfKZQZBGS6wox6GMwxuhLHsXmwIYDKqY2ToOgPm/Fa1etxHGf0xpUVtrMjszkPtwK8szbZYsWWchNMHQBTUkGczlVVSbuZ3ZULIuIGfQ+KLMNe2Lu/JgDs/G7J486wAoAoAAU0pQK8b5haG+d2NTsldi7XFGc2SB1fu87G9nzruHGZCVu4scPudbHvPKBzbnlhsa4qqOYYJaVuHjOzT4qMDWtd7ZeXSxiMHV9hmCxolQmZETxh5jFjFzDlabH0jZvfvIdT4znESZvg6qXkS1ZxBjIGGGAixyCCEjkzUoVZVwy4DnFiIe2HXLJxS6NWm1mRfvrC1966/o2juegvH8k+NzF6XaySz4V5XzSenYSDtV9eWWwSFBm0q/PEEJiHeBiMpWBUM5dGfb0gYsMBerUQM9EglCGpb1uAxUxhZqaAqibJMXW1lqjmbjPb/IZlbnYppvGGzpCWD+dL/+HLX1ij3tjwc6c+/Pb274rVZapclAsXWDu5JDYi6vWqylfeA09r7XmAATUAxCCvGWpTH2xtlsrBUuOLnBs248KjTWUowGwqKio7fDMAMnQVrZmBLpuyOq3MC6o5VsLzXnzHN7/9yvgVd/722y49eaFofurECdmb71y5jVV77kIP+9QSEdRsYVA5ckRgMPFuw0QOMPZmAhjDEwZpGB9+4rFHzzFKi7koPEFnmhpKAgp5W7O2tLmbbvlp7QlSAFk2IqqCG7F+0c4/vzw4Ub8GUnx2aXEkS8H3zg+tXOqJlP01ynmD0COYJh0O6q5JYyDaXQV4keQogIjIgGzg9nx6z7s/eOrIjUXVn8wzdUxQreuaneWm3ewBEKuqiHaNRpgHdHsiAjBjAK33So0hD8S5tv/hAy9ZnPWz3/AWxBvratWklE8VWepYPVaOFyMDSVWXlvtk1HEAu2eid86JdnqUPSdQgWuqjWMH19qWe0vIahZJ1KEYUJhP1mGsWws1nTIEZiI2MoDMpBPP7kbNDFgdNGcal2o7q1g4dFE3ipNuNGjDY8BA5Mk0buumn+owL+JiHABmJo7c3tUFJjbLoCtbBh5gJXiA2MFIACW84Sde+fhHHpzP2kAgJsBL0vF4ujFeizHmmFJqoZmZvS+8K+D4cqbRvNNVQ473m3Sul2KRl5oV4sw4g9mhOelKnk97GgJLUUZfl4ZxMV5KA5A6V+xZXiDASBmA0q7CNgOBFKowUvYg9KBvfvG1X7m//dZDj08ltZqVKIKFxA0HxcaGs+zMmYKZmUmklWik7ZYwS1c7beY5m86Wj+zXRltEZtQzx9fX3pfEEqZDkXlvIZOr40YzCAfmveRcl2CrulAFTMHAFWncd8LXtY03uUigcrhgF2djc54tWS7hrPCgWUiDpZyzy9lMHcjMWJMXNSx0nkQt01aTSTVrWKyZjHpUozAzK5g598mTGS3BuCImIiqKXsSUpbAUJRA3p0+NXnHTHhGXCYTWdUt2W/T4ziNJbmJeWFloZ9n5QkhVExOZEpFjR6pZzQzG5M2ZMZla55lAampkIGJiAlFXtXeJvuONwRwFeCZiAGbKIGby5EqEOD+/vFKrKMAE8G5PfVXQbTsv6wquJO/LomcmKWtROZLchdCky+HSPTkiEsmdNSXd9CfOObiuVUbbib37c86ZmNm5zW4qGdTMpE2qqqtL5Q1HDzAHkGZNhrCztL0q6Lqg4bA/EXWhLopCc4I670pybGYiTlhIM9R1UFRSZzEACEQJRGTcmVLqYnz57ERFqBTS3UC3CiMiqgbyNp7cfse1C0OnBoJ51t1tj6s31a87tCpxygTvvYnm1BqkM0k555xjzlGzdOYpxphSVBUz7WonVSNigLaXbrsKYHuAtDNWojnl2PGKnGcfKidvfPXLSlK7ytrcVSN9y5G9nGdFtShtTCmqtC5AcjRL3eogNgVOVdVUSY1gIqIpCSyEwLwj0zxtaEpExESac1Rl9r4IIYR5zjcfXHzlbTc6qDFMAbgs8M+GHtfuHbz01hu++uj6xvpaIeTKkCG5ZZN4+e7NaMvaqaQUJasAcBzYoCkrwWHTqWJH2MyMaVMfVRVg88LMQi6L3PGSY8MKmimRemYYX/HiylVB9zx+5LWvuvdbf7GxdqEwv7SyOG8baX2K006GjS6bZiJimIiYagghlJ7gRMREZQvlFRVDcJZS6irIEErmSmLKWcZNc/TIKgRd554BzYBPOwXkO4DuHmmEv+0o3nTHvv/z4JeePD9qRyt5OkrNZJamzjHzZhnL7ItQh1CKL81UcpPTXCQTcVEUoahgOefc1X9dZUlEIYRGqaqKvvOiWaeph2r//v379qzsHfhbDu8TDzbxMIDJs+2WvKu/7xEvcTG4OE733f+t4yceSe28593CsFbKReGrqvCBYSxiKYkKylAzwxEIGYBzzvnCe89kZtaB7jpPXYeE2AfP3ntmMJH3XJZlFYpUDEsPy8okzlFXauyutp7hzRpJMIMrAIAAE5DCFLadmXZ0fbpz8Fb/ygxGmwdu//od9hVmYN4BSaWz51stJFFxzils52tkV+W0cZAMD6jCYKoIIYgKbVK5k9iuCCdTogDbDIIR03b7bTskO2NjZo66KMJMzTY9LYE1tWB2HAComPMOUFVhvsyQq0Y6AgwQNKdYhAKAggVwl4V+e4cN5jdXsa3LJluR75YxLwdpe18t72jgMmx70U0BwLyKEXWlJmy3zbsqaLHMxLSJjE1gRuy2aohuwQ1dJ2tHJHdQ7/LDf/rYJulOzgAAks6DL3dmvW4lcufRV+e0AoCIusCbJ9WOr4rLseyiYgAUZgSmXT17BjI2Wzmdb9r9I9S61Hj5J7cFN+fo/eabY6q7bv4Z3stTYPM1+CQpOOc2g1sAsK3gEKj7J3Vr7tQd2Vm8rrzZHerNxs1OH3L5imYGcjHmovCAqinDbc6RnUdcHfQ/3PHCvV7/fRw/AP39Gj8A/f0aPwD9/Rr/HwzxAHEEsH4RAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAARfElEQVR4nO16TXNkyXXdOfdm5ntVKKDRPT1NkR7qyxYpW3KEFnaEw154LW+88S/x33F47Z1XXmnBhSO8cYQsi0FZokTKIsWPUU/PoAFU1XsvM++9XjwAjW4SZIcHHknhuYFFFaJe1slTJ+9nMiLw983kbxvA/419CfqLsi9Bf1H2Jegvyh4N9Dv+Pm7//l/Yo4Emeffa3Vtv5vZYi79jjymPO7Jbs+m4zFN1f8Tl39gjyyMieu+11lpra63W/q5sIj5/4vCYTK8K6d3NjNQI1lofcf07S4+1EBkAV9wkVQWAma+83lf857dHdnkRoapJC8kIkPxZMXz+DTwmaHd3dxEREXePCBF5FBG/Y495EEWE1Na9u4soyd57bRHB9QPufkPz5/Mqj+mn3yGVJMmVcjyqrB9f0xFvQiGJO9DAPYl/PvyPCPqNfEmSILEy7bcx5rHIfuSIuPK6CgO31N4n+1Hscb0HwnnfAL/DvX7mUch+RO+BOyXcYr6h/NHJfkzQ9w/cO4x+QfI4ri7AgfBuM9ARC/zggcC9fPkGjEfEUnuL6E6DUosZGDowwYSerd2t2C2Wu6fd3b1jXTcANEQ3a8v6bu7oNqPdx/ZzwuyN9QkiIVKRGSgBExyB0zUwxO1uuYrVa+2Hw0QVSMo5K6Mtc1K96ouq7jY7kaSAGbICAG8DTLx5wR6ePVMANoMHVJEYiADv0ftgwtTTJgUO1kNjS6IDs+lWOxCIoAcIMEAARKIkanF3ODro4a1KJ1I6YXfvzAkqLuz0ACNixE1klDsGQDWFAvSs1sGOhMYURHkfpmdgdMA9UpvrccMBWpqkfC8CB+AOEZCYjrXWCnhKaSxJBOGdpE3obpJT3oxQGGBArIu/WWglM0BCLlFPIAWyxqAFIVXye4Huy1XKZ3+9x3eu2g9eX+c0Ho79GMI+kzTSAmbm7qqacz44I4KIUtJYyp2zOw8rgl32Z4Ocqe/Uz0o+HYZFlpzzqFkBBcKdcBILMfQEYEpowBmA7hCHpF8OGubfPsh/+tPP/vilTy0n5WzzeDJiIZOC2qxX6womUVXd7YRkWF8zu1qbQ8xs0Z312do8KCR8LEUdIlJ4WbQMpYyaNaBhOcmQ0zf+wfDPd/jtYUHyhtE6RwVQwfLLQX8y4z/84f/6rjzfbl+0fZ/bYXda9q8+PZQzzSnI2ltEJNGshEdGZFEzI9QspsWYiln4ZtPNej1sTtKQ5WQ7TtO0HKeGoXez5vCIMEEMRcax9O7ffCH/Ytf+zVefDUQUVIBuRfQO24MH8T//FD88+TrSrr6eznbDy/3SfHM2foS+V1dHqJGUrWZFmPelBDK9BREd3hSapDNy/XTMyg23gxKSG6Y92z7Onm6r1S7uIlRQLA2aS/pI9I+O9Y9evpZ+9m8/Sm7XqmOqGSN+OejjBPb5Sc4XmqZX/XwYUvNLR01ZFSSMCZAOAdyIYtojLLIFnMqtBClQ61sIlHDNV1dXmodjLOl8W1Ob+zSe5kRPqhZxcjIE8XLys6SbfP5fLvD7v3lR5MkES6PfDykPgv7mi/n3h6fnEctZPjhsX4/XSx1G2yMkDLa419DG6Og97KKeAbBAa611s3AAjn5MgwBJPBcuecxpOM4pDxlAP9FxUAmIYOmWUnS3OaWXJWI4nR0v+9OPiIHRFPlehH0Q9L98ks+d9Wr/+vuvTkfqcvXkwxeWezxPgBNEKCLx9kQE59VFuXsAIhRJAKKJhFOI6IBCYZU6wDrcKQKzpqruIQkR0hP+5HD4wd7+9G/aJ/vnH51CNBZqvoftwYP4amrzZ6+GAcdXLy+Or69efvobv/t7Z0+/ppZBj7CARGj3iHCKqeY134gICdymSqaJAAQwb6qKkGaWc+ZNnwRmJklVRZVO5KWhGDB++4Ap4Z9tmuDAOMf7MF3kuD35ymuR/7bZ/e/pp7/9a9/4NT33KfJWk0rSJAyEIBx0kGGJBAgEwNvaxOjFARDhoWsalVxEwvtEKElSHE1FAVfYMm4HAyqe1GX2sE0EJNlbSB9k+j9+Et/94Sv08XX2Z2X3/VcXOvv5155xvtyWtCkYQ3JwS80SSt9oExFVFRFNFBFdF28wM+pNnVtKWVOkMdMsSKaUaq3DqGPOhLPIaWrPUX6y4AM5/PrJxiHh0Dce72Gmh8v5Rxqnw9Z7/YdV//tlT6Lz4bhMZTjJYlxaax2SwCSg2zHdloC2MrpWX5syHpdO9VLKNNWzs2TN27zsTsfDYQpiHPW4b6c7Pd9Rk84Hn60+D8tp8+9/k3ChwgL3MD8MmroZYtH9hX81Lj6ZuKvP2/Pri+V8tA1CXObW52rZNskYlOYNa54JkhQJAOE80ap+cMem7GjHcw7GdrTDxtl9yjmf5ELOu8AOweaRcR1YZFiIr+zE3TuspAqc3GF7MJ/+2F1ywZbDp+Py9Fm6LNWuylMyp9DSkKeInuAlmuLY/dhrBz2yVbGqresSqaosXSG7kNPjRMp2Ovac89Pz3dFqUJaKy2vLJx9+NtnF0UNHCflQylX3f/IEqYtQCmCxuY/t4dS0O0KIFEjTtJCiqiEZ4r27R4AiWHUZAHJKndak2xCA0COZbNLQfanePKg5CaLBF/NxSE/H7VHq9dWxR0gec06AT/M8bopV5gh5uKB8ELSZRUg3WvOL6RrCUornEn2urRuCVAdrtyAEXFoRRfNu1gBTkpTWRUXC1R2iyZSt1m4GGTbQkoYk5qLWKVqOS5+n/tUxMSLsJk1cpSp8SxEPgg7v7nRKEIvXzcluGNMCa+v5ogTEgW50uKp+hOXD7e5pHqUtCprqtfl1XTZb+kYtQBVVXWoD/LR41+uT09Npo93l0I6SVKIr2MLgZDAiSIkACcf7HcQkRiYV1VFFy5PNNqPv6wQkJlWkZmHdHViX/km2WetrD7ajIMAyUw6p/8qEnHNQrPeIINQjptq+pvpsm3pOS7fr2pRpHDabpN9pVVXUV2EIgPiZ0c2DoLebrB3Ww72NElkpzQVBEYq2oHtYBMkQBuB2/vIqftyn3kWIxEjCIZ/+8Xw9DEKKmZEOlQi69+9ofdZnBoLegwIrwTTbICbQIHvvYEKA4Dvu4kHQAvXevEdtNmzCrMEja3bA3Ky7WcAD1NUjix0hTJl53CoZrXpt3nwYswhEQCCiJ0ki0lprwcPSBmXK2G4Hs5bpMKsmSu8mc+0PwXsQdJ1qq0iSk2jJsZi629rocvNa3UJijdrmQTRlliwtfOqhKqkg6wJXl9ZdCYFEhKScVRliXdriZES1QYgOLUlDq4RIRsDC39T874KOmzxh7cGt/7XwS0/czGWK5v3g43mPGhzCLq32Q346yEdP8s5jZvzJp9On7flJfDo9waQ2uG8tzFiF1IHaRMSdFiEqFl28p4xCI6O691AsGMu2ee1SVQbIIingOw+neHh6J5w8GFwWVfOUQrfqjYePY/5r6y9rD8PJk/KPn2Zd/L/+eLlo0+9+ePTx4/3mw+V6GI9njtOXSS+3Sbbal6swj1szs25hDkBlLS4pANaBWHNzpPC3OlXvK4/1mY6FEXBFGpZ5j5BN0iean7tuy/XVHn922L7Stq1Dja+fa7taDnNU15PsOrLU4ySKJyFTBMFYhe8wepckSVQ8J1FBa2ZmLQwUSXB3Cj1ueoIr/EDwXm56ry6/t62ISD5vgC7DZd9G698Y/NkWT3Q8OVv+6lKf9/bvPvJLT9KXUeWvwvOz1JfhR9fHPztMPH9aPM1eDxvdxV2dACcQZASrbxISBYn0MAsLgblYEhUJAwT0eEAIDx5Ej23BNEnde/pIym+la+a2t/SXnxxKbK5dro+2Za5Gz9ojH6Yf/d72N76Wti8R37fDSZdTKZEErUZEwENkFYMbFrNCd9ekyElJd4c5avNCdRHcNAzt1l2/pZM3oO8fRJJL3y71aFG30n79tBTan4d97zjTX/yr8fV3pvqtT8fnSWpdKvybiR88O/+Dl68qR5Hds9q4UTrks9dxugkGApQghCQ9IqJZZDMVIZFUO6Jb771bzgqG4MY1IX5W1z+HaZKIKNKWmqjyLB9e7Ma/eZ3+wtNV0xfp8uPrT39nSC+e6kHyRny3uXZJaf76t+yTj3351fFsuNxfnGC/TbuzTe/h4reTAReQSgY91MCIUAYgBpfwCLbak5IqQvKB2cyD8vhgOHwsWXFyhjoyf3cvl5F+VcbWehtPp82HaX/8FX19qOXV8cMx15/o9amyV2s62wle6DBdL13QBXRC1j4uA1SqqK4hnXQg1tariISwuRVPAH7ByCDdbeZOGxEh4FmMU9PdydRyfHt/bLvN7shPri8/2Ina6f98ffG962W7nEyaX8vVV2r/5gc7y6VVpkXddD/I3Oy0Y5ZQ1RRy8xWyFgpuYSopi4o6xVOW6Fyap6EsdTCtZVjoOUJNscC39w7lg346pRrai/eTJabP9m2a29LrJje4gRAtpeScNXFQHYeSYPVwjb6MQyZR6wIgVBSUwFo+Aqi1124W6L4evnAHgqqqqhLIcy0BAy/asjCgoo7SlveSxyi108YoT9P24JeFKfU6JViPKWpEJHdgobFoK6KZUbxvUhmUCIN5EnX3nIRkeDcHAELdonULYbeo5gRFmClOV4msmgQq0juCuial6a22xy/Q9FictYOg5pPtSSnPF5jO26w05ojd2j2NNmqcpmToT7a7DK11dq/DuCEZtWYy59zMp7p0C82FFO8Wgdpckyayu0R3AKWUo9TihuZb6OhoDlGQb2WnD4L++sl2JA6Gn3o9DihRz0uSpOoAPRl2olqQDA4U+L72NG597pd1vzbuwz1KpjfAh5zMzJba6yIpp5R6mFn0Fpa0W/TeUkrDkOfovTvChyGBQII7QH+vIuB5knPVi9mD3dRlmbe+VYslIip6p1IiQUK8+2S2N9v0dr20vZuUIbpFRD7ZlIjWzczKkFX1OC+9NaqrJiDc0S3cjeEQGzA8SaNV7PvcCmdmQrIAlvA+fY9dWp5nebWf2ibT47C0PSAdkbWvPyjRLRywkHC99nScWrewkkUUzVLAe2URCQ/nOmpJQigjjCEqSmhrnURSWmBpNbug+pjsPA+cDxjG8Ey8X424G/zZkL0u3AzqcN1cRVIPeps7bfHuNmuHBHvyIMrgrUGFWTswQrNyPy9iODs7S1qurq72+wOAkgcRqS3WdpSZiYAlAZhrO2aeurzY7v7pizLIBPPFeyrpvjwenrl0/8OfXn3rx8f/sddXPgp021tpx88qoAmAB5ubOYJwYGKWcMLFu5olmpJZ2Zd6ktLZWK4vLqZm6fTplaulUSWBkVJKQoGTMZQ8juVfx/f+0bOz33l+9uGp5uKS0yAD365sf8Ecsc+T//DKfnBZf3g1fXI4zL0647qlCEaEOQyBoCRV1WfRlZKVRSKpjElL0iz6FJ9l4ZOTrbXWHVGGi6WH5H0qAJQUEYRFWEmplPTVs/Fc9Ll4obFAhzFRaO8H+gpzAkqX5IBJC5qoJYyYcTNmBQCKqGZVXQDiZoy2Thdvky/02lK+cbRBtACIDODu8krYeo8IYKUUAK0j3JOEJAGi3x9uPQx6/a/1SpiqggKIO0C5ywrWR9czYmz3DsubKzbC3LuD6o4QisC9J016+zjvfx+BmIAEEJSgrGMLekDe5CIPy6M6VFbG1uyQcMCxtk9uvuYWp4eHkKTcorhbNTpC3nQBCERDBLT8nGtC62wcCkis82e6rkkV3gTFB0Ev2CcMgrwGo8A6Bje753DkBgZxNyN/OzWLQEOovBXQCAQi4ebG5C1uuXlL4vZi1g0D0SKcMvxy0FgH/wEPuqiBFW6IJ7cn4ubHvZPK3b2lt4EHGsG7qT1vdkf5GW97s+uVI0LuXiMsepL3YNoNcqMmowOR8e6vtC7gNzt4N/+9nX17AtYZOm7Qrh9HgLydiq8JN95dygn3SPr29OIXMf131/7/vqn+RdqXoL8o+xL0F2V/L0H/H7ZXz34C2smNAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAARfElEQVR4nO16TXNkyXXdOfdm5ntVKKDRPT1NkR7qyxYpW3KEFnaEw154LW+88S/x33F47Z1XXmnBhSO8cYQsi0FZokTKIsWPUU/PoAFU1XsvM++9XjwAjW4SZIcHHknhuYFFFaJe1slTJ+9nMiLw983kbxvA/419CfqLsi9Bf1H2Jegvyh4N9Dv+Pm7//l/Yo4Emeffa3Vtv5vZYi79jjymPO7Jbs+m4zFN1f8Tl39gjyyMieu+11lpra63W/q5sIj5/4vCYTK8K6d3NjNQI1lofcf07S4+1EBkAV9wkVQWAma+83lf857dHdnkRoapJC8kIkPxZMXz+DTwmaHd3dxEREXePCBF5FBG/Y495EEWE1Na9u4soyd57bRHB9QPufkPz5/Mqj+mn3yGVJMmVcjyqrB9f0xFvQiGJO9DAPYl/PvyPCPqNfEmSILEy7bcx5rHIfuSIuPK6CgO31N4n+1Hscb0HwnnfAL/DvX7mUch+RO+BOyXcYr6h/NHJfkzQ9w/cO4x+QfI4ri7AgfBuM9ARC/zggcC9fPkGjEfEUnuL6E6DUosZGDowwYSerd2t2C2Wu6fd3b1jXTcANEQ3a8v6bu7oNqPdx/ZzwuyN9QkiIVKRGSgBExyB0zUwxO1uuYrVa+2Hw0QVSMo5K6Mtc1K96ouq7jY7kaSAGbICAG8DTLx5wR6ePVMANoMHVJEYiADv0ftgwtTTJgUO1kNjS6IDs+lWOxCIoAcIMEAARKIkanF3ODro4a1KJ1I6YXfvzAkqLuz0ACNixE1klDsGQDWFAvSs1sGOhMYURHkfpmdgdMA9UpvrccMBWpqkfC8CB+AOEZCYjrXWCnhKaSxJBOGdpE3obpJT3oxQGGBArIu/WWglM0BCLlFPIAWyxqAFIVXye4Huy1XKZ3+9x3eu2g9eX+c0Ho79GMI+kzTSAmbm7qqacz44I4KIUtJYyp2zOw8rgl32Z4Ocqe/Uz0o+HYZFlpzzqFkBBcKdcBILMfQEYEpowBmA7hCHpF8OGubfPsh/+tPP/vilTy0n5WzzeDJiIZOC2qxX6womUVXd7YRkWF8zu1qbQ8xs0Z312do8KCR8LEUdIlJ4WbQMpYyaNaBhOcmQ0zf+wfDPd/jtYUHyhtE6RwVQwfLLQX8y4z/84f/6rjzfbl+0fZ/bYXda9q8+PZQzzSnI2ltEJNGshEdGZFEzI9QspsWYiln4ZtPNej1sTtKQ5WQ7TtO0HKeGoXez5vCIMEEMRcax9O7ffCH/Ytf+zVefDUQUVIBuRfQO24MH8T//FD88+TrSrr6eznbDy/3SfHM2foS+V1dHqJGUrWZFmPelBDK9BREd3hSapDNy/XTMyg23gxKSG6Y92z7Onm6r1S7uIlRQLA2aS/pI9I+O9Y9evpZ+9m8/Sm7XqmOqGSN+OejjBPb5Sc4XmqZX/XwYUvNLR01ZFSSMCZAOAdyIYtojLLIFnMqtBClQ61sIlHDNV1dXmodjLOl8W1Ob+zSe5kRPqhZxcjIE8XLys6SbfP5fLvD7v3lR5MkES6PfDykPgv7mi/n3h6fnEctZPjhsX4/XSx1G2yMkDLa419DG6Og97KKeAbBAa611s3AAjn5MgwBJPBcuecxpOM4pDxlAP9FxUAmIYOmWUnS3OaWXJWI4nR0v+9OPiIHRFPlehH0Q9L98ks+d9Wr/+vuvTkfqcvXkwxeWezxPgBNEKCLx9kQE59VFuXsAIhRJAKKJhFOI6IBCYZU6wDrcKQKzpqruIQkR0hP+5HD4wd7+9G/aJ/vnH51CNBZqvoftwYP4amrzZ6+GAcdXLy+Or69efvobv/t7Z0+/ppZBj7CARGj3iHCKqeY134gICdymSqaJAAQwb6qKkGaWc+ZNnwRmJklVRZVO5KWhGDB++4Ap4Z9tmuDAOMf7MF3kuD35ymuR/7bZ/e/pp7/9a9/4NT33KfJWk0rSJAyEIBx0kGGJBAgEwNvaxOjFARDhoWsalVxEwvtEKElSHE1FAVfYMm4HAyqe1GX2sE0EJNlbSB9k+j9+Et/94Sv08XX2Z2X3/VcXOvv5155xvtyWtCkYQ3JwS80SSt9oExFVFRFNFBFdF28wM+pNnVtKWVOkMdMsSKaUaq3DqGPOhLPIaWrPUX6y4AM5/PrJxiHh0Dce72Gmh8v5Rxqnw9Z7/YdV//tlT6Lz4bhMZTjJYlxaax2SwCSg2zHdloC2MrpWX5syHpdO9VLKNNWzs2TN27zsTsfDYQpiHPW4b6c7Pd9Rk84Hn60+D8tp8+9/k3ChwgL3MD8MmroZYtH9hX81Lj6ZuKvP2/Pri+V8tA1CXObW52rZNskYlOYNa54JkhQJAOE80ap+cMem7GjHcw7GdrTDxtl9yjmf5ELOu8AOweaRcR1YZFiIr+zE3TuspAqc3GF7MJ/+2F1ywZbDp+Py9Fm6LNWuylMyp9DSkKeInuAlmuLY/dhrBz2yVbGqresSqaosXSG7kNPjRMp2Ovac89Pz3dFqUJaKy2vLJx9+NtnF0UNHCflQylX3f/IEqYtQCmCxuY/t4dS0O0KIFEjTtJCiqiEZ4r27R4AiWHUZAHJKndak2xCA0COZbNLQfanePKg5CaLBF/NxSE/H7VHq9dWxR0gec06AT/M8bopV5gh5uKB8ELSZRUg3WvOL6RrCUornEn2urRuCVAdrtyAEXFoRRfNu1gBTkpTWRUXC1R2iyZSt1m4GGTbQkoYk5qLWKVqOS5+n/tUxMSLsJk1cpSp8SxEPgg7v7nRKEIvXzcluGNMCa+v5ogTEgW50uKp+hOXD7e5pHqUtCprqtfl1XTZb+kYtQBVVXWoD/LR41+uT09Npo93l0I6SVKIr2MLgZDAiSIkACcf7HcQkRiYV1VFFy5PNNqPv6wQkJlWkZmHdHViX/km2WetrD7ajIMAyUw6p/8qEnHNQrPeIINQjptq+pvpsm3pOS7fr2pRpHDabpN9pVVXUV2EIgPiZ0c2DoLebrB3Ww72NElkpzQVBEYq2oHtYBMkQBuB2/vIqftyn3kWIxEjCIZ/+8Xw9DEKKmZEOlQi69+9ofdZnBoLegwIrwTTbICbQIHvvYEKA4Dvu4kHQAvXevEdtNmzCrMEja3bA3Ky7WcAD1NUjix0hTJl53CoZrXpt3nwYswhEQCCiJ0ki0lprwcPSBmXK2G4Hs5bpMKsmSu8mc+0PwXsQdJ1qq0iSk2jJsZi629rocvNa3UJijdrmQTRlliwtfOqhKqkg6wJXl9ZdCYFEhKScVRliXdriZES1QYgOLUlDq4RIRsDC39T874KOmzxh7cGt/7XwS0/czGWK5v3g43mPGhzCLq32Q346yEdP8s5jZvzJp9On7flJfDo9waQ2uG8tzFiF1IHaRMSdFiEqFl28p4xCI6O691AsGMu2ee1SVQbIIingOw+neHh6J5w8GFwWVfOUQrfqjYePY/5r6y9rD8PJk/KPn2Zd/L/+eLlo0+9+ePTx4/3mw+V6GI9njtOXSS+3Sbbal6swj1szs25hDkBlLS4pANaBWHNzpPC3OlXvK4/1mY6FEXBFGpZ5j5BN0iean7tuy/XVHn922L7Stq1Dja+fa7taDnNU15PsOrLU4ySKJyFTBMFYhe8wepckSVQ8J1FBa2ZmLQwUSXB3Cj1ueoIr/EDwXm56ry6/t62ISD5vgC7DZd9G698Y/NkWT3Q8OVv+6lKf9/bvPvJLT9KXUeWvwvOz1JfhR9fHPztMPH9aPM1eDxvdxV2dACcQZASrbxISBYn0MAsLgblYEhUJAwT0eEAIDx5Ej23BNEnde/pIym+la+a2t/SXnxxKbK5dro+2Za5Gz9ojH6Yf/d72N76Wti8R37fDSZdTKZEErUZEwENkFYMbFrNCd9ekyElJd4c5avNCdRHcNAzt1l2/pZM3oO8fRJJL3y71aFG30n79tBTan4d97zjTX/yr8fV3pvqtT8fnSWpdKvybiR88O/+Dl68qR5Hds9q4UTrks9dxugkGApQghCQ9IqJZZDMVIZFUO6Jb771bzgqG4MY1IX5W1z+HaZKIKNKWmqjyLB9e7Ma/eZ3+wtNV0xfp8uPrT39nSC+e6kHyRny3uXZJaf76t+yTj3351fFsuNxfnGC/TbuzTe/h4reTAReQSgY91MCIUAYgBpfwCLbak5IqQvKB2cyD8vhgOHwsWXFyhjoyf3cvl5F+VcbWehtPp82HaX/8FX19qOXV8cMx15/o9amyV2s62wle6DBdL13QBXRC1j4uA1SqqK4hnXQg1tariISwuRVPAH7ByCDdbeZOGxEh4FmMU9PdydRyfHt/bLvN7shPri8/2Ina6f98ffG962W7nEyaX8vVV2r/5gc7y6VVpkXddD/I3Oy0Y5ZQ1RRy8xWyFgpuYSopi4o6xVOW6Fyap6EsdTCtZVjoOUJNscC39w7lg346pRrai/eTJabP9m2a29LrJje4gRAtpeScNXFQHYeSYPVwjb6MQyZR6wIgVBSUwFo+Aqi1124W6L4evnAHgqqqqhLIcy0BAy/asjCgoo7SlveSxyi108YoT9P24JeFKfU6JViPKWpEJHdgobFoK6KZUbxvUhmUCIN5EnX3nIRkeDcHAELdonULYbeo5gRFmClOV4msmgQq0juCuial6a22xy/Q9FictYOg5pPtSSnPF5jO26w05ojd2j2NNmqcpmToT7a7DK11dq/DuCEZtWYy59zMp7p0C82FFO8Wgdpckyayu0R3AKWUo9TihuZb6OhoDlGQb2WnD4L++sl2JA6Gn3o9DihRz0uSpOoAPRl2olqQDA4U+L72NG597pd1vzbuwz1KpjfAh5zMzJba6yIpp5R6mFn0Fpa0W/TeUkrDkOfovTvChyGBQII7QH+vIuB5knPVi9mD3dRlmbe+VYslIip6p1IiQUK8+2S2N9v0dr20vZuUIbpFRD7ZlIjWzczKkFX1OC+9NaqrJiDc0S3cjeEQGzA8SaNV7PvcCmdmQrIAlvA+fY9dWp5nebWf2ibT47C0PSAdkbWvPyjRLRywkHC99nScWrewkkUUzVLAe2URCQ/nOmpJQigjjCEqSmhrnURSWmBpNbug+pjsPA+cDxjG8Ey8X424G/zZkL0u3AzqcN1cRVIPeps7bfHuNmuHBHvyIMrgrUGFWTswQrNyPy9iODs7S1qurq72+wOAkgcRqS3WdpSZiYAlAZhrO2aeurzY7v7pizLIBPPFeyrpvjwenrl0/8OfXn3rx8f/sddXPgp021tpx88qoAmAB5ubOYJwYGKWcMLFu5olmpJZ2Zd6ktLZWK4vLqZm6fTplaulUSWBkVJKQoGTMZQ8juVfx/f+0bOz33l+9uGp5uKS0yAD365sf8Ecsc+T//DKfnBZf3g1fXI4zL0647qlCEaEOQyBoCRV1WfRlZKVRSKpjElL0iz6FJ9l4ZOTrbXWHVGGi6WH5H0qAJQUEYRFWEmplPTVs/Fc9Ll4obFAhzFRaO8H+gpzAkqX5IBJC5qoJYyYcTNmBQCKqGZVXQDiZoy2Thdvky/02lK+cbRBtACIDODu8krYeo8IYKUUAK0j3JOEJAGi3x9uPQx6/a/1SpiqggKIO0C5ywrWR9czYmz3DsubKzbC3LuD6o4QisC9J016+zjvfx+BmIAEEJSgrGMLekDe5CIPy6M6VFbG1uyQcMCxtk9uvuYWp4eHkKTcorhbNTpC3nQBCERDBLT8nGtC62wcCkis82e6rkkV3gTFB0Ev2CcMgrwGo8A6Bje753DkBgZxNyN/OzWLQEOovBXQCAQi4ebG5C1uuXlL4vZi1g0D0SKcMvxy0FgH/wEPuqiBFW6IJ7cn4ubHvZPK3b2lt4EHGsG7qT1vdkf5GW97s+uVI0LuXiMsepL3YNoNcqMmowOR8e6vtC7gNzt4N/+9nX17AtYZOm7Qrh9HgLydiq8JN95dygn3SPr29OIXMf131/7/vqn+RdqXoL8o+xL0F2V/L0H/H7ZXz34C2smNAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAh5klEQVR4nK2bd5Bd133ff6fc+t59vW1vWOxi0QsJEARAEiLBYlGiHCtjy3Ek94xcJhNPMvb4n8wkGUeTzNgzcTKeUbHk2FalaElsokixgSBAdGBRF9vL6/W+9247JX8sBYO0AIFgzh+7Z96ce8/n/uZ32u98f0hKCR+xSAkIgZQSIQQAQgDGd2rPGMMY41sa3Xz23sode7tNWe/uZ8RCSn6HxlJKSqkQAgA4577v33z2ngv66JYW658qhLhpPCEYxvQOz9xq2o9pZgC4U08/t/iep2oaCMT8QFVVAAAspRACxE2mD+H6vm+aJudcCKEoihCCEPJxoO/F0lJKhN7vlTFGKb71l39ZOJeEoPWRwJigFK/X77l8ZEsDwNmz5+v1pu8xVVUl8EgkrCjEdf1b29y0BUKEc95oNBBCpmkyxvbs2ROPR+8d+R4sXSgVf/LKa0IAxsQ0Tc5Zt9tutupOp/sh3PV6NtszMjIipSSEOI5TLpdHR0cPHNj/cTz7I1t6ZW2tUq9Z4Zjv+I4XaJric9ZxHPRB1pv1ZrO5uLjoeV4QBKqqIoSmp6d37NgRChn3zH17SwsJGAGABBACQHJCEEi+uLJq6oZCMYAMAmaa4YXF5e9877vtLiGEYIzXX4gQCCGEEFOT/Y88dAgkVwgOPN8PGEKkb3DADEd+9oXr/YDrurqu3s0sfHtoCYDe/w/vV8Xy0sIPf/RC27Zdt2uoGkIokc5gRAWgVrPEOeecAwCllFAkhGCMReM5lRK71QoCz+s6WFEBkbGxsc985jOEEM/zdF2Hn82DQRAoivILoe/kHpzz9blJCODMVxRSqzWsUGRwYEAllFJqGEY8nrxy7Vq1Wu+iqCQSCGCMEaUcIAgCT/h+uXzkyJF6tVYqlRRFadmdlXyhUKlTQgFA19Ug8BRFQQjbtm1Z1i8kviM0gvW1QwpBMOYACBFApNmxy/WqYJxS2ul0fJ+l0umDBw/2ZHsVRdE0TVVVRcE3ffWnb7/9gx+94HmeYYQ67W7ICrs+77iB57qarge+rygK55wQsCyLMUbpLx5mt21xc5RwzjHGqqr6vu/7PlVVqmuMCd/3FdNiyFEM8/rs3OyNM0IAf7/I9ccRQl1ficVTrVZL0YyIGgKAqKFKRJvNTkbXEaaA0M3heDfEcAeflgAgJUKSM8Y5X15Zq9ebpXLZYb7v+wKwEIIxXigU0okEIWQln/c8z/eYlBJjjBBZH4j9vTkWCCah3emGw2HLspxON5VKcadjt+u7d+86cGAfen81xUHAFeUXL5Z3+jLGmKKQVqu1sLBQrtR8n3EBmUTS7jpSAJcCAEufKYoSNg0WE77v+z5DCKH3P0kIIQCr4YjheH40ljT0EALRm8kCgEs1l/F/+uGPipXiv3rm05wxSrFC72p5v717gKSUAsiVlZW5ublsrjeVCjeadkg3KFakBM9nCCEt2+u63XQqKUIJxpgQAAAICMZYVTVFUXjXFiClQIqmqlRRFRIJm4Lxmt3tGxxoNuvvvnvikYcOJuMJ13V1Tf9Y0AH4iIMKmm+DaSaIHtIMNeJTPaqHpO533UjID1tJnynVVtlK4wGaqBZWR4eH5uaXc339KwvzWyaHyvm8sWWsVKpZZjJsxDiXXuCGLKPttDGrJIY2T7Ye+emPv/ne6ZePPPo5leggmkB+8Qp/W2iNq0BRl7GyW4xHtXRY9aTKjWxITwSsHUpqsXikVFwywgjK3sw73Ik3Fmo+n5nBwMxCyQ5CF1mHNGrhgkhFsK41AtnGqtKb6/E9qWF9GcL9MewPRi8PTkxfazx5OACkMBK9m5F4+zYSAQg/sBUFG6EIQiZGkrGWiqLRKC8W5k9dcs9ds69Vg6oMcSMdXPdxJJWm7u8e2WnXqy+dnsnFenZvP+S1CgWHzi8T7LVGzPZU3wpCIj44aAH4gkdS5ifu2/Xaqz+uN4JYXAHuADHuHdqHQAXB61XR4UomKzQNeeUIKudrxelj7OgZe6bCbDBpKKNbxFC68RABi6iq9fKl64BIK5q57vqdG4t92b5suL6jnzkinGepH62UY9DZCcue46pGKGKwDX7Pcawvr5VDiSGF3NXu7bbQmILgwHylN91jqILJNkaoXmHffvU810Zv1Mlcs6PFjfFcnHVqY/FoqdaN6Z4BGBlhLRz18ossJBbaqNi9ohuRi3VrzMKbM2RyPFnwEj+ZKw2q0U676bgNKz2248FH28V5OhnxaPxuRuJtoSkgBtpy3QmCroWk78u3Tix/49tv2W7ut75435UXvr13Yrxa60b8pUC2Wvl630Act6/0aNgrtYx2eJspm4VLoFuBknVr3MVK1Oh97QqT3eLkWPTR3WMzS5VvvnR203h2XwrSCePqpQKm993lnvMOuzyQGM6ePR+JaHa7+/fff/0npwqePlBZnVF0bc+eg+2WPdinRPRafzKCfa1ot1ykd3yBqOIK2g6IipghuqpoRS2V6lTNDrdIMpHoH41bVmCbUfXUhUpCd3J4ac/GyXLTGRrrTRom0j7GhsnD4NUL2M1XbPNrz50+er2tZCYcr/3Q4Yevnj0ZFwtbx9VkbvBGOXy0RJoQUJ4uu4Rwr4+0OXgNlEQSZ6Ab4PGFkq2hprl8ZiRtmXZPx9vc1LOC+ZIbO7aOrMx31mwHt6t2XiQnNt+VpQPpU6kAAPAmUNNjCqUAwAKgQXV+/lr5r/7xnRfWghjFOapsGM9cXV7ZNWBOjm44U87PtrICOsh2vVaJNGymgKHx1lKFcx4dSLkuJgwJM4Qtjcejkma17uy45oRpX2ZLUhk90ihVfn2CjeXol1/vDATTjx3aGk4PAwCTgBEgwTDCIAAI5gC3LpWISR8LBSEA5HEhMdIBQRDYRLEuv/f2V7763Leuqb0p1cHhA5vHLp19+8ih3V4sdmympZh9repVVu2GA9mXRaF4qtquUCEyhlQUZbHmYlWLqJFWt95t2pUyd/Ww3t/rBlLrFCZTyNKtqcd+JR6SSj04cij3d69WtpJLk8NxGsu2O53llcWDBx7CQBDGQgJHoNxyxEFS+gAKSAAkvMDXqA4AINqVWufr/+drC3Tjaq29kG/u6Een5pZ+7eknl+v16QoOlCD/3oUkXzz4wC93Am9lubywYre9Om+LXZNKOBx+/d2SlbUwU7NpmuixeiKJmXM/LrRVbfgAirNGvvpwRoYGYsnt/3ZDzElQJZKN/vS7zz/zcJ+hSkSIzwJVNzeMT3U7vhlSf3YguQnNPUBqwAFTQEKA5BgkY+73nnv5L7763o7776/azdpaieD6088cPLmizLcN6U6z+fzBvo1btzmvHS+88k6dhLChRHxhp7TeWv4HYcMk1mEH1bmvYKaiiIiEm3tGUJ/Zf2GxfiK/NrjpM4XFNzclwhNbR/o3H1hda/7RwcFGOPbDl9471FvauX1zIIJ8odI3OJ7N5RgTCoVbj2EUAAECBlIFhDGWzAOiXL629K1XzlVl5O3jp+7bOdwzlonmxmfz9aLXC/UZpVL8pfsPXrhwrnwmttZczqQlFxsY7VAkPNbJ9MQQQl3uYi3QNY0zHsEgOtUa33XqYvng/j49qpx778exvbuv58vGpXdqPPzQ3v1HZ5sCLSzXu80kXcxXh/rTGJCmaV4AmoLhZ5Ggm9BKwH2FqgAAXCCC7a77/KvvvrcsUjqj8f5WcSE5PqnoytVSXDTzoeLq4UOb3n7j2sWlVjjU8BrnItZOF3HJNKBEIqNcDwshrHRICgmgc1nx6ytO98Zlr7ej9j778qlPP3Rw197ImxdPy2z8lL1x2+U3rlO5Gh2Jt93f+dS2F37w8tXZxQe2Dj165BOAVS5ACkAiAKrdhMYAILEEEBjWD7Pi9LlLb564LIXiCG9IbwdaangwejzP1AB1lq49efjg86/MXyjPqiaPkh6DDNnBipAqAp8Q0uF2NDmW7tnU8ZuKrjHuhPVM0a8YyZ6IqkSCbi664fsvHzNzw3tHkiHHralmZY1du3o0ChbJDevMjw7vsVlo+trCyvy82+4QBBjDh+JRWAggiAAI3+WAIHCc986cXy22IgRymWilWj44mTldA8W0irNznzyw5603TixUuzJOQLFaXc6VzUKisL+MkGzaLY5YuRbYXeJLv9PpCB74jqfEEr62yWOKFvVtzuJW9PQ/vTYy1BcC2ucUF0PxIO/a13+6Vlj9n3/74otvnpmeXVvNV77/7D9dOH/2ZpzqA+4hKRApOVIEYQDOylL19Xfnat0gFcEsCHrSmp/oXVsQLH99k3oDPOXdlSCs6GoLBX6VYddzVc16uAnVQSOxa3PWYyUA0CElhGi4FYHp3GpVEw8qVPNgSRdaiKc8aTSs5enFpZh/nnWjNLtvtq35hfdWmwjnxfYhr63T1aqfS9nfefbY8Ggikxn3iKLdCg0AwvdBU1SFgkDnpq9gRT944KHpa7PUl9mBoZVWV8dm13VzQ2NmdGgIv8iDtE1zXihtIZ4x2NLqQgWp+59M7nuwt9OKqxAyDSYF8uREl9vt750ulle6moYM0Wj7MeoqwSJ3zlqhXx3b8XCt47xwcS0SiklpObUCdkLjE5v6Jw59/Utf2jQUxUicOnnpqae2MGDarbMHBhDrQRnBpeufvzJbanVJ2LUsbSCqJvsGZwtuZWXxvuH+dtD8m7/7yUCohwV2x613vUjHWf43v7ZxeGDrN344e+bMmbOnrw0PjnDfxoIJCbbPzGja9XzTiDlOIAE0Krifr+Xnk+H4iWOXB4YS9+8bSM8tNzttzEUqLUnCeu4H379//8FGM1hYXk1Ho9evLj71GKyv0je3SRSBIIrCAJjvte323GpltdSoVFujY0Mm4Wv1NjPSMaWeMMgPTlxzZORaB3pDiaGour0n3LDj56ev/Mc//J1PHXnwP/z3r7z5pnN1uhTgqhWKOF1mhrS1/CINaYHTSUcjG4f7YlHcssurMbVa9ZJacq7QnGjbo9n4laWGQCmD2afOnSSiefn013OpSKHc6k0FudwYKIDBBdBvRhowgACEAUBVSKVcWyrWu4HUVa3dqEsZaLGs3eXSbSgIO4GKgPSmMlsOjD7xuQMP7d3zyU/8Su/kvv/77EuJUPZL/+n3H3lAlaJihvs6qMOURrvdChkCvOaBvSNPPTk5MKzk+rMTW3bt/cQj6Y0Z13WJGqnU3Z6YwYXnCFUVQSyium2mGPGW7QXcmNjYv2Pr1Fq+QuEDcWQsQUqgAIAxKeaL9ZaHqJGIhIGxaG+m7Um7UOvLRuptZ2m5mojwz+6Oq8x68c3Z41fPLZaWy3byH1+4/Jdf/l8vPffKwo0LD9zXLx1H2Cissw1j0VZVPryjl3je9PTyctlR4sl8o7O8XI1oUTNCVSwWFpvRsKIr1EWi67KQjoBjgyJAbGWlZjfKkYh66er5b3ztq7duoSmSwNetzkWj1ux6QkokfI8SHJhau82MgGuUL5camXTfzon4ar594srV7NimhWqdsVCt06Xh8NELJcqvCRkuLZ+d6EtevZJXVCmZls7kOG/OXQvUcE+SBqXCnNthXkcEHVUzOG07rmMYphKipC39AFSNelpEmxjOjG3cfeytZ3UF9470twIsO831K7L12CIFRAImKUWAEGPMcTxBQCM4EByFwrylIMcd6M9evDqNBOJe4eXVjt/1o8sLiLZrVej68W5VKmHDzBhSa4Dd1HHx889MnD7vnJ1uZyac8zeW3a4WZrVqZR65UyFrS36l7EGLOU2d6i4KVasVFHDVUgQoCLq53rgZYtms5Tge83wAoSiKrsTW47EYY4QQBoF16XsgACuN1srBPQ/87tO72536aBZpLi/RkNSc2tl3n9o5PpjpVNvUzNeY7S6szutozWqXqzPXK4WLzUorIeSlBVJqVet+qetWrbDn6zHP7hhB7MC++OR4plyox+LhlcXrjdWLD24cGbB6feQ++UCiUzkncElvp0VAWVBdvrRy9MLKN587FlPSldpifrZcL8/nG3OM+Qi9H17EEq3PJQIATNMqFNaWi9V031CdKToWqNtwPB/06PXVWq2LEmEzu9GiES3V0990ysXWUjydiqSjRs6zSd2KE+b0SZycX66V8ovjo02Fqz6szcx2Z1fopq2fvXKjqIZsK5V558ylfH2JaObxEzMbNj6omUnXryuEYYxVnXNhl25MO24jHk/2jIwlkxldC6/b+H2fFgiIQiggALDCyYWF1y/n87l0SjU0ygJLOp1QMpTJXLxUKNuQiCQnt2ztGao120GjDBgsSaIbk9r2DRtPXD7WbrDhXhP07OVrczqsDA708r5sNNJ7Zb6CwnJk02bwU8XSTCLd72Lbba11HaVpc4ZyviiGLCLB77rMDZpD46PRTZPNmWMdJ1hbXLoxOz8/t0QpXYeWUmIAAAQEsAiCVDIbi5kM62o4EjBJQYYorTq47sr+XLbjw6Wra6m4QJzX6lq07wEttdlj0VQ07Tqzy7M9CSOSyIhOoKQG9mYye0sLuFxr9eWULVtG+4c2VuqdqS27e3MjqoE9hgSOtzt+biDTdHi17SsqIogSrE9MTG7etGVq4wQmrK9vvOV0Mj25L37xi5TSm3etFIOQgCgggWUkGk/F9YUCcjutkKZUKw09MQhGbKW6tKUvpWIodODV18oPP947tIEVK1LTjPBm1rWLr/207naCQ/vdofGNSE8YSsQpcN9bfvHE27OXgrGdQwOpSNf3yuV8KrY12+seP322XLcIciNR38c+qHoQOAhoqWID6wZEyYZjyXikWGwVq7W9+7apinnrVQxFAAwIlUAojkQiiSiIJY+3vVCkt2I7mX6aTJqV/JJBWV9CaTtw6vJSvnx+7/Ydvblwq52vzBlvHL/skHjWaKRj/WsrIYRDhsUcx0goY2NjpT/7zcfXiv5Xv3E0krNiKaVZL1RuzNaXZIDCYY309oUWinmiGhjbmJOAqRD4c1du5DF94kBmabXWfOvooYfuv/UMgBCiIDEgkByA8lQmuXNqsCDIVEadrTkB5wloaVytY8MR/paR9KvvXrt/Z2rP5i3f/9ZZn6Ql5dJhusUwWdq2PVMt0xu1RiokOmslPTmSz9vY7F6eee9XP/MH1bzzP/76WQ+5Aba79lu9UYTV3VFTy8QSR9+7zkncCAun3O4bGktacuPk+InX3ohGZciMJjJpBkADibR/3p1i4AIApAQOkob0vp5ENKxbGur4olCqqU5pMGPReM+V+aXxoewTjzw4lfGp46uRuJP17IRtJLLUJ7vHQvFYKprK1dq40jxdrd3wRaTeWhxJj/3D1y48/91Tv/UbB/7o3z+BQ3UaZtnU1lYRpqYS/bn44swq801VD8fi2srygusFW7aNbN8+noiHhkd7SpXa1NRmBAr6YLAdSS493lUVFXEKPJhdmv3j//zXp2b83GBqMKHHEE4devTYjaZYKcSXX9r34IG/fSnvM0XiwLKQ7/hY0KEMzkVa5aaxUJ4BFtZleXLr4NwKrTY8k9KeTLTbLfy3P/vzTzyc/ou//OGXn1vARtls9iX7ynFSmV4M4Q37A97KoJWEllVi5sO7+q6uOgsnXtnVA5N79/z6F35HEQwh9dbjOAYJhBAOEjAAIalUat/u7XEDOrZQFbi4VBzy81MpIzvQdyOyGRMrnhBEa4Ro2+w0VL8LGi47QcehshW4FRalSQ202lrFxFHqaYag4RjudPU//69funaj+Cd/+GtTOenX1BKUx7Zsx8mdXjanMPdQdpG6bssK9/b2Tk3taa1dmxhLP/LEY7/5+d8OPIGwCugDB1sMIAgmcn2VQTIajTyyf89QUnG6bHrmxuP7py5Ozz+aFVWGMpM73pl3n9q33cTSlVbdDenQ2TvaycTthhbfcWjgs7/1TKSnP7vhvi7NKMnU0PbeZ75wwAz1a7q3vDT3hd/7qx+/8+ojD29gVWP/wZzwvZNzdRkbk3jN6aA9hw+ObRjYlBDH3jk5FsebxtKPPPU0SBJSqATg4H0QGnEAjIAIAAkSENq6cWT/zuFUOv6vn/xEvh6sra2dmy8/tTGiS1YLD+Yb3acPHzIpNDHVk6En7h/ePZxeLQWx1IArfDORjmc2T24/DGaIhNVGJ1ioNUsLfjYmF/Orv/8nz337xZ8+8yujA2b62JkZMzWUwu2dk9EVGC4HsClNP/2pTzYaazvG0o8e2L9crINk0uswCRiUD0JjuCm+QBhAkmgs8snHHtw9pHJpnL5ayE1tO3H5Sipo7U5hYoVPNL2laulzj2/bMtCJJLU3T1fnZhRSV84fXe5NpDcM6mP92qE9wzsm4ht6+q6/V5vPt2KpYV1J7d+3NaInctkJX3Gef3Ma9281JN6WswMbHji8N6eEdFn73z86vWVTLhbSejIDnisvXDiDNI4RfChQigEABCIAGAIAEByBxNu2b35yR+I7L70OSLmer27oDX33+dcfGO8dsYK+oclFN3702srjD45/7sguqcTfvLCMVHTx2tqbx84gGtIM4+rV65iaa8XW5evLMsAdxV8sRwd7+j/9WDqmp187UbO2bNelN5HzaShJ+7YqAp64f2Ksf7xZWx1I0qntu0vlemDXM5kUYMICH30wHI2YDIikACDBQYgypiAAQgO7UPwvX/3WP7xRjKPCwMate0dHTl+/+ktPPn3hWvmGYzbaNpt/c8hob9998Ox87cbyatDEy+UVVWRHs9roeOaNEwuCIIOyeDTQjYH7d+85c/rv11bLofR+qz8nFLItJWk4iGW3FVslA8V3DiJWLO5/cLxTXDSj2asXzh24b9fQph0cAQEBct0N/hmaE4lBAkAHsCqlIgAAfCLVc5eP/eVXXplt0Kf2b3/33JXB4dTi2ZmnPv3YTJefWQmAx/38ksGWcgkaMi2fBR0Xdct8OFuc3Nz78mttRoy+XggFtAl8Pt9sdB29b4jpuQgPtqWDruyu6ckHh8wHe3rKVvzNt27sz7Qf3p3sH9pc44pXW+oJqxAe8BBojAN1AUK3zNN3kE5A4+ixd7/1wwsksfMnx06MjKbTERVVK9nJyLZt+9483boR6L7niOIq79bC2ONCJC1cL6x22n5/37AncMXhvkvcuEWiUUQiJpE70/Ws5pf9tNGTmGvJIb/9uUf2vTN3fTjMJnQ3unFrLpG4uVz/fLA7QDd9J6oYF868V6g3/+abr0zPOZLQ3l5zeGTz2+8c3dqXe/zwoXZIz7c7C2uiQYcCu8BZF1ib2zVd0YEaLQ9Cqd4uiF7DUZiTRrAh5NS8TjU+5CjWI309lumdbPilwtoXxqi07ZYa/8zjD0hE7x26C2AANFbXrlw9oyRzX/32628cu/ipzzx9+drcC68vg2CjY5H79m4d7wmN9iQLttr0Sd3xa4y6oOgIqdwlwlXBtULcaJeNcLLGdGLGIdK7UitnwvZIOv741JaX3vppxNJ++/D+7zz37XB//+M7dlArfGdiuMOdCxLg+V0zrLsuJr73e59/tC+tBY63Z2Lk1Z9cn9o+sGfv6OW57sJsbag/r8TSG02S0PiEFaaqojG36zOumq16xSAh1rNtzXFlTBGe/1Ca7YiF317lpfLy86/mf+O+gZiBTs6W3r66+u+2jiph424uEm8LbSABusKJisMxLRQC2T2yf2d5xf3yiy8mze5v/NJ9ZlxZKNfLjGupZNtj352x901m22XP99qbe2OrTbdCQn3ZPVmFJyIxO79cYkHU1EbiVAVyKl97tH88EvO5hVg0uTB90uRBT3QUwAMw7x0aoA0sIgjQsFqultKRdDZhxvXqH37+cO2Xk1cuz5cda6Ve3jA8tHcsXZhd9uJaT5iUNavaouFwOKdHqNA10ezS2OGkvX9k9OvHi76Dj18vjKfgs5uFBUGrW41MPLiysFJbvpTU3VRvWgBDd6FEvYMcSPO5IBQbCm60PGzpjbZDFBiImqP9oRQkiJnmrOHyqqEP2zSUjIkd432z+armVg9vnlpsBi9dLii6wN3uUhOiojOGm/eNphXRGtkwko6Z52dnEETdmpu/fmNuNr9n12YuOpKGyM8bYx8Sw93+HpFrRGMYvP5kbvXyqtdtkpDaDnTsW+kefdcDm7xity8xZUXNt09e2zWRbTX87splLhPYys3la003GIlrWahNRiPLvj3VS4Z9d2hjCkLDvm0zFsMtrnFvrrF8rDhbrrZ7e8aIqoEXwMe5/KTAkcAIG7EUZmpQblZTSooK0fGa3VLihu+buiGp2Wnx0Q0jVFPbVjMSSQ81GpGI0e12hkMklUrl887IaO76y+eLUUMxBi7NFzBIHviJmH253DA0nTcbhenrCImBkWEpAKk/X1nzIYe5LfR6AEpKqShKIpHI5/O6rhNC6vW6pmm+61bLNc/zAKFas4Ex1TStOzvXbrcppZ7nEUI0TWu32++dPCkxOXrsHcf3IlYMgwiFTFVR6radyWSuTE8vLc5vndo8MDCAMJJCIPSLxYS3hV4XiQEAxri/v79YLLquyzl3HKdYLAeuxxjzPM/zgtVCPp1OG6a5uLgYBEEQBOtvWI++scCJRGII00Bw3/fXtX6aplKQp+dn283W5MYNf/xHf4AQAinRnSXvd2npdaHchg0bpJT5fH5hYSGQIgiaImDr8lHGWKvVMk2z3W6VSwWMse/7iqJIKRljmqYRKQiSGPF6o15nVcuypJQtKVNRc+fWKcuynnjiCcYYxgBApJR3Iz697Yp4U4h+iw5SYIxffvUn169etW2bB4wx0el2bdue3Dw13N/TbrfXNd2apt0Mchqaadv2yZMnK5WKYRgSYSGE6wWbJob+9E//FN2ib+dc3qUY/PYiFYwZYwCwriIGAM/zVFUlSDZqVdd1QUqMKCUomYipFG8cH6eUEkIQQoQQzvl6KoDT9S5dvDjY39uTTmGMBUhCFKIovX05hEjg+5TSda8ghHApyMfxafgXekRN0zDGmXRycmI8FAp1WramGaYVJoSsrq1979kfrHvFemNCyPo3tzudRDx+5LFHKIJWs0koZYw1Gq1UrgcQoQq+GaETwPBdEN8JWgixrrtcn9jXnZsxlkokjlcrjVoVBFBqLy8vJhKJZrMRTaSllDdFm4ZhrHtL3AzFYpFzFy+4nbauKo7jROPxVsvesmM351IIoShEgEQI4btOBfnISnUm+MWLF9djmKqqUko558ePHz/+7qn1BlLK9Xeu/w0C7/HHH7///vs9z2s0GqZplstlz/OefOLIR+r31vKRleqSi/nZuZmZGU3TfN93XTccDhuGMToy9C/zLgAAIbm6svSNy9Occ9M0HccRQhw5cu/E9wKtKMrg4KDneaZpep6XTCZd111aWup07PUGt65e6971wAMPxONx27bX5xaM8f79+z8O9Ed3Dz/wfb9UKjHGXNfVdV1KaVkWF8GHoNcrhJBut7ueSEQIkVKqqjo4NHRvyUz3CA0SAt8nhGBCpBAIIUBICnH7NBcQnOP1mf5nFSkEumMG0v9n6JuyfcdxDMNYT8rCGN8ug2s9aWc9P0BV1Y+fA3Uv0HALN/xsnb81j+tDxfM8TftnCQHn/P0bqrvbZvzc8pGhb7YWUiCEEPxis3Eu10ckIWg9JUoIIPfODP8P5ESJILBgJpQAAAAASUVORK5CYII=",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAh5klEQVR4nK2bd5Bd133ff6fc+t59vW1vWOxi0QsJEARAEiLBYlGiHCtjy3Ek94xcJhNPMvb4n8wkGUeTzNgzcTKeUbHk2FalaElsokixgSBAdGBRF9vL6/W+9247JX8sBYO0AIFgzh+7Z96ce8/n/uZ32u98f0hKCR+xSAkIgZQSIQQAQgDGd2rPGMMY41sa3Xz23sode7tNWe/uZ8RCSn6HxlJKSqkQAgA4577v33z2ngv66JYW658qhLhpPCEYxvQOz9xq2o9pZgC4U08/t/iep2oaCMT8QFVVAAAspRACxE2mD+H6vm+aJudcCKEoihCCEPJxoO/F0lJKhN7vlTFGKb71l39ZOJeEoPWRwJigFK/X77l8ZEsDwNmz5+v1pu8xVVUl8EgkrCjEdf1b29y0BUKEc95oNBBCpmkyxvbs2ROPR+8d+R4sXSgVf/LKa0IAxsQ0Tc5Zt9tutupOp/sh3PV6NtszMjIipSSEOI5TLpdHR0cPHNj/cTz7I1t6ZW2tUq9Z4Zjv+I4XaJric9ZxHPRB1pv1ZrO5uLjoeV4QBKqqIoSmp6d37NgRChn3zH17SwsJGAGABBACQHJCEEi+uLJq6oZCMYAMAmaa4YXF5e9877vtLiGEYIzXX4gQCCGEEFOT/Y88dAgkVwgOPN8PGEKkb3DADEd+9oXr/YDrurqu3s0sfHtoCYDe/w/vV8Xy0sIPf/RC27Zdt2uoGkIokc5gRAWgVrPEOeecAwCllFAkhGCMReM5lRK71QoCz+s6WFEBkbGxsc985jOEEM/zdF2Hn82DQRAoivILoe/kHpzz9blJCODMVxRSqzWsUGRwYEAllFJqGEY8nrxy7Vq1Wu+iqCQSCGCMEaUcIAgCT/h+uXzkyJF6tVYqlRRFadmdlXyhUKlTQgFA19Ug8BRFQQjbtm1Z1i8kviM0gvW1QwpBMOYACBFApNmxy/WqYJxS2ul0fJ+l0umDBw/2ZHsVRdE0TVVVRcE3ffWnb7/9gx+94HmeYYQ67W7ICrs+77iB57qarge+rygK55wQsCyLMUbpLx5mt21xc5RwzjHGqqr6vu/7PlVVqmuMCd/3FdNiyFEM8/rs3OyNM0IAf7/I9ccRQl1ficVTrVZL0YyIGgKAqKFKRJvNTkbXEaaA0M3heDfEcAeflgAgJUKSM8Y5X15Zq9ebpXLZYb7v+wKwEIIxXigU0okEIWQln/c8z/eYlBJjjBBZH4j9vTkWCCah3emGw2HLspxON5VKcadjt+u7d+86cGAfen81xUHAFeUXL5Z3+jLGmKKQVqu1sLBQrtR8n3EBmUTS7jpSAJcCAEufKYoSNg0WE77v+z5DCKH3P0kIIQCr4YjheH40ljT0EALRm8kCgEs1l/F/+uGPipXiv3rm05wxSrFC72p5v717gKSUAsiVlZW5ublsrjeVCjeadkg3KFakBM9nCCEt2+u63XQqKUIJxpgQAAAICMZYVTVFUXjXFiClQIqmqlRRFRIJm4Lxmt3tGxxoNuvvvnvikYcOJuMJ13V1Tf9Y0AH4iIMKmm+DaSaIHtIMNeJTPaqHpO533UjID1tJnynVVtlK4wGaqBZWR4eH5uaXc339KwvzWyaHyvm8sWWsVKpZZjJsxDiXXuCGLKPttDGrJIY2T7Ye+emPv/ne6ZePPPo5leggmkB+8Qp/W2iNq0BRl7GyW4xHtXRY9aTKjWxITwSsHUpqsXikVFwywgjK3sw73Ik3Fmo+n5nBwMxCyQ5CF1mHNGrhgkhFsK41AtnGqtKb6/E9qWF9GcL9MewPRi8PTkxfazx5OACkMBK9m5F4+zYSAQg/sBUFG6EIQiZGkrGWiqLRKC8W5k9dcs9ds69Vg6oMcSMdXPdxJJWm7u8e2WnXqy+dnsnFenZvP+S1CgWHzi8T7LVGzPZU3wpCIj44aAH4gkdS5ifu2/Xaqz+uN4JYXAHuADHuHdqHQAXB61XR4UomKzQNeeUIKudrxelj7OgZe6bCbDBpKKNbxFC68RABi6iq9fKl64BIK5q57vqdG4t92b5suL6jnzkinGepH62UY9DZCcue46pGKGKwDX7Pcawvr5VDiSGF3NXu7bbQmILgwHylN91jqILJNkaoXmHffvU810Zv1Mlcs6PFjfFcnHVqY/FoqdaN6Z4BGBlhLRz18ossJBbaqNi9ohuRi3VrzMKbM2RyPFnwEj+ZKw2q0U676bgNKz2248FH28V5OhnxaPxuRuJtoSkgBtpy3QmCroWk78u3Tix/49tv2W7ut75435UXvr13Yrxa60b8pUC2Wvl630Act6/0aNgrtYx2eJspm4VLoFuBknVr3MVK1Oh97QqT3eLkWPTR3WMzS5VvvnR203h2XwrSCePqpQKm993lnvMOuzyQGM6ePR+JaHa7+/fff/0npwqePlBZnVF0bc+eg+2WPdinRPRafzKCfa1ot1ykd3yBqOIK2g6IipghuqpoRS2V6lTNDrdIMpHoH41bVmCbUfXUhUpCd3J4ac/GyXLTGRrrTRom0j7GhsnD4NUL2M1XbPNrz50+er2tZCYcr/3Q4Yevnj0ZFwtbx9VkbvBGOXy0RJoQUJ4uu4Rwr4+0OXgNlEQSZ6Ab4PGFkq2hprl8ZiRtmXZPx9vc1LOC+ZIbO7aOrMx31mwHt6t2XiQnNt+VpQPpU6kAAPAmUNNjCqUAwAKgQXV+/lr5r/7xnRfWghjFOapsGM9cXV7ZNWBOjm44U87PtrICOsh2vVaJNGymgKHx1lKFcx4dSLkuJgwJM4Qtjcejkma17uy45oRpX2ZLUhk90ihVfn2CjeXol1/vDATTjx3aGk4PAwCTgBEgwTDCIAAI5gC3LpWISR8LBSEA5HEhMdIBQRDYRLEuv/f2V7763Leuqb0p1cHhA5vHLp19+8ih3V4sdmympZh9repVVu2GA9mXRaF4qtquUCEyhlQUZbHmYlWLqJFWt95t2pUyd/Ww3t/rBlLrFCZTyNKtqcd+JR6SSj04cij3d69WtpJLk8NxGsu2O53llcWDBx7CQBDGQgJHoNxyxEFS+gAKSAAkvMDXqA4AINqVWufr/+drC3Tjaq29kG/u6Een5pZ+7eknl+v16QoOlCD/3oUkXzz4wC93Am9lubywYre9Om+LXZNKOBx+/d2SlbUwU7NpmuixeiKJmXM/LrRVbfgAirNGvvpwRoYGYsnt/3ZDzElQJZKN/vS7zz/zcJ+hSkSIzwJVNzeMT3U7vhlSf3YguQnNPUBqwAFTQEKA5BgkY+73nnv5L7763o7776/azdpaieD6088cPLmizLcN6U6z+fzBvo1btzmvHS+88k6dhLChRHxhp7TeWv4HYcMk1mEH1bmvYKaiiIiEm3tGUJ/Zf2GxfiK/NrjpM4XFNzclwhNbR/o3H1hda/7RwcFGOPbDl9471FvauX1zIIJ8odI3OJ7N5RgTCoVbj2EUAAECBlIFhDGWzAOiXL629K1XzlVl5O3jp+7bOdwzlonmxmfz9aLXC/UZpVL8pfsPXrhwrnwmttZczqQlFxsY7VAkPNbJ9MQQQl3uYi3QNY0zHsEgOtUa33XqYvng/j49qpx778exvbuv58vGpXdqPPzQ3v1HZ5sCLSzXu80kXcxXh/rTGJCmaV4AmoLhZ5Ggm9BKwH2FqgAAXCCC7a77/KvvvrcsUjqj8f5WcSE5PqnoytVSXDTzoeLq4UOb3n7j2sWlVjjU8BrnItZOF3HJNKBEIqNcDwshrHRICgmgc1nx6ytO98Zlr7ej9j778qlPP3Rw197ImxdPy2z8lL1x2+U3rlO5Gh2Jt93f+dS2F37w8tXZxQe2Dj165BOAVS5ACkAiAKrdhMYAILEEEBjWD7Pi9LlLb564LIXiCG9IbwdaangwejzP1AB1lq49efjg86/MXyjPqiaPkh6DDNnBipAqAp8Q0uF2NDmW7tnU8ZuKrjHuhPVM0a8YyZ6IqkSCbi664fsvHzNzw3tHkiHHralmZY1du3o0ChbJDevMjw7vsVlo+trCyvy82+4QBBjDh+JRWAggiAAI3+WAIHCc986cXy22IgRymWilWj44mTldA8W0irNznzyw5603TixUuzJOQLFaXc6VzUKisL+MkGzaLY5YuRbYXeJLv9PpCB74jqfEEr62yWOKFvVtzuJW9PQ/vTYy1BcC2ucUF0PxIO/a13+6Vlj9n3/74otvnpmeXVvNV77/7D9dOH/2ZpzqA+4hKRApOVIEYQDOylL19Xfnat0gFcEsCHrSmp/oXVsQLH99k3oDPOXdlSCs6GoLBX6VYddzVc16uAnVQSOxa3PWYyUA0CElhGi4FYHp3GpVEw8qVPNgSRdaiKc8aTSs5enFpZh/nnWjNLtvtq35hfdWmwjnxfYhr63T1aqfS9nfefbY8Ggikxn3iKLdCg0AwvdBU1SFgkDnpq9gRT944KHpa7PUl9mBoZVWV8dm13VzQ2NmdGgIv8iDtE1zXihtIZ4x2NLqQgWp+59M7nuwt9OKqxAyDSYF8uREl9vt750ulle6moYM0Wj7MeoqwSJ3zlqhXx3b8XCt47xwcS0SiklpObUCdkLjE5v6Jw59/Utf2jQUxUicOnnpqae2MGDarbMHBhDrQRnBpeufvzJbanVJ2LUsbSCqJvsGZwtuZWXxvuH+dtD8m7/7yUCohwV2x613vUjHWf43v7ZxeGDrN344e+bMmbOnrw0PjnDfxoIJCbbPzGja9XzTiDlOIAE0Krifr+Xnk+H4iWOXB4YS9+8bSM8tNzttzEUqLUnCeu4H379//8FGM1hYXk1Ho9evLj71GKyv0je3SRSBIIrCAJjvte323GpltdSoVFujY0Mm4Wv1NjPSMaWeMMgPTlxzZORaB3pDiaGour0n3LDj56ev/Mc//J1PHXnwP/z3r7z5pnN1uhTgqhWKOF1mhrS1/CINaYHTSUcjG4f7YlHcssurMbVa9ZJacq7QnGjbo9n4laWGQCmD2afOnSSiefn013OpSKHc6k0FudwYKIDBBdBvRhowgACEAUBVSKVcWyrWu4HUVa3dqEsZaLGs3eXSbSgIO4GKgPSmMlsOjD7xuQMP7d3zyU/8Su/kvv/77EuJUPZL/+n3H3lAlaJihvs6qMOURrvdChkCvOaBvSNPPTk5MKzk+rMTW3bt/cQj6Y0Z13WJGqnU3Z6YwYXnCFUVQSyium2mGPGW7QXcmNjYv2Pr1Fq+QuEDcWQsQUqgAIAxKeaL9ZaHqJGIhIGxaG+m7Um7UOvLRuptZ2m5mojwz+6Oq8x68c3Z41fPLZaWy3byH1+4/Jdf/l8vPffKwo0LD9zXLx1H2Cissw1j0VZVPryjl3je9PTyctlR4sl8o7O8XI1oUTNCVSwWFpvRsKIr1EWi67KQjoBjgyJAbGWlZjfKkYh66er5b3ztq7duoSmSwNetzkWj1ux6QkokfI8SHJhau82MgGuUL5camXTfzon4ar594srV7NimhWqdsVCt06Xh8NELJcqvCRkuLZ+d6EtevZJXVCmZls7kOG/OXQvUcE+SBqXCnNthXkcEHVUzOG07rmMYphKipC39AFSNelpEmxjOjG3cfeytZ3UF9470twIsO831K7L12CIFRAImKUWAEGPMcTxBQCM4EByFwrylIMcd6M9evDqNBOJe4eXVjt/1o8sLiLZrVej68W5VKmHDzBhSa4Dd1HHx889MnD7vnJ1uZyac8zeW3a4WZrVqZR65UyFrS36l7EGLOU2d6i4KVasVFHDVUgQoCLq53rgZYtms5Tge83wAoSiKrsTW47EYY4QQBoF16XsgACuN1srBPQ/87tO72536aBZpLi/RkNSc2tl3n9o5PpjpVNvUzNeY7S6szutozWqXqzPXK4WLzUorIeSlBVJqVet+qetWrbDn6zHP7hhB7MC++OR4plyox+LhlcXrjdWLD24cGbB6feQ++UCiUzkncElvp0VAWVBdvrRy9MLKN587FlPSldpifrZcL8/nG3OM+Qi9H17EEq3PJQIATNMqFNaWi9V031CdKToWqNtwPB/06PXVWq2LEmEzu9GiES3V0990ysXWUjydiqSjRs6zSd2KE+b0SZycX66V8ovjo02Fqz6szcx2Z1fopq2fvXKjqIZsK5V558ylfH2JaObxEzMbNj6omUnXryuEYYxVnXNhl25MO24jHk/2jIwlkxldC6/b+H2fFgiIQiggALDCyYWF1y/n87l0SjU0ygJLOp1QMpTJXLxUKNuQiCQnt2ztGao120GjDBgsSaIbk9r2DRtPXD7WbrDhXhP07OVrczqsDA708r5sNNJ7Zb6CwnJk02bwU8XSTCLd72Lbba11HaVpc4ZyviiGLCLB77rMDZpD46PRTZPNmWMdJ1hbXLoxOz8/t0QpXYeWUmIAAAQEsAiCVDIbi5kM62o4EjBJQYYorTq47sr+XLbjw6Wra6m4QJzX6lq07wEttdlj0VQ07Tqzy7M9CSOSyIhOoKQG9mYye0sLuFxr9eWULVtG+4c2VuqdqS27e3MjqoE9hgSOtzt+biDTdHi17SsqIogSrE9MTG7etGVq4wQmrK9vvOV0Mj25L37xi5TSm3etFIOQgCgggWUkGk/F9YUCcjutkKZUKw09MQhGbKW6tKUvpWIodODV18oPP947tIEVK1LTjPBm1rWLr/207naCQ/vdofGNSE8YSsQpcN9bfvHE27OXgrGdQwOpSNf3yuV8KrY12+seP322XLcIciNR38c+qHoQOAhoqWID6wZEyYZjyXikWGwVq7W9+7apinnrVQxFAAwIlUAojkQiiSiIJY+3vVCkt2I7mX6aTJqV/JJBWV9CaTtw6vJSvnx+7/Ydvblwq52vzBlvHL/skHjWaKRj/WsrIYRDhsUcx0goY2NjpT/7zcfXiv5Xv3E0krNiKaVZL1RuzNaXZIDCYY309oUWinmiGhjbmJOAqRD4c1du5DF94kBmabXWfOvooYfuv/UMgBCiIDEgkByA8lQmuXNqsCDIVEadrTkB5wloaVytY8MR/paR9KvvXrt/Z2rP5i3f/9ZZn6Ql5dJhusUwWdq2PVMt0xu1RiokOmslPTmSz9vY7F6eee9XP/MH1bzzP/76WQ+5Aba79lu9UYTV3VFTy8QSR9+7zkncCAun3O4bGktacuPk+InX3ohGZciMJjJpBkADibR/3p1i4AIApAQOkob0vp5ENKxbGur4olCqqU5pMGPReM+V+aXxoewTjzw4lfGp46uRuJP17IRtJLLUJ7vHQvFYKprK1dq40jxdrd3wRaTeWhxJj/3D1y48/91Tv/UbB/7o3z+BQ3UaZtnU1lYRpqYS/bn44swq801VD8fi2srygusFW7aNbN8+noiHhkd7SpXa1NRmBAr6YLAdSS493lUVFXEKPJhdmv3j//zXp2b83GBqMKHHEE4devTYjaZYKcSXX9r34IG/fSnvM0XiwLKQ7/hY0KEMzkVa5aaxUJ4BFtZleXLr4NwKrTY8k9KeTLTbLfy3P/vzTzyc/ou//OGXn1vARtls9iX7ynFSmV4M4Q37A97KoJWEllVi5sO7+q6uOgsnXtnVA5N79/z6F35HEQwh9dbjOAYJhBAOEjAAIalUat/u7XEDOrZQFbi4VBzy81MpIzvQdyOyGRMrnhBEa4Ro2+w0VL8LGi47QcehshW4FRalSQ202lrFxFHqaYag4RjudPU//69funaj+Cd/+GtTOenX1BKUx7Zsx8mdXjanMPdQdpG6bssK9/b2Tk3taa1dmxhLP/LEY7/5+d8OPIGwCugDB1sMIAgmcn2VQTIajTyyf89QUnG6bHrmxuP7py5Ozz+aFVWGMpM73pl3n9q33cTSlVbdDenQ2TvaycTthhbfcWjgs7/1TKSnP7vhvi7NKMnU0PbeZ75wwAz1a7q3vDT3hd/7qx+/8+ojD29gVWP/wZzwvZNzdRkbk3jN6aA9hw+ObRjYlBDH3jk5FsebxtKPPPU0SBJSqATg4H0QGnEAjIAIAAkSENq6cWT/zuFUOv6vn/xEvh6sra2dmy8/tTGiS1YLD+Yb3acPHzIpNDHVk6En7h/ePZxeLQWx1IArfDORjmc2T24/DGaIhNVGJ1ioNUsLfjYmF/Orv/8nz337xZ8+8yujA2b62JkZMzWUwu2dk9EVGC4HsClNP/2pTzYaazvG0o8e2L9crINk0uswCRiUD0JjuCm+QBhAkmgs8snHHtw9pHJpnL5ayE1tO3H5Sipo7U5hYoVPNL2laulzj2/bMtCJJLU3T1fnZhRSV84fXe5NpDcM6mP92qE9wzsm4ht6+q6/V5vPt2KpYV1J7d+3NaInctkJX3Gef3Ma9281JN6WswMbHji8N6eEdFn73z86vWVTLhbSejIDnisvXDiDNI4RfChQigEABCIAGAIAEByBxNu2b35yR+I7L70OSLmer27oDX33+dcfGO8dsYK+oclFN3702srjD45/7sguqcTfvLCMVHTx2tqbx84gGtIM4+rV65iaa8XW5evLMsAdxV8sRwd7+j/9WDqmp187UbO2bNelN5HzaShJ+7YqAp64f2Ksf7xZWx1I0qntu0vlemDXM5kUYMICH30wHI2YDIikACDBQYgypiAAQgO7UPwvX/3WP7xRjKPCwMate0dHTl+/+ktPPn3hWvmGYzbaNpt/c8hob9998Ox87cbyatDEy+UVVWRHs9roeOaNEwuCIIOyeDTQjYH7d+85c/rv11bLofR+qz8nFLItJWk4iGW3FVslA8V3DiJWLO5/cLxTXDSj2asXzh24b9fQph0cAQEBct0N/hmaE4lBAkAHsCqlIgAAfCLVc5eP/eVXXplt0Kf2b3/33JXB4dTi2ZmnPv3YTJefWQmAx/38ksGWcgkaMi2fBR0Xdct8OFuc3Nz78mttRoy+XggFtAl8Pt9sdB29b4jpuQgPtqWDruyu6ckHh8wHe3rKVvzNt27sz7Qf3p3sH9pc44pXW+oJqxAe8BBojAN1AUK3zNN3kE5A4+ixd7/1wwsksfMnx06MjKbTERVVK9nJyLZt+9483boR6L7niOIq79bC2ONCJC1cL6x22n5/37AncMXhvkvcuEWiUUQiJpE70/Ws5pf9tNGTmGvJIb/9uUf2vTN3fTjMJnQ3unFrLpG4uVz/fLA7QDd9J6oYF868V6g3/+abr0zPOZLQ3l5zeGTz2+8c3dqXe/zwoXZIz7c7C2uiQYcCu8BZF1ib2zVd0YEaLQ9Cqd4uiF7DUZiTRrAh5NS8TjU+5CjWI309lumdbPilwtoXxqi07ZYa/8zjD0hE7x26C2AANFbXrlw9oyRzX/32628cu/ipzzx9+drcC68vg2CjY5H79m4d7wmN9iQLttr0Sd3xa4y6oOgIqdwlwlXBtULcaJeNcLLGdGLGIdK7UitnwvZIOv741JaX3vppxNJ++/D+7zz37XB//+M7dlArfGdiuMOdCxLg+V0zrLsuJr73e59/tC+tBY63Z2Lk1Z9cn9o+sGfv6OW57sJsbag/r8TSG02S0PiEFaaqojG36zOumq16xSAh1rNtzXFlTBGe/1Ca7YiF317lpfLy86/mf+O+gZiBTs6W3r66+u+2jiph424uEm8LbSABusKJisMxLRQC2T2yf2d5xf3yiy8mze5v/NJ9ZlxZKNfLjGupZNtj352x901m22XP99qbe2OrTbdCQn3ZPVmFJyIxO79cYkHU1EbiVAVyKl97tH88EvO5hVg0uTB90uRBT3QUwAMw7x0aoA0sIgjQsFqultKRdDZhxvXqH37+cO2Xk1cuz5cda6Ve3jA8tHcsXZhd9uJaT5iUNavaouFwOKdHqNA10ezS2OGkvX9k9OvHi76Dj18vjKfgs5uFBUGrW41MPLiysFJbvpTU3VRvWgBDd6FEvYMcSPO5IBQbCm60PGzpjbZDFBiImqP9oRQkiJnmrOHyqqEP2zSUjIkd432z+armVg9vnlpsBi9dLii6wN3uUhOiojOGm/eNphXRGtkwko6Z52dnEETdmpu/fmNuNr9n12YuOpKGyM8bYx8Sw93+HpFrRGMYvP5kbvXyqtdtkpDaDnTsW+kefdcDm7xity8xZUXNt09e2zWRbTX87splLhPYys3la003GIlrWahNRiPLvj3VS4Z9d2hjCkLDvm0zFsMtrnFvrrF8rDhbrrZ7e8aIqoEXwMe5/KTAkcAIG7EUZmpQblZTSooK0fGa3VLihu+buiGp2Wnx0Q0jVFPbVjMSSQ81GpGI0e12hkMklUrl887IaO76y+eLUUMxBi7NFzBIHviJmH253DA0nTcbhenrCImBkWEpAKk/X1nzIYe5LfR6AEpKqShKIpHI5/O6rhNC6vW6pmm+61bLNc/zAKFas4Ex1TStOzvXbrcppZ7nEUI0TWu32++dPCkxOXrsHcf3IlYMgwiFTFVR6radyWSuTE8vLc5vndo8MDCAMJJCIPSLxYS3hV4XiQEAxri/v79YLLquyzl3HKdYLAeuxxjzPM/zgtVCPp1OG6a5uLgYBEEQBOtvWI++scCJRGII00Bw3/fXtX6aplKQp+dn283W5MYNf/xHf4AQAinRnSXvd2npdaHchg0bpJT5fH5hYSGQIgiaImDr8lHGWKvVMk2z3W6VSwWMse/7iqJIKRljmqYRKQiSGPF6o15nVcuypJQtKVNRc+fWKcuynnjiCcYYxgBApJR3Iz697Yp4U4h+iw5SYIxffvUn169etW2bB4wx0el2bdue3Dw13N/TbrfXNd2apt0Mchqaadv2yZMnK5WKYRgSYSGE6wWbJob+9E//FN2ib+dc3qUY/PYiFYwZYwCwriIGAM/zVFUlSDZqVdd1QUqMKCUomYipFG8cH6eUEkIQQoQQzvl6KoDT9S5dvDjY39uTTmGMBUhCFKIovX05hEjg+5TSda8ghHApyMfxafgXekRN0zDGmXRycmI8FAp1WramGaYVJoSsrq1979kfrHvFemNCyPo3tzudRDx+5LFHKIJWs0koZYw1Gq1UrgcQoQq+GaETwPBdEN8JWgixrrtcn9jXnZsxlkokjlcrjVoVBFBqLy8vJhKJZrMRTaSllDdFm4ZhrHtL3AzFYpFzFy+4nbauKo7jROPxVsvesmM351IIoShEgEQI4btOBfnISnUm+MWLF9djmKqqUko558ePHz/+7qn1BlLK9Xeu/w0C7/HHH7///vs9z2s0GqZplstlz/OefOLIR+r31vKRleqSi/nZuZmZGU3TfN93XTccDhuGMToy9C/zLgAAIbm6svSNy9Occ9M0HccRQhw5cu/E9wKtKMrg4KDneaZpep6XTCZd111aWup07PUGt65e6971wAMPxONx27bX5xaM8f79+z8O9Ed3Dz/wfb9UKjHGXNfVdV1KaVkWF8GHoNcrhJBut7ueSEQIkVKqqjo4NHRvyUz3CA0SAt8nhGBCpBAIIUBICnH7NBcQnOP1mf5nFSkEumMG0v9n6JuyfcdxDMNYT8rCGN8ug2s9aWc9P0BV1Y+fA3Uv0HALN/xsnb81j+tDxfM8TftnCQHn/P0bqrvbZvzc8pGhb7YWUiCEEPxis3Eu10ckIWg9JUoIIPfODP8P5ESJILBgJpQAAAAASUVORK5CYII=\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAANb0lEQVR4nO1ayY4kS1Y9dzBzj4jMGhE0SCDeUy8QiN9AQnwuv8CCFSxYwGNQI+hBTfWrqhzCw83sDiw8h8jqejQCKRFSnkUozMLM/Ngd7F67HpSZ+P8G/r8m8D/BC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp54JmJhFlJogAOMJgDFZQAIAEwAABjAAQGUIKIJCOIKRAaaudPJRQiIBtSIIemkDcPQWZSaD77wAA2YYYGZACpIOzQGAEg83QB9KU6QCQnBEUBCEkEBvbDXzHAEBuLUYCBJBtcxHsso17mHUHS2YCA5nIBG+DAsyPIxOPBSPuggIQ7mgYQAlylDPStp4gLFrvOG1DE1m2PT0+PoBMBN91cgKEpDua53Z2LvGHBQhPQIlNu3T2QwBiADBodWGCAilIQgrK2VzPzEihQBrg4UosxAoC4m4Hdw/lBCdWQBgFCGSAEiAHy6axrzDks32c98c966e7wWaYDsBBgDKQYczn5hGZAAhxRpEBoGQi7zqRJNvyAgtIgnjTQ1gQgoXSNxuNM6EnQKBNf5RPhEpAPqoEibs934L3yAlEjgjmh8XkbG6zLAICcnRiAtH9dAYTmEB3BozcDNNBuiaYUe953WnlqcwyEbizXbrryc3viSiSH/yQn0xsQMAYELAaA3CBE+ojacsUAJEAQOSExcGCQzaAOmhAMlPhlZKR4eX70T92A9OeaUfMoBSipNiQRER+3zx/2NajzCICHSLCCffBRFWViOCxk4pIEA/BtWPY8rbkZQXo8GhAkg6iTED4JvHXf/8vf/Ov/+bT/Ee/98312v7jZv289kBeTuXdRX09T7/4ZD89Hn++HEfmpcgeJBkG6nNxd7d0JECR6Z4jfJoUgBBlprtHBDOrqhCrKjx6OyFyKsIgs84zSwqzrOanm+sfSf7FH//4z/70mzPrgHaiCibahO1/+d3HX14dlwl/9ZO/XRi/O7+6iXUqMqV+0PTF95UpOB1jvYmZv8/wsh9Zrz9fTeCSxFUaZ/dQEU2a4aN7MrXRt4N1WRYRKZNOdSe1jmGtNXNPRMAl6TBffLz6NKuw8z+M0+Wbn//5n3xzfjwpn7Xc3ZGesa79XSkjRoMv5KtZWY9dZDZ5d3j789vrn11/VvJ3LjX52vuRyoh2qLOCxuqhLFONyOPabgWtNc8Yw1W11trM+rLMXnVYnnh09wympAjzXmsVG448je6rW/bT6F8EbiXchS0wjZ4ioqqjeY/RRpeEc5qPdly6Csv+777/91cy/3491Kqf1tuP3j4fm/CMAl8WYdZSiMiHESBEgzCIEtxitN5RShZZV0OjwgrmE6VHFIDdvftp3Fps3pMD4cjbtfXIeuatCiAziDiBboNYS5nQ+lGMA5L0NtUjVylQMo0//JXZ3D/EerO4Udb9/nKaXGS9WlYfc5mllGR2d4rUaQ7vxAImiViWhU9NRAjCLDrVLAWZPgYjhahKWcaQddVdFaJSipK6u5nV+hhclHGXGwSwjj7CPcLdRWkvc4AziYJKKcxYbPzj6yE5ZMRF5/f7txNVozy29Z+GlanqPDU371lU4X5qqxC7JycVLgLpayulMCDE7GQZ0YeNISTCUoR3WZW4knIaEUFImSctT8wjkXwfbSMTTA4CSVktOH6FwcwZvRZ640QjD/vXNAYqrkt+mPm03r6X8ju7+YNZJ2IVhoQPeIwxRGSeZ6zoNlR1P+9aa0JJhIywvqZoJSnTTpDkPoaBUKTWWiUlAPdO+SSbAKCZDtJIJIFZCGJm7u6ITLklU0gCKSxQzXDdncDNDRA5ES/5qZxOOt7vD/9xvLE+wFJUMTw9RMgzkmBmRMRKbADAzCQEQIh3RTLTrA8fnpZMSTB3VSXJCIBpeEzy6IzKxNuxD+YkWPi6rutqn3dZ4av5JWv0aJK3ESvZ0sauqpKY1qsWdnkx2bIPid7SzXpbuk1cL6bdYF7XtXsQ0UAgnBkgklKUCMJEDMCHtdHHaEEhVUTEIk/L0WstKGAikXwaMzlBwBBiwpCYoh3f7C/e7GQ3zLPv0uS42K68H0VBOw/2tV1/yuNN8fX1HHtpEwWG3wA877s5iFBoGSeP4WYY3k8re8awtLzYX87TnkgnLUCu/cSapFnmCWAY0SCesScdliNOEyvNl0RPSCuBANoyl4eIJbUIoCMX4djx2+CRYy30mvavTdZZ1rBcT5PM73W2SU/eP3265lIpU4jZMz1AxLVkYnu/ul011t6EOCKSIxNbHlJKYVYlJiIGncaSht2rV1XCjv10Ork75DEm6vkOIsLdM5OZsyMiD0xXaDr8xnvx+VQrMREYAWuDKFF9UN76kDo5MiML8awFih4jCJ5Z5omZY5iZiQgx511uicxsNohEhFQ1IjgxlRpt3NzcKFlNJSIzQ30kzRm4P/SQieFhHuYegZudXpR5R0wCFLlwHVVPVUZizvpqOlDRK2+L2SQ7nWdiIUAyOEMIRGThw22e58PhQEQRUUqZ5xnCEeGBCLQ2eu8xLDMjorWmqtM0pUfvfXNWPMW5pCmQEZFIImpCnRMqk0zVoQ4M1+SjNWu9hExzYU5qGcw87w6CaZoygoZ7H633jnABJec93L33HgR3N/PNNgCICDMTESI983Q6zVHevXuHbH7sY4wvbfohy84tdUQmAaJLidL9WJHTvtzanPk5+/uO2u3W/KO3Q8ob5QvIkfgqbJ88hhNCGaRctqtPukhZ1zWGKYuytNO68eZkEdVJNbOUIiBKOEUp5bbf2tr2LFXCzCJCnwr7TtIZgOAue0SOcKLclynqpKAj+353eR0fx2hv5v3ip6MNCwcwFe3JGHl7vFnakhS16CQ6TdMsyuEopZ1W89zPszIv6zrcmHnSSVXLPJn1wtJaQ3rvvXCptUYfx+NxxahQkfO0FAA0E0R3lwgicvfmttpAi3x/SBJc9194+/F84ODv19sf7d8Xx35wZYqCEzxC9g59/bq0YjGG9eOyrOs6zTsI12kiIiREZCpVVU+jNxu11mTaDN0iW2uEiGGDUS7K/s3BWbwfs/nmr08lTUAyFB4xGZrYZxwirOz6hePDhw83b3e/lfu4Wt7xxU+1na5uXiu/fzWtw8aQMZXbMXre7m3qY7XWijLPJRzBREB2O8w7qaW7fz5+bq0Vlt1ux4zjuhyPvtvtjuvp1NZpmpKYSCzcico0K2e3JZCkT206kRQEgbKSqEd45Gl0qtG8W1hfVyKbSQYTJv7lsYt1SQx3LjOBjAmkxFprpYjMdLNkqiLJsis1icjT3SgS5gOeEYf9JXsigOEYrkk7rVBYs956D+4WnB3u1r33vjureygjQRQZ2+UzQFQrmxH1jJhZEaQZymrIIjwuLsba+zADF9EiUoKUVJl0mgCMtVmmkqgqwEqIDBBVFqqTgtxdiI99SSQrO4eRO0eLnpkHnTN7VW2jW7QJmpnn9YMzR8wkou3CTkQkhfsaaTNJCYanMNxMunJQzUJViblMNSJ6X9jHqFxKUWJnnrRM07Tf7dx9PR4dycyiRYirlmAhorolTMwA6pRRgkUysyQFeFeqN/cIIop8WnwANCIYzMyJnEpVluxdMtakDFQGp1jYCTghx/BD3KVswTHSmJnJpiKXhwstxcx7mZoNVZ2S1m5hgwjMSnAkE5IJzDQHwh0+zKxmqqoIkzC0Uo6Z2VKcS6GihSFPjzzirbAIRuyKXlS9amPPelOljeg+atDqnclNGIiEEcxHtjCKIlWIEsrj+spZu1skhVlLb5nLcluViSilSNFIcncAzGyVrQ/K9GHMrFxibVJ07j7G7U0sPZLFXSJdfDSU/ZmkwUJAOBCz6sR0+vSxiDp8+Fhvj7taj30Nplqn9LhOK5DCkkncRhAdl5swq4FIJEmdJ2ZOD1DEunYiIhJVUwVgCQCFZZHtlkVhLiIk3G1IKW+irn41BmeRUklKXpa3b/b7J5IOJAexMJBzBbl9+NlPEZiKmtnVp4/7Wm7WxZCH+RBrb28OYskD3kxKqZOu65o2oDksPDHvdwBaa8jw3hQUBBbhUkEcEUTErFNkW1dKxDARIZXhttvvrxOD1zqI56oFdb5ov/0KFtvFcAP5MFbBfdHrn3/yk++++25d19WltdZaw31W+ZAAPrjsluJs/Q/1LtxXkrZE96FzW+f8c1tHRLbcY8Msycy11lIKgN1u9+233377zR+cR0XKSGzXIWEmDmCYl/ttRID51+qaZ8j7wrN8mYrd/fRF0fEB93W4L/vT72Z9EbzPx9B5hNxYjnBVkfvM/YcJP6X4NNI+TPyh/t8I9+0UBu5l97jIpsGtEciHcjGlP5HSk0L508vxV4fhLEn/GjZz+vV1zEJVcW9jm818MfdR0plpZszMIuZWRPGMeKDxVVXEk0o1Hg/OhwF3q2BztccXJT/8vG3dPHO534wvRj7ogwkPHs/MX1HIg6S3c2B7abQ5NdGXWSx+bcf/G/yQaN39PIH+4ly6m3Ju0+fvpsKdmR8t+MFA/2thftWC//vyB3Cn4a9wfVzv5f/Tz4QX0s+FF9LPhRfSz4UX0s+FF9LPhRfSz4UX0s+F/wRjFnscL9rXQwAAAABJRU5ErkJggg==",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAANb0lEQVR4nO1ayY4kS1Y9dzBzj4jMGhE0SCDeUy8QiN9AQnwuv8CCFSxYwGNQI+hBTfWrqhzCw83sDiw8h8jqejQCKRFSnkUozMLM/Ngd7F67HpSZ+P8G/r8m8D/BC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp54JmJhFlJogAOMJgDFZQAIAEwAABjAAQGUIKIJCOIKRAaaudPJRQiIBtSIIemkDcPQWZSaD77wAA2YYYGZACpIOzQGAEg83QB9KU6QCQnBEUBCEkEBvbDXzHAEBuLUYCBJBtcxHsso17mHUHS2YCA5nIBG+DAsyPIxOPBSPuggIQ7mgYQAlylDPStp4gLFrvOG1DE1m2PT0+PoBMBN91cgKEpDua53Z2LvGHBQhPQIlNu3T2QwBiADBodWGCAilIQgrK2VzPzEihQBrg4UosxAoC4m4Hdw/lBCdWQBgFCGSAEiAHy6axrzDks32c98c966e7wWaYDsBBgDKQYczn5hGZAAhxRpEBoGQi7zqRJNvyAgtIgnjTQ1gQgoXSNxuNM6EnQKBNf5RPhEpAPqoEibs934L3yAlEjgjmh8XkbG6zLAICcnRiAtH9dAYTmEB3BozcDNNBuiaYUe953WnlqcwyEbizXbrryc3viSiSH/yQn0xsQMAYELAaA3CBE+ojacsUAJEAQOSExcGCQzaAOmhAMlPhlZKR4eX70T92A9OeaUfMoBSipNiQRER+3zx/2NajzCICHSLCCffBRFWViOCxk4pIEA/BtWPY8rbkZQXo8GhAkg6iTED4JvHXf/8vf/Ov/+bT/Ee/98312v7jZv289kBeTuXdRX09T7/4ZD89Hn++HEfmpcgeJBkG6nNxd7d0JECR6Z4jfJoUgBBlprtHBDOrqhCrKjx6OyFyKsIgs84zSwqzrOanm+sfSf7FH//4z/70mzPrgHaiCibahO1/+d3HX14dlwl/9ZO/XRi/O7+6iXUqMqV+0PTF95UpOB1jvYmZv8/wsh9Zrz9fTeCSxFUaZ/dQEU2a4aN7MrXRt4N1WRYRKZNOdSe1jmGtNXNPRMAl6TBffLz6NKuw8z+M0+Wbn//5n3xzfjwpn7Xc3ZGesa79XSkjRoMv5KtZWY9dZDZ5d3j789vrn11/VvJ3LjX52vuRyoh2qLOCxuqhLFONyOPabgWtNc8Yw1W11trM+rLMXnVYnnh09wympAjzXmsVG448je6rW/bT6F8EbiXchS0wjZ4ioqqjeY/RRpeEc5qPdly6Csv+777/91cy/3491Kqf1tuP3j4fm/CMAl8WYdZSiMiHESBEgzCIEtxitN5RShZZV0OjwgrmE6VHFIDdvftp3Fps3pMD4cjbtfXIeuatCiAziDiBboNYS5nQ+lGMA5L0NtUjVylQMo0//JXZ3D/EerO4Udb9/nKaXGS9WlYfc5mllGR2d4rUaQ7vxAImiViWhU9NRAjCLDrVLAWZPgYjhahKWcaQddVdFaJSipK6u5nV+hhclHGXGwSwjj7CPcLdRWkvc4AziYJKKcxYbPzj6yE5ZMRF5/f7txNVozy29Z+GlanqPDU371lU4X5qqxC7JycVLgLpayulMCDE7GQZ0YeNISTCUoR3WZW4knIaEUFImSctT8wjkXwfbSMTTA4CSVktOH6FwcwZvRZ640QjD/vXNAYqrkt+mPm03r6X8ju7+YNZJ2IVhoQPeIwxRGSeZ6zoNlR1P+9aa0JJhIywvqZoJSnTTpDkPoaBUKTWWiUlAPdO+SSbAKCZDtJIJIFZCGJm7u6ITLklU0gCKSxQzXDdncDNDRA5ES/5qZxOOt7vD/9xvLE+wFJUMTw9RMgzkmBmRMRKbADAzCQEQIh3RTLTrA8fnpZMSTB3VSXJCIBpeEzy6IzKxNuxD+YkWPi6rutqn3dZ4av5JWv0aJK3ESvZ0sauqpKY1qsWdnkx2bIPid7SzXpbuk1cL6bdYF7XtXsQ0UAgnBkgklKUCMJEDMCHtdHHaEEhVUTEIk/L0WstKGAikXwaMzlBwBBiwpCYoh3f7C/e7GQ3zLPv0uS42K68H0VBOw/2tV1/yuNN8fX1HHtpEwWG3wA877s5iFBoGSeP4WYY3k8re8awtLzYX87TnkgnLUCu/cSapFnmCWAY0SCesScdliNOEyvNl0RPSCuBANoyl4eIJbUIoCMX4djx2+CRYy30mvavTdZZ1rBcT5PM73W2SU/eP3265lIpU4jZMz1AxLVkYnu/ul011t6EOCKSIxNbHlJKYVYlJiIGncaSht2rV1XCjv10Ork75DEm6vkOIsLdM5OZsyMiD0xXaDr8xnvx+VQrMREYAWuDKFF9UN76kDo5MiML8awFih4jCJ5Z5omZY5iZiQgx511uicxsNohEhFQ1IjgxlRpt3NzcKFlNJSIzQ30kzRm4P/SQieFhHuYegZudXpR5R0wCFLlwHVVPVUZizvpqOlDRK2+L2SQ7nWdiIUAyOEMIRGThw22e58PhQEQRUUqZ5xnCEeGBCLQ2eu8xLDMjorWmqtM0pUfvfXNWPMW5pCmQEZFIImpCnRMqk0zVoQ4M1+SjNWu9hExzYU5qGcw87w6CaZoygoZ7H633jnABJec93L33HgR3N/PNNgCICDMTESI983Q6zVHevXuHbH7sY4wvbfohy84tdUQmAaJLidL9WJHTvtzanPk5+/uO2u3W/KO3Q8ob5QvIkfgqbJ88hhNCGaRctqtPukhZ1zWGKYuytNO68eZkEdVJNbOUIiBKOEUp5bbf2tr2LFXCzCJCnwr7TtIZgOAue0SOcKLclynqpKAj+353eR0fx2hv5v3ip6MNCwcwFe3JGHl7vFnakhS16CQ6TdMsyuEopZ1W89zPszIv6zrcmHnSSVXLPJn1wtJaQ3rvvXCptUYfx+NxxahQkfO0FAA0E0R3lwgicvfmttpAi3x/SBJc9194+/F84ODv19sf7d8Xx35wZYqCEzxC9g59/bq0YjGG9eOyrOs6zTsI12kiIiREZCpVVU+jNxu11mTaDN0iW2uEiGGDUS7K/s3BWbwfs/nmr08lTUAyFB4xGZrYZxwirOz6hePDhw83b3e/lfu4Wt7xxU+1na5uXiu/fzWtw8aQMZXbMXre7m3qY7XWijLPJRzBREB2O8w7qaW7fz5+bq0Vlt1ux4zjuhyPvtvtjuvp1NZpmpKYSCzcico0K2e3JZCkT206kRQEgbKSqEd45Gl0qtG8W1hfVyKbSQYTJv7lsYt1SQx3LjOBjAmkxFprpYjMdLNkqiLJsis1icjT3SgS5gOeEYf9JXsigOEYrkk7rVBYs956D+4WnB3u1r33vjureygjQRQZ2+UzQFQrmxH1jJhZEaQZymrIIjwuLsba+zADF9EiUoKUVJl0mgCMtVmmkqgqwEqIDBBVFqqTgtxdiI99SSQrO4eRO0eLnpkHnTN7VW2jW7QJmpnn9YMzR8wkou3CTkQkhfsaaTNJCYanMNxMunJQzUJViblMNSJ6X9jHqFxKUWJnnrRM07Tf7dx9PR4dycyiRYirlmAhorolTMwA6pRRgkUysyQFeFeqN/cIIop8WnwANCIYzMyJnEpVluxdMtakDFQGp1jYCTghx/BD3KVswTHSmJnJpiKXhwstxcx7mZoNVZ2S1m5hgwjMSnAkE5IJzDQHwh0+zKxmqqoIkzC0Uo6Z2VKcS6GihSFPjzzirbAIRuyKXlS9amPPelOljeg+atDqnclNGIiEEcxHtjCKIlWIEsrj+spZu1skhVlLb5nLcluViSilSNFIcncAzGyVrQ/K9GHMrFxibVJ07j7G7U0sPZLFXSJdfDSU/ZmkwUJAOBCz6sR0+vSxiDp8+Fhvj7taj30Nplqn9LhOK5DCkkncRhAdl5swq4FIJEmdJ2ZOD1DEunYiIhJVUwVgCQCFZZHtlkVhLiIk3G1IKW+irn41BmeRUklKXpa3b/b7J5IOJAexMJBzBbl9+NlPEZiKmtnVp4/7Wm7WxZCH+RBrb28OYskD3kxKqZOu65o2oDksPDHvdwBaa8jw3hQUBBbhUkEcEUTErFNkW1dKxDARIZXhttvvrxOD1zqI56oFdb5ov/0KFtvFcAP5MFbBfdHrn3/yk++++25d19WltdZaw31W+ZAAPrjsluJs/Q/1LtxXkrZE96FzW+f8c1tHRLbcY8Msycy11lIKgN1u9+233377zR+cR0XKSGzXIWEmDmCYl/ttRID51+qaZ8j7wrN8mYrd/fRF0fEB93W4L/vT72Z9EbzPx9B5hNxYjnBVkfvM/YcJP6X4NNI+TPyh/t8I9+0UBu5l97jIpsGtEciHcjGlP5HSk0L508vxV4fhLEn/GjZz+vV1zEJVcW9jm818MfdR0plpZszMIuZWRPGMeKDxVVXEk0o1Hg/OhwF3q2BztccXJT/8vG3dPHO534wvRj7ogwkPHs/MX1HIg6S3c2B7abQ5NdGXWSx+bcf/G/yQaN39PIH+4ly6m3Ju0+fvpsKdmR8t+MFA/2thftWC//vyB3Cn4a9wfVzv5f/Tz4QX0s+FF9LPhRfSz4UX0s+FF9LPhRfSz4UX0s+F/wRjFnscL9rXQwAAAABJRU5ErkJggg==\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAY5ElEQVR4nJV7Wa9lx3Xet1ZV7b3PcKceOUhsUhIlKpZMmjKsmE7gGA4kG4kyKEAcIEEA+yHIS4I8BHn1T8h7AiQPAZIXB0mQlwhBlISSEVM0xUE0JVFNsslmD7f79u177xn2ULXWykPtfc653c3uVuHcc/fZ41ervlpjbTKNAAAGAcZGAKDoGwMAyAACDEJoAQEYcAABZGADCEr9+QQ4KCwCEQRDELAHwQABYABACQ6AGrzAAV6Hx+XbPrz59abxZ54+7M83HZCBbH2UN7oKAHD5n4Jz14gAymcpyAOaZUKwfDbn7jwSMkBrSYP7G9wvafQCAm0AM8AyDoAggA1ACHBDf9Kws+9kHjSCQRUKGAOUH6wMAPzZshuaBwDih4i5R0zaozQACjOQwhQAWAEwWMAMtx49AwzEfTdWgtWMEAwwZ8HDYAqTXgS9rB4CehDVZltd1O8m7aVvDOMeNwBIP9xQAhMYCAAcfC92wDEMifKeodeKlQQYYI808EtXvHoo6GHE7DPP0TVfaNUpBgzkwPkE3rjc1v8JMBABpgDnbWc9nVZ3N3hi7e/+OJxWM/3M8dDTusQAZ/nZ/d0VUIMpdJAsOzgHhgICUOZ46q/O3YAHQYZpgNVZw/ejQSdby+g0dAVAp1WCgQV8TycF61mYb+IBN8zF3O9+XmoaVB6BGMT5Wgzd+eVV3r1wAcCMVNXMwOTZKaDQOnUOZfB0coJqCmN0wKe3sOxSOfIXz6LIM88QGAJ4oCBYxNR7WERXIwQkA7GjQOTMrfv8OO2BklYApkpERGQDbfOhVheeKyBkW5GATw7w7/7j//zk5kGYTLbP7jzxxMUnLp49d2Zne1r4gBvX5fDOnQnVz54ff+Mr5wuJ45JgKz3rQB4ENdhjqTsA8JsDvXkBsQegMMmznqACta703KZZ8HuHx3GyU3TAn76+/3/+7P3nvvYSdnaOnL95rZFrHxWBTdKy7ra3nolNPdu/fGnPP/WF339yEkqAI8jE2s7MuKrgiEkhHYQRRo9UeaSDpDcQ9+Q0IGUBbFBb0TLcsuVQ8se38e//0/cP2+qg1pmG8bmLxda0sySQUBCpNk0E75wc3MFif7eoX3p279LZ8Hd+98XdgGBwGGaiRVACBASgAj2QtBugzTY01IbMVUHcK9T8nSdNp/CM1vAn/+317//wrfGZSw1vabWzv4g82Q6TCYUAMjMhqKmLrWeNx/sfXro4euZc+fFP33h6Z/T7v/vbv/r8me0RCoAVJWXT2XaLWTE99xkz7X7Q92hpAjZ0gg2gI9AAr787+5P//N+pmN48mC+Sf+K5F3hr707d1UKJOfiCmVWSU5S+APynVz7YnfqXv/5Fh9knH7x3cmt/d1yd39l75ddf/o1f2zs/BkUEw1aRAAHCo+lh+iCrQjBDtN65yDp3tsTBEv/1//78rfeviWJ79+zhyWLeRS7H1e7eeHd3VndtFx1xwY5EKSmrtXXj2M7sjbo4296pbt++dXBw54Uvf/Xw9mFJdHF362tfeurlF7afO4cSMEkT538pL2+wF6QAlLxRT4mjGr/46OjHb7/zkw9vzsOTsTiztbM7b5rjbl5HufTMxRu39kdbE2epIPFk01AWhUtt1zXL0SRcv3H1c0897/y4Gm8LjuG3OjedXNhansw+vHP86e13fvh6+8yFyV9++YVvfnWXgaLX1uuptbIMlF2Gnh668r8SqDFoRBlR1sD+Av/2P7x28+48McqdM42V5EYppRjjzs7Oq3/6w+9+97sfXvkIwGQy0STOufNnzjrmo8O7dV1/ev3aM898bnd39+Dwzt7ezhtvvPHMc1/o2sTsxuOxpSSp8SSpWTLJ03vhn//By+cLjAGSlh0DLqI38Q5wiLDkN1zijNuABGgHCMq54NUfHV09TOXuJQ58krqymqSUIsyPKg7h3LlzN27cOLt3ZnZ0PDs8OpkdBedZZW9vzxeOOoDt1t07Qry9e6YaT9hXKphsTc1ghFaFfRkmE6m6etHcXC5/8ObB3/jmOa8YOQcRMKlxdgtWZsQrlPuwZYXdAyAEBa7fwo/f/kk0d2Znt2WrZzMwgz17IkcK+/ylS4dHR+cuXDAzOIbjwI7Yi0IU80U9Wy5OFvPYSVEUURJ7ZwRmZnZRBMzkHDkXyiIlVW1fe/vdl770154/C4MnUsAKRrfWyLSyIHBraRPgFEwo54J33v14Vqfdc09Fo1aUfEhqLviiKGKMdRt39vaIqGkaMFfj0fb2tojM5/O6a0XkeD47f/48ERWhSirNyeL8+fN7e3ttijEJM5dlqbCma41QjqqJ8/PbB2+8d+XZv/qstjItyNqaKufXXiQD3lt2aYgHBx8gDwQBDg7x5l/8AmFaTncOm9iSiXHlXEziiuALiEgb097Z84u6DiEYsQJtjIu6LopiPB6fPX9uZ2eLiFJSAGY23dnm4GNTE7ERnPcEizEayDsW5urcUz9+/9orv/bs56YOZkSAiSMI2AABM5gVsDxPs+owhoXM6xu35ndOGnFla0jkKJRG7ELZdV2XYlGOymo8Xyx8EYxAjsn5VjSajqfT7TN70+3t7d09JW7bNqUksHI8MmBZ10QUQlCYwsg5XxRlWQrs8HiB0c6tpbzzwZFm8YWgyxlMeJh0sqHGE5BAmgMZAZYdfnb5mh/ttupaY/hA7NmHpOqLysh1kozJFeWybp0v6qZTM1FVo3I0JvbLpq3bRlUFBsdqNp5MvPdmVlSlCz4HF0QEgL0jx63Y0VJ5fO6nV/bvJiQAxMwAEiHREI/wgHtFjr438xZ/8f41LrZahRIl06bpYLxcLre2tqqqWszrrut2dnaWbZOnYDme+LIwJgOiigGjyRhERVU670/ms7Ztm65dNvV8Ps9wnXNm1sYupRRCqEaTu4uu2r5wcNJevho7oG0jyhKmm/BYYACaugYUKlnMdcJ7v0itldX2XqOY1w0zS+pgUhVlXddR0mgyJua268qqApHzvm4aMIWy6CSxd9Vk3MYopj6Eo5Pjn77/8//1v79/+aMPBaaElFJRFMwcY4Qag0xUVZd1x+Vk/6S9/OlhC1A5HYJu5ewzA96MiKisAiBwAUBnII9ffHwz+RHgxcg5ahfzuFhOww4cDc2ITjsJpJaTPdzPDyOIajLdPXvmxRdfFJHJZFKWparGLhGRmZEZA6nrCOLIS7KTeTPeOvfB9Tt39WLBcPCOEqAEYbAB7MEAE7GmlEO3aLjb4GdXrpsfJ/Jg8kzLkyPqWm/myNhlOjARERuxgQbjDxibsSmpkiqBmOu2adp2NB5v7+ywczFGVXVEnpnMyMCg2HZNXTsyVum6rhhtXztcvH1ZaqDWMLgbSjkqY4KoASA2ZJvu8O7PcbxIkQtlV1Rlapt2drwVnIvdWmEyHCPLHP18UmJj5rzHzACrphUHrwQzMzMRUVUHcs4xKBMjEFtM0nRsKMgKpk6h5fYP3nhvCUiAIWTQDsnlgWQjwMh5Mc3e4Zvvvu8m262yMfuiaJYn3WI2hrbHR4jRUiSVDNQRciqEGYARgZmYs4E1Iqqbhpir8ShUZVEUVVWVZcnMnp2JOgMDse26pkUStO3EGUuXFH68e/n63Z9cQwRiLygBxCFxn0PJbhNTAq4f4ur+7dF0NxorMTOnrpN6vrx79+6NaxLblJKqkgmgK4JnsmSF4JwbdrKIZMFHSV3XiQipQY0MmhKDrEt3bt0+PjiMbRebumTEeuF8Ec1pufXaO59GIPWKI2t2Yc7JK/IGU6Dp8P9+9H6npuzIeXYBwLgqNDbXP/rg4Pr12LWSOtGoqgwwjBjE2Z1gR+YZ7JCJTmxbW1u+LFYsMjNmLopCRFJKAOq6/vSTqzdv3GjrpqvrgpKzpKrJXLVz4YOr++9eidIb8JyIU6YhsVM3FlHOGvzorfc0jGplKysLI0MYTbZN3fXr145P7moSETHRzNG1d5iZvaFccquXy3o277ronA/jETOnlCR10CiSiKhrm6P9qycH12NbxxjN+XI8aWPyReFCmMf05k8/iICgBAIIMGUAsWtT4qLaEuC/fO+1VO7x1lm3faaWUAtFni5qd/FzzybH1WTU1Y031zVxOa9hTMSS1PtgBvJeiaIYjE3JorFhxDzyRUFBErWi6tgTkNqki5gWbZd2p5On98KFLSXEw/mioaIh70IQ6bz3wY9+/O6Hh4oFkGgCBBCzdk01Kr3jusXVG/GjK58KsZGbL2bMYKDwxe7umdnx8XhSLhbHxCYxaUwmaqopqoiISM4kmfUObi94A5k6A4wVLMQ57ceG0aiM2h0dH8Zu+be+/dtP7Y2uXblcVUWYTFBUwlgul/Vicebs+XK89WdvHKQ+Je8A5qQCoGlSWWIUuKtPgjYTF7eDjtFgMePmyHWzyonUx3vbkzL4FR1VNauw9VR+cFsnj4ygxEocVcqyLIri+PDO13/ly9/6nb9ycO0Dp51zbl53BJ5Ot1OSxWKhqrPZbG3GDFyMRgCqkYfhzsG+NLM4O/Dx6GwZt2hRdIeVnNjyzqUL23dufPSlZ58clVllwnufzatnZtBm2pSGdD4R9WniIRtvYAMZWI3APJmMu3aJ1HznW1+rsGxnt0tHDOuaxjGmk3HpmKBZw65wM8BN24gIDL/6wlP/6l/802/8yrP7H7y9uPH+01u4OEo038dyv9CTnUrP740d9xqAmXOab2VNaAjsMwHoVCVCV4eFWImr0bhp2+ViNi7c2KULE/zmi8/Pbn40v7N/bme6PQraLjjWpK12bVcvN+/FIHjvnXNsxoZLF4q/++3f/ON/+YcvPLVjJ5/Wty5/6cnxV57eef0H/+PzF7e/+etfl9SqavYXs0HOynitSU7xRAHbLHoosYGVqE0ynW7XdS2pPbNVBuAP/8Hf9t0Rd8fx5PbJ/ieYH465C2lJ3YJTs65+AN6ALDDv+qTz3gg7W/jH333p1l386M9/9uqrr9az49/6xlf+6B/9wyee3/vem58aCu89gJSSd8zMSZUcZxkPU3GgR07tGtg2E+kc2ziajJ07MZLpiCvgW7/13DvvvvK9P3/t6S9+/dLTT5aFu/7JhxRnLz3/zN/7zm/4Vb7Y2ItYKAqIwpmk5Fwx9VhE7AToCH/wey/8/d974fKHR09f3N2e4Gc3oRKdJ8/OE0eNTOScSzpQdpUZvKdKRYZTRTKEarSslwacO7tXefYAAf/sj/7mB5/8m8XdKx/f+fDM7s6lC2e//Tvf+eoXywnB9Zl8BeBdFjAzoM4xkMh4GliA8xNEhWN87Qu7+ZGTMofPTkQQY2aziDBzTmQOlq/3DdTUZS/ELIc1nJ1AsxRjDmzbu+248g6J4ace//qP/8msgQmqCtMRfJ8IRXAZMQG4Pwdl2Vo6Ygemgb7rOoPBzFSVBumSgWAwy260mRHBBs/a0NvczBCCwowtu7BKRKrati0mROBgvFdgwoAihF5duP5vFWqpv69ANMhJBaQMdSjWaUiDWlJVVbWUmPnUtFMzzjy2oZBgSt5gMDIYqToitnVd1NjFpIvFAmemgDoQjLwbSlyqsASidUk0x5MbIh7S8Lk6CAWBTYFE8JyTqANCVd0kbfZDciQyDFfeT0YwYxgx9VeSwvqBIGLXih6fzNWmTAw2dDGHJTAAAlUwg9a1JEMu760fP9QeSWEGo9V86quFG+OiuvZLVQYVbQDBaP3LwEagnNgicSCn0CE0c1zGpHdnC8t1MwDOE9m6uOtWHl1/Q+3DmIGwq5oA5W6RKfVhGfpKDBGcI3ZEup52UFUb4pcVp3vQRqYEIyYjA5mQGYwUSi6Qd2I8X7RCvs8NOAYAE5iCByNouWjOmQMepkNx91R9iYgYBOqnQO6i5P3MeXauNlSVnLNBgeQNNojBmC0rFDMy6xcuQKEGB++CgpZNp8Nkihk6OYDZhNkBSJocWNGrBF7Rd2NAH9yorwD2IUm/gV7Sq9Ms50OBXGEiqJko+ioZkA+CTBnKzAZfq5MVO60XEDkC5zUP7F2xcj0IYLD2ywLoVDFPJQHKDJhpjKr96gbnnKp2XUdEOQBpmo7Jm+XhIyPOfoYRGwEaCWIE7eFrAglxEUjaWqUrJ5Orh3WXc+ltWxH8UMLgviDKfSw7fPzAC76n9khkyIPIHHwwggI+e0uOyTERQU1VmR0RZQuysVyDe6lDDGRmBjMywCivSVBzrKZKLrSaUh5JsmwiHjzUm7febKsatXMOgIlsHnXuXkN9n7Lr95j10SsZ84MIlz0tVQ0hxCg9bdyjlyBgkPSaLg8mNCFGwIEdABIRgoHZBe8H7QEmMxsq3+u8B2CG4cDQo1xVY3Jm5r3PU0IV7nHqtcMilc883Gs0gRgcIwRkw6sqCviiDwhUexVE2lvEzwZ9akwAMPveU7CHIbkP9AOaZnXbc5SRtacSjAlGImoqKSWS5OCwQY/NlnGfBj0QjCAihMrMQlEAYAYeDzffT+uN52VdyEZ9MezoGI5D8GVRVESu61JTd5KMyGXtAbAZsTEpUU6SWb+obOPWDICIUkrkWETKsswzFA/q+QNB37cFAH3Qlx26vKducefuEkyuCCEE51xUiTEmFR5Ml62J0f80M8v5U7Xe6zAjNbBTBRGJagg9zXB63n9W8/cMB63LjJRiJHLMHIE2oSxx5ZOrXdeV01JEnHnr2rppQln0a0JWouztvoGMwEwwg8AMxj2pTVJy3td1HUIZY4usA1boHwH6QS1XS5m5D8ysLyQtm1aJmYnJsQvwzoA+JuDsdTyAkr3GICYbtkGrMRSRumu7xwH7cNC5sXO9w2bwDAFmJ4uUhETMzHtXlqWZZV4SOSLi7CJtrOTLFsd6VWI0LCHIoA0mInVdL1to8cuBvofPmcQG9N63Uu8tHc9nSUrruk5SoRKKwsw4YxrcutU3BtC5I2RqRAbdBM1ghdVN07aw8Pgq7yGrNfun9hsCNE3n3BTg2Ensal8kIipoyHtQ/pAN8VVe3QYDtLfhMDPttYmqOkc5JRmlXzX3eKDvk809XciDbYAokohzzhVFl1KMMcaY6UFELoRVTIA1aAVZH9jCuFfTBpgpiUjhaRWzPZ6UM+iHn2u29loNRC7G6IlGo5FzLkrK1bScTN8EPWQ8bDVU1lv5NTdyioc5p7nvfdxDQee1hIRVpU5WKydNzbI/Ds1rE9jPF0svGkIg59B1UZIpFFIoiK131PpYM6OAgciiA4gU2muPXEcimIM50yGCBOjRK8YYKkDqCdB/sluWQEImsesALDs4hzDe9dXWyWzRtJHYj0aTne3d4AoGp04kiiY1sWGhJxlYyAsIlqAtJ2UhMxOQWTmp9pqTI23mFbtUSxLAhceTNBTmVmEjVh2Okb2D48IVLeADDpa4e3RSFHvJkWnSSN67wrlyUgFV0zRAv2aXTE3NAIGp80YKjayqYgAJQYhAwQeeTkI67paLu2XhhNBJLPyj7Yu/3/fIXeUQsrhSSo14LnF7X5azo3Jrh63h2JlwGgJbDIxaJ3n7rA0pq5pBkqkoFGAxVXixrp7XFbeVa32pYYycMDYoPWrh1anDtLnfCGJQ8t77AAe0de2ZYoytiBrgvQ8FhWDOCdGibRdtO+/aZYp10kasM4pwbXIx+U581BA1JPOCoHDleMvIKXtXVq261956bwE0RvooxNj0p+mBSoeHKgRw5fLPr1y9cu7FFzTsROLouDXuJHVtilF9sUVElqu45PqkNQcRR8YgMVJHRkRGDkwn886HPeLYdJrS6K33b/71V/5SoCCPsYD6wQ4TAyAHR1lLd511oKriL37+ydvLO4mjMhdFUVTj6aTkaQmm5XIpOf1FAITIiAhGasrGDpJrpAQiggKBpfCIi3mcH49AFZwDFktsjR8p6P6dgH5VsK3X7ytBYCYxumKSgATMEj7ax6tvXz6JWC6bpmlilJhSjClKGo+mAlNQ78oaK4GNrTNWkBmZMrKk2YiTqiMdebm4Vz6541956ctffXYSNiPjxwc9CDu7G0gx+jCKigiA0RiynDpBJzCFGFJCFKQIySvADXk25cfHBk6zyjey7E2xEUIAGZ44j70R2hOc24LVNVUB/JlxySbovCyVN5MeK9CZLDJocQIKw6rsi+HtmM1EGzZU5+boYSNwXt8aCABZgrWwCGLwCHiE1vOnVcbQlfUvRl/gRZ+AzXdf9zrjzREUu9WFBBh5MkFn617QoGT7YGNY6ShAtoXc+zoPbfcHpJtJm3X+b8hl5d9p1bPNvm1KMTcBDDEv7NIeq8eG4DHAX30/TuvXT9O9j8MDiGUbmdX78G2C5lOH8ssOyJW6Taz3P+Mxofv7Xr1Y71jNy+FHfldgnTDijWs2cawCTQeQrdjCa1Lj9MYmzAfbi9OgVzBPC/t0R3rEAiPcl2ijvtjygJbzgT1cyj7N6oYbs3mYBo/BZyDXEU+d95npknWd5n7fYH1FPzqnO08bn/6CNLwGARDndKzA45d/ZUSHVb0PaXrKyp4a4g0a24Nn84A7u+5p0Idm0OGFF3aP4Xv8f4v4aTRb5QZGAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAY5ElEQVR4nJV7Wa9lx3Xet1ZV7b3PcKceOUhsUhIlKpZMmjKsmE7gGA4kG4kyKEAcIEEA+yHIS4I8BHn1T8h7AiQPAZIXB0mQlwhBlISSEVM0xUE0JVFNsslmD7f79u177xn2ULXWykPtfc653c3uVuHcc/fZ41ervlpjbTKNAAAGAcZGAKDoGwMAyAACDEJoAQEYcAABZGADCEr9+QQ4KCwCEQRDELAHwQABYABACQ6AGrzAAV6Hx+XbPrz59abxZ54+7M83HZCBbH2UN7oKAHD5n4Jz14gAymcpyAOaZUKwfDbn7jwSMkBrSYP7G9wvafQCAm0AM8AyDoAggA1ACHBDf9Kws+9kHjSCQRUKGAOUH6wMAPzZshuaBwDih4i5R0zaozQACjOQwhQAWAEwWMAMtx49AwzEfTdWgtWMEAwwZ8HDYAqTXgS9rB4CehDVZltd1O8m7aVvDOMeNwBIP9xQAhMYCAAcfC92wDEMifKeodeKlQQYYI808EtXvHoo6GHE7DPP0TVfaNUpBgzkwPkE3rjc1v8JMBABpgDnbWc9nVZ3N3hi7e/+OJxWM/3M8dDTusQAZ/nZ/d0VUIMpdJAsOzgHhgICUOZ46q/O3YAHQYZpgNVZw/ejQSdby+g0dAVAp1WCgQV8TycF61mYb+IBN8zF3O9+XmoaVB6BGMT5Wgzd+eVV3r1wAcCMVNXMwOTZKaDQOnUOZfB0coJqCmN0wKe3sOxSOfIXz6LIM88QGAJ4oCBYxNR7WERXIwQkA7GjQOTMrfv8OO2BklYApkpERGQDbfOhVheeKyBkW5GATw7w7/7j//zk5kGYTLbP7jzxxMUnLp49d2Zne1r4gBvX5fDOnQnVz54ff+Mr5wuJ45JgKz3rQB4ENdhjqTsA8JsDvXkBsQegMMmznqACta703KZZ8HuHx3GyU3TAn76+/3/+7P3nvvYSdnaOnL95rZFrHxWBTdKy7ra3nolNPdu/fGnPP/WF339yEkqAI8jE2s7MuKrgiEkhHYQRRo9UeaSDpDcQ9+Q0IGUBbFBb0TLcsuVQ8se38e//0/cP2+qg1pmG8bmLxda0sySQUBCpNk0E75wc3MFif7eoX3p279LZ8Hd+98XdgGBwGGaiRVACBASgAj2QtBugzTY01IbMVUHcK9T8nSdNp/CM1vAn/+317//wrfGZSw1vabWzv4g82Q6TCYUAMjMhqKmLrWeNx/sfXro4euZc+fFP33h6Z/T7v/vbv/r8me0RCoAVJWXT2XaLWTE99xkz7X7Q92hpAjZ0gg2gI9AAr787+5P//N+pmN48mC+Sf+K5F3hr707d1UKJOfiCmVWSU5S+APynVz7YnfqXv/5Fh9knH7x3cmt/d1yd39l75ddf/o1f2zs/BkUEw1aRAAHCo+lh+iCrQjBDtN65yDp3tsTBEv/1//78rfeviWJ79+zhyWLeRS7H1e7eeHd3VndtFx1xwY5EKSmrtXXj2M7sjbo4296pbt++dXBw54Uvf/Xw9mFJdHF362tfeurlF7afO4cSMEkT538pL2+wF6QAlLxRT4mjGr/46OjHb7/zkw9vzsOTsTiztbM7b5rjbl5HufTMxRu39kdbE2epIPFk01AWhUtt1zXL0SRcv3H1c0897/y4Gm8LjuG3OjedXNhansw+vHP86e13fvh6+8yFyV9++YVvfnWXgaLX1uuptbIMlF2Gnh668r8SqDFoRBlR1sD+Av/2P7x28+48McqdM42V5EYppRjjzs7Oq3/6w+9+97sfXvkIwGQy0STOufNnzjrmo8O7dV1/ev3aM898bnd39+Dwzt7ezhtvvPHMc1/o2sTsxuOxpSSp8SSpWTLJ03vhn//By+cLjAGSlh0DLqI38Q5wiLDkN1zijNuABGgHCMq54NUfHV09TOXuJQ58krqymqSUIsyPKg7h3LlzN27cOLt3ZnZ0PDs8OpkdBedZZW9vzxeOOoDt1t07Qry9e6YaT9hXKphsTc1ghFaFfRkmE6m6etHcXC5/8ObB3/jmOa8YOQcRMKlxdgtWZsQrlPuwZYXdAyAEBa7fwo/f/kk0d2Znt2WrZzMwgz17IkcK+/ylS4dHR+cuXDAzOIbjwI7Yi0IU80U9Wy5OFvPYSVEUURJ7ZwRmZnZRBMzkHDkXyiIlVW1fe/vdl770154/C4MnUsAKRrfWyLSyIHBraRPgFEwo54J33v14Vqfdc09Fo1aUfEhqLviiKGKMdRt39vaIqGkaMFfj0fb2tojM5/O6a0XkeD47f/48ERWhSirNyeL8+fN7e3ttijEJM5dlqbCma41QjqqJ8/PbB2+8d+XZv/qstjItyNqaKufXXiQD3lt2aYgHBx8gDwQBDg7x5l/8AmFaTncOm9iSiXHlXEziiuALiEgb097Z84u6DiEYsQJtjIu6LopiPB6fPX9uZ2eLiFJSAGY23dnm4GNTE7ERnPcEizEayDsW5urcUz9+/9orv/bs56YOZkSAiSMI2AABM5gVsDxPs+owhoXM6xu35ndOGnFla0jkKJRG7ELZdV2XYlGOymo8Xyx8EYxAjsn5VjSajqfT7TN70+3t7d09JW7bNqUksHI8MmBZ10QUQlCYwsg5XxRlWQrs8HiB0c6tpbzzwZFm8YWgyxlMeJh0sqHGE5BAmgMZAZYdfnb5mh/ttupaY/hA7NmHpOqLysh1kozJFeWybp0v6qZTM1FVo3I0JvbLpq3bRlUFBsdqNp5MvPdmVlSlCz4HF0QEgL0jx63Y0VJ5fO6nV/bvJiQAxMwAEiHREI/wgHtFjr438xZ/8f41LrZahRIl06bpYLxcLre2tqqqWszrrut2dnaWbZOnYDme+LIwJgOiigGjyRhERVU670/ms7Ztm65dNvV8Ps9wnXNm1sYupRRCqEaTu4uu2r5wcNJevho7oG0jyhKmm/BYYACaugYUKlnMdcJ7v0itldX2XqOY1w0zS+pgUhVlXddR0mgyJua268qqApHzvm4aMIWy6CSxd9Vk3MYopj6Eo5Pjn77/8//1v79/+aMPBaaElFJRFMwcY4Qag0xUVZd1x+Vk/6S9/OlhC1A5HYJu5ewzA96MiKisAiBwAUBnII9ffHwz+RHgxcg5ahfzuFhOww4cDc2ITjsJpJaTPdzPDyOIajLdPXvmxRdfFJHJZFKWparGLhGRmZEZA6nrCOLIS7KTeTPeOvfB9Tt39WLBcPCOEqAEYbAB7MEAE7GmlEO3aLjb4GdXrpsfJ/Jg8kzLkyPqWm/myNhlOjARERuxgQbjDxibsSmpkiqBmOu2adp2NB5v7+ywczFGVXVEnpnMyMCg2HZNXTsyVum6rhhtXztcvH1ZaqDWMLgbSjkqY4KoASA2ZJvu8O7PcbxIkQtlV1Rlapt2drwVnIvdWmEyHCPLHP18UmJj5rzHzACrphUHrwQzMzMRUVUHcs4xKBMjEFtM0nRsKMgKpk6h5fYP3nhvCUiAIWTQDsnlgWQjwMh5Mc3e4Zvvvu8m262yMfuiaJYn3WI2hrbHR4jRUiSVDNQRciqEGYARgZmYs4E1Iqqbhpir8ShUZVEUVVWVZcnMnp2JOgMDse26pkUStO3EGUuXFH68e/n63Z9cQwRiLygBxCFxn0PJbhNTAq4f4ur+7dF0NxorMTOnrpN6vrx79+6NaxLblJKqkgmgK4JnsmSF4JwbdrKIZMFHSV3XiQipQY0MmhKDrEt3bt0+PjiMbRebumTEeuF8Ec1pufXaO59GIPWKI2t2Yc7JK/IGU6Dp8P9+9H6npuzIeXYBwLgqNDbXP/rg4Pr12LWSOtGoqgwwjBjE2Z1gR+YZ7JCJTmxbW1u+LFYsMjNmLopCRFJKAOq6/vSTqzdv3GjrpqvrgpKzpKrJXLVz4YOr++9eidIb8JyIU6YhsVM3FlHOGvzorfc0jGplKysLI0MYTbZN3fXr145P7moSETHRzNG1d5iZvaFccquXy3o277ronA/jETOnlCR10CiSiKhrm6P9qycH12NbxxjN+XI8aWPyReFCmMf05k8/iICgBAIIMGUAsWtT4qLaEuC/fO+1VO7x1lm3faaWUAtFni5qd/FzzybH1WTU1Y031zVxOa9hTMSS1PtgBvJeiaIYjE3JorFhxDzyRUFBErWi6tgTkNqki5gWbZd2p5On98KFLSXEw/mioaIh70IQ6bz3wY9+/O6Hh4oFkGgCBBCzdk01Kr3jusXVG/GjK58KsZGbL2bMYKDwxe7umdnx8XhSLhbHxCYxaUwmaqopqoiISM4kmfUObi94A5k6A4wVLMQ57ceG0aiM2h0dH8Zu+be+/dtP7Y2uXblcVUWYTFBUwlgul/Vicebs+XK89WdvHKQ+Je8A5qQCoGlSWWIUuKtPgjYTF7eDjtFgMePmyHWzyonUx3vbkzL4FR1VNauw9VR+cFsnj4ygxEocVcqyLIri+PDO13/ly9/6nb9ycO0Dp51zbl53BJ5Ot1OSxWKhqrPZbG3GDFyMRgCqkYfhzsG+NLM4O/Dx6GwZt2hRdIeVnNjyzqUL23dufPSlZ58clVllwnufzatnZtBm2pSGdD4R9WniIRtvYAMZWI3APJmMu3aJ1HznW1+rsGxnt0tHDOuaxjGmk3HpmKBZw65wM8BN24gIDL/6wlP/6l/802/8yrP7H7y9uPH+01u4OEo038dyv9CTnUrP740d9xqAmXOab2VNaAjsMwHoVCVCV4eFWImr0bhp2+ViNi7c2KULE/zmi8/Pbn40v7N/bme6PQraLjjWpK12bVcvN+/FIHjvnXNsxoZLF4q/++3f/ON/+YcvPLVjJ5/Wty5/6cnxV57eef0H/+PzF7e/+etfl9SqavYXs0HOynitSU7xRAHbLHoosYGVqE0ynW7XdS2pPbNVBuAP/8Hf9t0Rd8fx5PbJ/ieYH465C2lJ3YJTs65+AN6ALDDv+qTz3gg7W/jH333p1l386M9/9uqrr9az49/6xlf+6B/9wyee3/vem58aCu89gJSSd8zMSZUcZxkPU3GgR07tGtg2E+kc2ziajJ07MZLpiCvgW7/13DvvvvK9P3/t6S9+/dLTT5aFu/7JhxRnLz3/zN/7zm/4Vb7Y2ItYKAqIwpmk5Fwx9VhE7AToCH/wey/8/d974fKHR09f3N2e4Gc3oRKdJ8/OE0eNTOScSzpQdpUZvKdKRYZTRTKEarSslwacO7tXefYAAf/sj/7mB5/8m8XdKx/f+fDM7s6lC2e//Tvf+eoXywnB9Zl8BeBdFjAzoM4xkMh4GliA8xNEhWN87Qu7+ZGTMofPTkQQY2aziDBzTmQOlq/3DdTUZS/ELIc1nJ1AsxRjDmzbu+248g6J4ace//qP/8msgQmqCtMRfJ8IRXAZMQG4Pwdl2Vo6Ygemgb7rOoPBzFSVBumSgWAwy260mRHBBs/a0NvczBCCwowtu7BKRKrati0mROBgvFdgwoAihF5duP5vFWqpv69ANMhJBaQMdSjWaUiDWlJVVbWUmPnUtFMzzjy2oZBgSt5gMDIYqToitnVd1NjFpIvFAmemgDoQjLwbSlyqsASidUk0x5MbIh7S8Lk6CAWBTYFE8JyTqANCVd0kbfZDciQyDFfeT0YwYxgx9VeSwvqBIGLXih6fzNWmTAw2dDGHJTAAAlUwg9a1JEMu760fP9QeSWEGo9V86quFG+OiuvZLVQYVbQDBaP3LwEagnNgicSCn0CE0c1zGpHdnC8t1MwDOE9m6uOtWHl1/Q+3DmIGwq5oA5W6RKfVhGfpKDBGcI3ZEup52UFUb4pcVp3vQRqYEIyYjA5mQGYwUSi6Qd2I8X7RCvs8NOAYAE5iCByNouWjOmQMepkNx91R9iYgYBOqnQO6i5P3MeXauNlSVnLNBgeQNNojBmC0rFDMy6xcuQKEGB++CgpZNp8Nkihk6OYDZhNkBSJocWNGrBF7Rd2NAH9yorwD2IUm/gV7Sq9Ms50OBXGEiqJko+ioZkA+CTBnKzAZfq5MVO60XEDkC5zUP7F2xcj0IYLD2ywLoVDFPJQHKDJhpjKr96gbnnKp2XUdEOQBpmo7Jm+XhIyPOfoYRGwEaCWIE7eFrAglxEUjaWqUrJ5Orh3WXc+ltWxH8UMLgviDKfSw7fPzAC76n9khkyIPIHHwwggI+e0uOyTERQU1VmR0RZQuysVyDe6lDDGRmBjMywCivSVBzrKZKLrSaUh5JsmwiHjzUm7febKsatXMOgIlsHnXuXkN9n7Lr95j10SsZ84MIlz0tVQ0hxCg9bdyjlyBgkPSaLg8mNCFGwIEdABIRgoHZBe8H7QEmMxsq3+u8B2CG4cDQo1xVY3Jm5r3PU0IV7nHqtcMilc883Gs0gRgcIwRkw6sqCviiDwhUexVE2lvEzwZ9akwAMPveU7CHIbkP9AOaZnXbc5SRtacSjAlGImoqKSWS5OCwQY/NlnGfBj0QjCAihMrMQlEAYAYeDzffT+uN52VdyEZ9MezoGI5D8GVRVESu61JTd5KMyGXtAbAZsTEpUU6SWb+obOPWDICIUkrkWETKsswzFA/q+QNB37cFAH3Qlx26vKducefuEkyuCCEE51xUiTEmFR5Ml62J0f80M8v5U7Xe6zAjNbBTBRGJagg9zXB63n9W8/cMB63LjJRiJHLMHIE2oSxx5ZOrXdeV01JEnHnr2rppQln0a0JWouztvoGMwEwwg8AMxj2pTVJy3td1HUIZY4usA1boHwH6QS1XS5m5D8ysLyQtm1aJmYnJsQvwzoA+JuDsdTyAkr3GICYbtkGrMRSRumu7xwH7cNC5sXO9w2bwDAFmJ4uUhETMzHtXlqWZZV4SOSLi7CJtrOTLFsd6VWI0LCHIoA0mInVdL1to8cuBvofPmcQG9N63Uu8tHc9nSUrruk5SoRKKwsw4YxrcutU3BtC5I2RqRAbdBM1ghdVN07aw8Pgq7yGrNfun9hsCNE3n3BTg2Ensal8kIipoyHtQ/pAN8VVe3QYDtLfhMDPttYmqOkc5JRmlXzX3eKDvk809XciDbYAokohzzhVFl1KMMcaY6UFELoRVTIA1aAVZH9jCuFfTBpgpiUjhaRWzPZ6UM+iHn2u29loNRC7G6IlGo5FzLkrK1bScTN8EPWQ8bDVU1lv5NTdyioc5p7nvfdxDQee1hIRVpU5WKydNzbI/Ds1rE9jPF0svGkIg59B1UZIpFFIoiK131PpYM6OAgciiA4gU2muPXEcimIM50yGCBOjRK8YYKkDqCdB/sluWQEImsesALDs4hzDe9dXWyWzRtJHYj0aTne3d4AoGp04kiiY1sWGhJxlYyAsIlqAtJ2UhMxOQWTmp9pqTI23mFbtUSxLAhceTNBTmVmEjVh2Okb2D48IVLeADDpa4e3RSFHvJkWnSSN67wrlyUgFV0zRAv2aXTE3NAIGp80YKjayqYgAJQYhAwQeeTkI67paLu2XhhNBJLPyj7Yu/3/fIXeUQsrhSSo14LnF7X5azo3Jrh63h2JlwGgJbDIxaJ3n7rA0pq5pBkqkoFGAxVXixrp7XFbeVa32pYYycMDYoPWrh1anDtLnfCGJQ8t77AAe0de2ZYoytiBrgvQ8FhWDOCdGibRdtO+/aZYp10kasM4pwbXIx+U581BA1JPOCoHDleMvIKXtXVq261956bwE0RvooxNj0p+mBSoeHKgRw5fLPr1y9cu7FFzTsROLouDXuJHVtilF9sUVElqu45PqkNQcRR8YgMVJHRkRGDkwn886HPeLYdJrS6K33b/71V/5SoCCPsYD6wQ4TAyAHR1lLd511oKriL37+ydvLO4mjMhdFUVTj6aTkaQmm5XIpOf1FAITIiAhGasrGDpJrpAQiggKBpfCIi3mcH49AFZwDFktsjR8p6P6dgH5VsK3X7ytBYCYxumKSgATMEj7ax6tvXz6JWC6bpmlilJhSjClKGo+mAlNQ78oaK4GNrTNWkBmZMrKk2YiTqiMdebm4Vz6541956ctffXYSNiPjxwc9CDu7G0gx+jCKigiA0RiynDpBJzCFGFJCFKQIySvADXk25cfHBk6zyjey7E2xEUIAGZ44j70R2hOc24LVNVUB/JlxySbovCyVN5MeK9CZLDJocQIKw6rsi+HtmM1EGzZU5+boYSNwXt8aCABZgrWwCGLwCHiE1vOnVcbQlfUvRl/gRZ+AzXdf9zrjzREUu9WFBBh5MkFn617QoGT7YGNY6ShAtoXc+zoPbfcHpJtJm3X+b8hl5d9p1bPNvm1KMTcBDDEv7NIeq8eG4DHAX30/TuvXT9O9j8MDiGUbmdX78G2C5lOH8ssOyJW6Taz3P+Mxofv7Xr1Y71jNy+FHfldgnTDijWs2cawCTQeQrdjCa1Lj9MYmzAfbi9OgVzBPC/t0R3rEAiPcl2ijvtjygJbzgT1cyj7N6oYbs3mYBo/BZyDXEU+d95npknWd5n7fYH1FPzqnO08bn/6CNLwGARDndKzA45d/ZUSHVb0PaXrKyp4a4g0a24Nn84A7u+5p0Idm0OGFF3aP4Xv8f4v4aTRb5QZGAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAe0klEQVR4nM17d5hV1d3uKrufs0+dM70wODC0gYEBhiJKVCwYa0g0aiz5YtTkmvjlidHcL818xiR+xpJmoqISE1tQEIMIqIh0GMrQYXqfOVNO3X3tte4fW8ZhQAHjvc9df5xnn332Pvtd7/6tX1+QMQb+PxiMMQih93nGi9G/85izvMA7+IzrzwkxAAB+Dqa9W059AGOMUuqd9z49HJRShNCpuCGEZ4nyCwA9EiWE0HVdAABCaBSCU5k77RlKKcb4tL9+YaBH/vUwhQBQAJCu6319fZqmAQBc1/UAUUq9uzDGCCGMMcaYMRYMBvPy8nieP6enf07Qp6Jfs2bNgQMHent7+/r6EomE4zjDUxqWllGzdRxHVdVoNBoKhaqqqr797W+D/zdMezQ//uQTy5YtQwhZhs0Y4zjO495bWB54AAAAyJsAYwwhJIqiKPKMMQhxQ0PDyy+/fNFFC13XRQhAiM+IgTsnxODECiOEcBz37tr1v/n1o4FAwHEcn8+HMQYQUsa8iUEAKKUQIcYYABRCSBmDEKbSacuyOI4TBEEURZfS119//aKLFjLGIDwrbXbOoAEAHqMMgFWrVqmqGgoGIWSKooy8wPtECDEGAaAUfKxwvJ9yc3NNSycONU2TUrr/wAHDMGRZZoyNFJBPE5jPCRpC+Ohvf1u3a8fY8hLXdW2buK5LKT0hEh8rOMZsyADECHjqBSHHtkWBC4cCrutDHHYs+8hRvb2tpbOrZ1zF2P9bxsUT5fr6A2+99Zaq+gihrvvxqoAQYow5juM4hDHkOMRxHC9KHJYEQcKY5znZtokkSd4Mie0Q6kbCwd6+/taWJnY6RX5aDJ/K9GknPby2/vrXPxFCHIcjhDiOYxgGAZAR15Nn9vHwvjIAEKUEQkgpAIDyQgFxDZ5DCCEOYeIyl9itbR3wLKzsGUCfFrEnpitWrFi/fkM4HMxqBqUAIxAOhxFCPM97ZCOEEICeySCUua5DToyMltU1TZIEQ3cJsQHEjm0CiAf6+4YfcUYJ+SyZHnX/sNVdvny5JAm6YQFIIWQBNcRxPCFU101CbNd1qaflABUEgeMEnseCIEiSIsvi4GBC0zSMwxzH+f1+jDEhBDD36LEGAIBna86I+2z1tGfeEELr1q37j/+4Mycnp6pq8qJFi1566aXm5laEkEMoAJSNGAihE+IBEIQcz8uy3NbWdt/3v19ZWfnmm8sPHz5MGQQAdHd3A0hrps948MEHFy9ePMLQnjvTJ03uxHj19ddmzqy+9pprpkyZYuhWW1sbACCTzWqaZhgGZeST6wEGAAAMJF6SJElijBCq6/qCBfMvu+yy66+9ZtuO7Uuff3Hjxo2iKBqG0dcfX7Vq1eLFi8/I49kuRMYYgqi7q2PaxIllY0tVNWQatiiKOTm527ZvCQaCZcVFY88bU1RUFItEJUlAAJu2lUgkunp7Orq7Ojt6E4mEbhoXzJtbVlrc3NysKMqCBReeP2/+W2+vuvfeeyFiGPGpdBZ8utL4hMGzFw8AwEcbNyT7B6P5uT5F5TFGCDS2tjU1Nc2smV5aVCjIimVZhqXbpkMp5XksCJIsiLZtxuPxAwcOHGlovP7q60rGlOiaCRHjOCQqPoHjb1zy1Y1btkJeuOSSS9a9s/qMMn0G8RjpnhuGwfN8xaRJiiIxFxiGwQvC3No506qm1tXVrX537dEjx7u7unTDABQySCGEkk/JLyiaVHnerJoZCy++5BvfuG1gYCCTyUiKXxRFy7L0tJnU+6PhiORXHcexdOPUl3xuoEf6RhjjeDwezcl1HbJ7916M8eTJk3t6ex9/6o/vrl9nZDOyXy3KzysfW9HR1i4pcllJ6Tvr11aXlrU0N++u27n02efDsZwrL7v06zffVFE+ZmAw0dDSFAkGCguKh4hRVlQgSYJtE0IIOAvxOLNMu66LMU4mk9lsNh6PP/7EU+lUYnBwMJab397eyfP8rBk1eQWFoYA6NDCom0Z+YQGlJJVJcxyHGJg4vnLChKsETty0ZfPK1e/+c8XKa7985dFjDZqmmaZ5+WWLvvuduy+67NIPtm2rHzxi2Jb3uJHB0anEn8G4eH+xatUqjuMmTpy4bNmyCy+6eObMmctfe3XFyjeoC77+9ZtFUdy8+SNd13t6+kxT9+6ilAoit3Pndk6UGlsai/OKp1VN5SXxvffWLX3+xR//9Odza+esfPONp//yTGnpmBu+cvWtN339l79+LODze4hH2YdzYNrTl2+88cbevXvvvvvbx483ZrPZhRd+qX7vXlHgFEWBAK9ZszqZTCbSKcvMQoCYSwEEgCEAKcgAAABCYCDe2SAeO9ZwhLg2hqyouPi6a66v27G5YtyYUDT04YcfXH/dVYsWLdpXf+Bfa9+rq6ubOXOm67pe/HZa+f5U0J4cb926dd26df/7xw84jmPb9qFDh9745+s+2bd+7Tq/4kulMp0dbYZhAAD8algWZV6QIMSmY1NKiGXzAs5mMy4xDcNoaW7OicVyIrGOzs7nX3g2ElD37Kkz03pxcaki+12Ou+3WWw4fPf61G2/YuXNnTiT6GSb99CrP4ziVSt19990//OEPA341FAkue+nvj/72MQSZKIqSIvf1dKfSGQS5/LzCaF6BX/RlTfvSRQsifpVCAAC1iYUpWrbspfauVsQQhdQF1Kf4VH/YIrrASxBiTdOqqquefOy30UgkHo/v37XzgZ//4sKFl6x4c/knNDMATkZ+eqYRQoAB27arqiaHw0EAELHdHTt2QADKysqyWf348aOEkGhOQcX4CZFwHghGbMtiun6oM8H4tJEY8gdChqEBAJxoUUAOuK7rxDuJbRmGYdskJz+P4zhdNzketDQcf/jhR37+0M8oY5JPmVlds/a99S1trWPHlH8cqJ8C+/SgvSnGYtFwOOY4bk5O9Fe/fvitt9+O+AMDA/G2jk6X0JLiipLysT6fj1JXDsYwY2Y62WYQ3WJOyuShA5HP6m5DuaV+xUd1LTWUMLIpBLBDnXhvdygQtBxbkWRJEg4dOfzEU0/fc8fN/f39u+v31c6cNXZMGQNgOLUAAAAj5IQbBXT4IB4f+P3vn5wwYUJJSdHDDz/yzDPPRAIqpW4ikcKILyopLi4pmVUzzedTGpo7mvdslDjeF1B9jmvaVhhSOpjocihmJNvZkx7s6+/vr55dW1Qwd2goIfvELZu2phLpnNywovgppVomu3PrluL82MTyMn/AxxBsa2kvKy/1YpSPJeQzZHrYBP7mN7/ZtOHDv738jx27dv7o/v+UBLm1rYPjOElWSwrLw7kRgYOyKAHI6ZaupWw1FBAEwaa0palRYC6HQMpyQqqfIgwY62xtoczybBNj4MixQ35/IBaLmUbGshweI8umBUX537nz9sbDR5559Z9TJ0997q9/njh5EgUMAcgAhSOCLO60K7Svr++999679dbbRVl4/tlnhEhlTOUQdZt7+mN5hbH8sKIorkuSumHbtuUwkcN50Zy2rs5jRw4FK2fJhWNTqX5JVbXEEG3cU1BUKPqUhqMNHR1t3pLx+Xw8wpZDMCcpGHORMpDsa2tv+nDzlisuuKA4/8Pm9vZX/7n8F5N/BigDpyTPuFEnPNlfuXKlIImXXnrJ+vXvH2/uClbMddJNpuXEYnk+SY5Eot29vWjs/IqqmZijDQNZmB2yevZ393Tmzbh4zPmXi7F8O5uxEe7v6rIjeUbr7lRioLx47IQpkwf6+6O50fo99clUStP1wsJCBggM5ksQp4Z6dtXtWzh/3rxZM19b9W5dXV1HZ0dpUQlgDAA0ciWe5Gt7ySvbtuvq6mZXV0cikXfeXgn9OZgDTnYga5GgoiKEIGMUSrGScp8i5gSVSDAUCQYlR7MIU4srbdvuPFi3/vH/atv9kRzL4/OKwhAEJKW8ctzcuXO/dNFFNTWzx5x3HmU2zwu6rruE2N0N6ri54VhBX1//gYOHZ06f7pelxoaGA/X7AaQUMHYy06cJEBobGxuOHZ97/vz21raDhw8Fcsv5bN9QOiOKSklZKQAAIORoqfp/vbDllccPrHpx919+1rn6uaCAGINDfa02hxs3rY0f2di2/V1Dy2T6e/MEgKjb2dOdSCQsw+rs7BgaSECIRVFY+KULoCC7+qCrp/lgIXDJ3gMHw7k5ZSUFyVRq06ZNACDIRqnpU5gGAPT390uKPGnilLo9uzIaRNR29YRm6Ln5hQXFhbZtA8Aslx463tzdFZd40HD0wNFjTW0WoqbOB2KEkyu+fHPpRTdWfvluIKp8pOCowRKWOamiIhgIuJAW5OeqgYDruslkStfMgpx8x8po3U1SIF+QYXt7p2lYE8ZVaKbR1t6ZSqUgRqO0xUl62ovMFixYMH/+fF9Q3Ve/G/ljghzK9ux1CY6Gg/G+fhewVCoViwRmlBcbxO7t7MvNzYlFQyJGPA+N3lZT8atF48qv+iYT/Iahwda9IsQ8z+/YWdfdE0+nhiBG6VRWlvy2Yxw+fLioqIiXfHp/gxCqVcPFyYHegYGhSZMm/X35ysrKiX6/nzEGwad7ea7rYgy3b9+alxdDkGtvbIZKEFkDhmFgXuiPJzCGPIaJjMYzCJgJHbOjI+vzqY7NOjo6CovHxDv26/3dRkkz0DMsmBM2Bljzbl0JMRd293R297RD4OlcFAxEAMTptBYK6YrkG0plkw07OOJAiJvbOy67eCG1LY5DCGPIAGUUjlAin4D2coorV765ffv2e+65Jzk40J/UxWzCxT7TtAHgIYcpIAzgnvbOQCw6ZuJ4XTMdxyW2RSkIhgJ6yogFwxktld+2FbpuU6PNfLJOkGRpocJwODeMAaMUUAgIsTuamijjLDubTCYRpgw5rkE4URRFvjfeV1Radsc3bnlx6XN9fX2/fvi//QF1pIR8Atqbx9Gjx88//wK/P9Dd3ZnNJgEhrgEM0xZEATKHImhkMxWTJ9/3yE9CAR9FCDJEHXtwaEAWpaajDdlEhnIolYjLnDxPFDVNS8QHZs2fWzym2HYcCABFkDGmiNLql//51MO/sh2ntbGxYuI4DDnKCIRQFMVsOiMr/vsffED9059//4c/fGXJdQsvWMAYOA3T3ilRFDHGlmW5ruu4lAFIASOOhXiFMExty2X4hru/OdDVBUju3p11sbzc7Zu3bt28ubRkzPd+cn8slvPq0r9t2fSRGgzd9YN71y5/q66urqe3647v3u3z+QRZMnWN5wSG4FfuvO34kaMrXnlZkn0YQwgxhcRLUHlOqezzl5WVYQwd2wUAMeaeRnt4dYZ0Oq1pGsYYQgwZggwAylyKXEoYJYRQUeaGhgbefmuVpuvvrvrX/n31e+rq/uvhhzpamrdv+Gj7xs1r31n73f+8r7+jc9O6Dw8fPvzTR365b9deRNnxY0f/9vRSPZXd+tGm5cv+wRgMRgMQUJeYPIcAANAlEADOy6ohxPEiYdR1XYQ4cHKaD41iurS09MnHn2hubPL7/YIgENNwGaGUuKZj27brupZhR3Ki37nve/l5eVXTqwuLi+acPz+ak1Mzb8702TPzCgtq59VG83Jr5s8rLi4UeeG91Wsrp0zAolA5YSLm0YvPPb9nZ92MubMBcM2siYBYXFLGYQEiHBo3G/ICY8wfUAOBgGMarU3NAAJZ4sDJQdcnoL33cscdd9x+++3r1q0LRKJ+iSehchQqg4BktGxFRYUkScSyecwxxrKa5rmOsixrpiHLMnVIIpGQfYrtEkGRPAFta2lRFEVV1aP7D6aTqcmTJ7uO09feBQC2HFv2yVOmTKOMQMGvhEp4nncJyysooJR861vfevnV12+7/fZJkyZ9KujhccsttyQSCUBJQUGeIwZReKxPki1dJ4TKso8wCiHECKVTqU0bN7Y0NTcfPW4k09s3b8no2uH6/Q1Hjtq6Ubd958F99WXjzrvhGzd3tncAAM6bWMmLQktb69jx43bt2nX00EGJwzmhCHNd0zSxP2plB3kEKSPTpkxrbGzc8OGGn/78Fy88/0IoFBiV3RsNmjH25soVu3fvtgxzUtVUs/uI5VJfKOZQp7Ozs7g4nwccxMiFiFI6vaamcsqk9vb25/74dPXMmpra2VOmTs0mUkt//+epU6aMHT9u15Ztf3z8yZpZM13X3Ve328xqAb/a2dpmmmYgHKJQyCsooMDNappSWAlcg2NEkuWp06bsqdsrSkpuXh4A1HXdUbWY0caF4zhVVeMD/U1NTbNmz+Gfe4m4tqjGfD6uubnxvIpKBkHjwWOlpaX5BQUXLLpIEITF115t6sbU6mlHDhwMhEMLL1uUTqerZ86QfMqXFl1CKZ06u2awL97f0zdj9qyS88oP7tlXWFai+hRHMyrGj+vqbjcIUhBvp/so4IqKc0uKCrds2xqORJqaG+CJ+GXk+GQGXnIWADB16tRIJLJx44aqqdX5hYFUTweIlEYjsXRycO+uXQTAt//xum1addt3NB9rMC0rHI3MOn+uHPCnhhKZTGbWgnkXLLqopaEpHA5PnTVjYtXkvLy8zs7OCVMmMcZ6Ojp9qn9K9bSPVq/f/uEGXdd6ezuF3HHYTCA3qxMyZ84cQ9f37dsXi8XGnVcBADqR7T4Z9HA6xwNdWlpaUVGxbdNm4JLFl16Z6awXRH8oFBE5GB/q5wDs6eh85IGfmKZ58RWXaYlUYWFhIj4gStJgX39qYCibyRBCfKo/mJvT3dZhGAZjTFXVhiPHTNPkeX76zJq3X3596e+eSutaOjWYsEF4wpzsUJeIeQnz11x19fvvbRhMDJWUlNTW1oLTpUdPBGEnoHslyiVLlhxrbNi0eeNXv3ZjRBGT+9/NZtOI411bS6fTkMM7PtxkpDKCLJWNOy+TybQ0NZuGYThWJD+3rblF4gVCXdswDU0/sLde17S0liW2nc1mRUWWZHn98re6ejpnzZ5+rLFJT2et5r283mfazuzZ08rHlL7y2uvBQHh6dXVJSRk4XWA1Wk97n7W1tUWFJc8/+3wslnfbrTd19HQPDSVdRgC0LTNt26bf73/6kcdWvfIGY5DnueramelEYsqUyYVFBdNmTBcEnuc5nyiNHV9RO39OfnGJLAu1C+YXl5RhjH90212767ZVV1cPDQ0NxvuplU41buN5niJ46x3ffP+DD/bt21daXDZ3bq0o8i7zqo/uSNCnSdZ4+mX16tV//tMfbrzxxsuvuOKWW259//0NatCPITJ1gwIWDsWICzACY8aP50URYg5jjDgMAOA45BhW1shEo1EEOegSwqggCY5DZFk4VFd/9Ojh2bNqksl0T0+Xz+czbcsn+3lBWHzFZQ888MDXvrakpaXjpptueuSRh0+UQ0czfRLo4Ss8j6+1ueVvLz5/y+13mKZ+45IbjrU0qGpQ8Qfi3V0Y8z5/EEHOSCYCtVfgwlKSTli2YSLMBD/ubbPDeY6AsJYFSGACR1JJtmcDsBI+OVA9Y5ooC7t37SHElNWAIvoFgYuEgy8sfXHbjs3f+ta3f/nLh++//35R5D8razp8dvg3hBADdP/BA9FIKJlMhsPhX/3qv79x512O7fZ19ymK37asVGpIkWU5GLCPbaHHdyqqP0dRSkpKCNUslYh4yHWgCczOto6saVDT5kTgyx9bXlRg2vbhI0eAwPnlMHEszoc4UbjnnntycqORcBBCqKqqJAkeceDTsqandjdQSjHiuru7V7/zzoyaml7DLCwtC4ej3e1t06ZVZQ2SHOzVbN3UdEIdDsscICZ1p0+cePklC4dSaV5EHC9GgqFEIvWb3z4GtKwkCcHcfEXmunt7mpubAQCBYNjikc+vQkBvvP762tradDoZCgWDweAHH3xw333fO1U9fwJ6JPmfOKwcBwC4+66716xZ+49XX7nphptcAufMrIFza++77wd1dXVP/+HxTKeNOegSYjlZyFzOFHfu3LZnTx0FDDLA8zxjDGKEsOsPqTyHEkN9cZdoWWNsxXkP/vih1oYjr61YYenavNmz5s+dlcmkMENP/M/vksnklVde+dlV0NF5j+FBKUEIvbhs2VVXX1FeuuXCBQstQ6+aXGtqhp7KFBUUNza1lY8tozbp6umFSLBsYyDRxaDIQQ5CBCGFHIaUOQwAaPOQGz9uUnNbK3XTd9x+Z8XYMltLzJ5eU79/b1lZSTabFXnplVdeefvd9d///vfvuuvOk6WCjnI3PjU/jRBHCAmHAs89s/SBH/2gtKSkatqUvy19loeopflYQ0ODaWiTxk8KhENHjhwZGBgAjBmmo2lpCKgNAGSIg8gfDhTk5uXn50fC4enTp/9l6fOZZGLbti2lJUU9fb2d3R2UEkBcyzTWr13z9AtLl3z1hieefBKcqVZ0hpKcV75IpRKr3nxD4PmVb6/Zsn0HQigUCvlVZcumzUXFpdXV1ZzIjS0ewyAIhUKHDh8OBoOiIg/1D+TGYn3xuCL5EqnU7t27h1KDiqJAl/jVICdKbW0t58+eveTqxelU4s2318xbcPGj//PIsDf3OUGzE81gGOOhwf7XX3m5uKiot69vcHAwPy+vcsKEPfsOvrb8jV179rqu4/cHcqM5Y8vLEsmkqqqBQKC7uzeVzXR1dXmWPOAXKsdNmFk9LRqOHG88lkwm83JzqyZNFmRpy0cf+XPynv7LX8AJMJ+zJDc8GYwxpTQSjamq2tbUkJNfEA6FGGOtLc0Txo3505O/a+vo2lm3a1/9gZaWlu11u1zX9VrFJF6QZXlMaWFBXn5FaenUaVMKi4qCaohSOm/+HE1Lm5qZGBoYGBo81tR09fQaCABxCCecuX/sbFsnGAATJk/51/JDgOMDPlWSJEmSs5q5c807Bbmxyy++8KvXXmU7TiqVSSQShBAKAY+gLMsBxaeoftcliaQWiUWASzVNowwCyDFB9AXDLW2t3X1xr5voLLvFzqqg76VJxldOjOQVyIIIGbNtO5QTXb/hw6d+/+dIJBLLyRlXMaaifGxhYX4oFJIkCQGo61Zv/0Bvb29Tc2tLS0tjU8ukqilP/e5RkVFBEEKRHH9ANfTs/v31ffGBnJwcBgDDXxBoxhiEjFKmqmrGsI8fO3b1VdeqwVAwHN658zHCqE1ZU3vH8eYmAN6HGAmCwCHMQeQ4juu6FnEw5mVBVBT5YP3+FSveuve7/8txSTAYHBoYfG/92g82bXNd16/4IADw7NrtzlxmhhAC8LGfNXfe+dc++vixpq7FV166ZMmS6hnTN23bDpjLQ8BLEkAQQQ4wBiFyAeVEgafMh30YIYHjGQSmYza3d+XkxtrbO5e/+cY/Xvr77r17MBL9fn84HAZnDfoztQcAgLkQ4hPFJcoYuvyKxbt378YYl5eXW5Y1ODgYjUZN0ySEeLzSE5EGhBDznMLLogAQxyuS3NrWEYvFFl9x2cYtm9tb2gVBAJiztKxJrA3r36uaOpWdqT3lzExDAADE4EQ5zHUZxmDO3Nn76vdEI9GBgQGvliwKnCyFeB4P98h6D/a+QggxhrZtAwTzC3LjfQMr33pbkqSioiJCiKZpCcMIBoPhcBgCwM6ue+1TmT7VJnl+9v6DB665+jrGGGGUUgpcCiFkwIUQchzndV15BxBgxhhgjEHqui4hxDIdxpiiKJ5a9KbU1tY2ZsyY+n17VFU9y768c+gW86peU6dUXXft1f9avSaqqo7jWJb1ceaJuKZue8deQd/rLUSMeiGzl7vJz8/nBSxzIocFjPHQ0BBDMC8vz+fznQXFZwJ92ml4r+Xmm29et26dF9xLkiSKoigIAI1uHfiENoYYY5iDuq4jBBRJJoQAgBijCCFV8RUWFnpdWl+knh4JhVJaU1Mzd975Gz/aEAwGiQN0XXepQ5yPqR2O7Uf2bHihPkQMMsBjAQCIMSKEYARc183PzwcnxO/fEo/PwA0A+N69321qPJ5OpwVBwBhD9HFjPQJw2BX2mmK9WponvoyxTCajKJJ3CWNM13Vd04qKisC59E9/HtC2bVdVVS1e/OWHHnpIkmXGWDQa5ThuuCl9JM3eNw8Nz3Guy1pbOwkhmpaxbTsUikiyXFFRAUZJ1OcD/VmBA8cBAGbPmaX4fAzBbEaz430cRBBCiNgIkwQAABBg76Q3JUPTdV0HAACIg8EgA0BV1XHjxoFz2dfwOdvrPWT33nvvhg0bFEVJJpOm5Xh226Gf9CQPt+eM9Bn9fr/P5/PLCs/z3d3dqqpu37YlEAiMXAOfPT5P//Qw6AcffLChoSEej4dCoUAgUFhYSAjhed6rsBJCLMvy+/2WZXmvnjFmWVYikfDcXcpYNpu98sorA4GA57Wf5dM/5z4XeGL3Sjwef/bZZ+vr67PpjGGZCKH8/HzLsgBAjDFCiCyLHlyO45LJ5ODgoLc9QxRFRVF4nn/66acrKyvP2F/674IeHsPtUZTSRCLR2tra399vmqZpmrZtE+oSQphLh7cwQAi9duVAIFBRUZGTk1NQUHD2BH8xoMHJu2vAOW5oGqVnzv6hX8A+FzBi58Kof4Nw9P8P33U2Aeynjc+5EEeNYbN39gZieIya/Nncfs4bGdjJAfOp1I667IxjlMdyNrf8H+A3ZdvUfUQnAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAe0klEQVR4nM17d5hV1d3uKrufs0+dM70wODC0gYEBhiJKVCwYa0g0aiz5YtTkmvjlidHcL818xiR+xpJmoqISE1tQEIMIqIh0GMrQYXqfOVNO3X3tte4fW8ZhQAHjvc9df5xnn332Pvtd7/6tX1+QMQb+PxiMMQih93nGi9G/85izvMA7+IzrzwkxAAB+Dqa9W059AGOMUuqd9z49HJRShNCpuCGEZ4nyCwA9EiWE0HVdAABCaBSCU5k77RlKKcb4tL9+YaBH/vUwhQBQAJCu6319fZqmAQBc1/UAUUq9uzDGCCGMMcaYMRYMBvPy8nieP6enf07Qp6Jfs2bNgQMHent7+/r6EomE4zjDUxqWllGzdRxHVdVoNBoKhaqqqr797W+D/zdMezQ//uQTy5YtQwhZhs0Y4zjO495bWB54AAAAyJsAYwwhJIqiKPKMMQhxQ0PDyy+/fNFFC13XRQhAiM+IgTsnxODECiOEcBz37tr1v/n1o4FAwHEcn8+HMQYQUsa8iUEAKKUQIcYYABRCSBmDEKbSacuyOI4TBEEURZfS119//aKLFjLGIDwrbXbOoAEAHqMMgFWrVqmqGgoGIWSKooy8wPtECDEGAaAUfKxwvJ9yc3NNSycONU2TUrr/wAHDMGRZZoyNFJBPE5jPCRpC+Ohvf1u3a8fY8hLXdW2buK5LKT0hEh8rOMZsyADECHjqBSHHtkWBC4cCrutDHHYs+8hRvb2tpbOrZ1zF2P9bxsUT5fr6A2+99Zaq+gihrvvxqoAQYow5juM4hDHkOMRxHC9KHJYEQcKY5znZtokkSd4Mie0Q6kbCwd6+/taWJnY6RX5aDJ/K9GknPby2/vrXPxFCHIcjhDiOYxgGAZAR15Nn9vHwvjIAEKUEQkgpAIDyQgFxDZ5DCCEOYeIyl9itbR3wLKzsGUCfFrEnpitWrFi/fkM4HMxqBqUAIxAOhxFCPM97ZCOEEICeySCUua5DToyMltU1TZIEQ3cJsQHEjm0CiAf6+4YfcUYJ+SyZHnX/sNVdvny5JAm6YQFIIWQBNcRxPCFU101CbNd1qaflABUEgeMEnseCIEiSIsvi4GBC0zSMwxzH+f1+jDEhBDD36LEGAIBna86I+2z1tGfeEELr1q37j/+4Mycnp6pq8qJFi1566aXm5laEkEMoAJSNGAihE+IBEIQcz8uy3NbWdt/3v19ZWfnmm8sPHz5MGQQAdHd3A0hrps948MEHFy9ePMLQnjvTJ03uxHj19ddmzqy+9pprpkyZYuhWW1sbACCTzWqaZhgGZeST6wEGAAAMJF6SJElijBCq6/qCBfMvu+yy66+9ZtuO7Uuff3Hjxo2iKBqG0dcfX7Vq1eLFi8/I49kuRMYYgqi7q2PaxIllY0tVNWQatiiKOTm527ZvCQaCZcVFY88bU1RUFItEJUlAAJu2lUgkunp7Orq7Ojt6E4mEbhoXzJtbVlrc3NysKMqCBReeP2/+W2+vuvfeeyFiGPGpdBZ8utL4hMGzFw8AwEcbNyT7B6P5uT5F5TFGCDS2tjU1Nc2smV5aVCjIimVZhqXbpkMp5XksCJIsiLZtxuPxAwcOHGlovP7q60rGlOiaCRHjOCQqPoHjb1zy1Y1btkJeuOSSS9a9s/qMMn0G8RjpnhuGwfN8xaRJiiIxFxiGwQvC3No506qm1tXVrX537dEjx7u7unTDABQySCGEkk/JLyiaVHnerJoZCy++5BvfuG1gYCCTyUiKXxRFy7L0tJnU+6PhiORXHcexdOPUl3xuoEf6RhjjeDwezcl1HbJ7916M8eTJk3t6ex9/6o/vrl9nZDOyXy3KzysfW9HR1i4pcllJ6Tvr11aXlrU0N++u27n02efDsZwrL7v06zffVFE+ZmAw0dDSFAkGCguKh4hRVlQgSYJtE0IIOAvxOLNMu66LMU4mk9lsNh6PP/7EU+lUYnBwMJab397eyfP8rBk1eQWFoYA6NDCom0Z+YQGlJJVJcxyHGJg4vnLChKsETty0ZfPK1e/+c8XKa7985dFjDZqmmaZ5+WWLvvuduy+67NIPtm2rHzxi2Jb3uJHB0anEn8G4eH+xatUqjuMmTpy4bNmyCy+6eObMmctfe3XFyjeoC77+9ZtFUdy8+SNd13t6+kxT9+6ilAoit3Pndk6UGlsai/OKp1VN5SXxvffWLX3+xR//9Odza+esfPONp//yTGnpmBu+cvWtN339l79+LODze4hH2YdzYNrTl2+88cbevXvvvvvbx483ZrPZhRd+qX7vXlHgFEWBAK9ZszqZTCbSKcvMQoCYSwEEgCEAKcgAAABCYCDe2SAeO9ZwhLg2hqyouPi6a66v27G5YtyYUDT04YcfXH/dVYsWLdpXf+Bfa9+rq6ubOXOm67pe/HZa+f5U0J4cb926dd26df/7xw84jmPb9qFDh9745+s+2bd+7Tq/4kulMp0dbYZhAAD8algWZV6QIMSmY1NKiGXzAs5mMy4xDcNoaW7OicVyIrGOzs7nX3g2ElD37Kkz03pxcaki+12Ou+3WWw4fPf61G2/YuXNnTiT6GSb99CrP4ziVSt19990//OEPA341FAkue+nvj/72MQSZKIqSIvf1dKfSGQS5/LzCaF6BX/RlTfvSRQsifpVCAAC1iYUpWrbspfauVsQQhdQF1Kf4VH/YIrrASxBiTdOqqquefOy30UgkHo/v37XzgZ//4sKFl6x4c/knNDMATkZ+eqYRQoAB27arqiaHw0EAELHdHTt2QADKysqyWf348aOEkGhOQcX4CZFwHghGbMtiun6oM8H4tJEY8gdChqEBAJxoUUAOuK7rxDuJbRmGYdskJz+P4zhdNzketDQcf/jhR37+0M8oY5JPmVlds/a99S1trWPHlH8cqJ8C+/SgvSnGYtFwOOY4bk5O9Fe/fvitt9+O+AMDA/G2jk6X0JLiipLysT6fj1JXDsYwY2Y62WYQ3WJOyuShA5HP6m5DuaV+xUd1LTWUMLIpBLBDnXhvdygQtBxbkWRJEg4dOfzEU0/fc8fN/f39u+v31c6cNXZMGQNgOLUAAAAj5IQbBXT4IB4f+P3vn5wwYUJJSdHDDz/yzDPPRAIqpW4ikcKILyopLi4pmVUzzedTGpo7mvdslDjeF1B9jmvaVhhSOpjocihmJNvZkx7s6+/vr55dW1Qwd2goIfvELZu2phLpnNywovgppVomu3PrluL82MTyMn/AxxBsa2kvKy/1YpSPJeQzZHrYBP7mN7/ZtOHDv738jx27dv7o/v+UBLm1rYPjOElWSwrLw7kRgYOyKAHI6ZaupWw1FBAEwaa0palRYC6HQMpyQqqfIgwY62xtoczybBNj4MixQ35/IBaLmUbGshweI8umBUX537nz9sbDR5559Z9TJ0997q9/njh5EgUMAcgAhSOCLO60K7Svr++999679dbbRVl4/tlnhEhlTOUQdZt7+mN5hbH8sKIorkuSumHbtuUwkcN50Zy2rs5jRw4FK2fJhWNTqX5JVbXEEG3cU1BUKPqUhqMNHR1t3pLx+Xw8wpZDMCcpGHORMpDsa2tv+nDzlisuuKA4/8Pm9vZX/7n8F5N/BigDpyTPuFEnPNlfuXKlIImXXnrJ+vXvH2/uClbMddJNpuXEYnk+SY5Eot29vWjs/IqqmZijDQNZmB2yevZ393Tmzbh4zPmXi7F8O5uxEe7v6rIjeUbr7lRioLx47IQpkwf6+6O50fo99clUStP1wsJCBggM5ksQp4Z6dtXtWzh/3rxZM19b9W5dXV1HZ0dpUQlgDAA0ciWe5Gt7ySvbtuvq6mZXV0cikXfeXgn9OZgDTnYga5GgoiKEIGMUSrGScp8i5gSVSDAUCQYlR7MIU4srbdvuPFi3/vH/atv9kRzL4/OKwhAEJKW8ctzcuXO/dNFFNTWzx5x3HmU2zwu6rruE2N0N6ri54VhBX1//gYOHZ06f7pelxoaGA/X7AaQUMHYy06cJEBobGxuOHZ97/vz21raDhw8Fcsv5bN9QOiOKSklZKQAAIORoqfp/vbDllccPrHpx919+1rn6uaCAGINDfa02hxs3rY0f2di2/V1Dy2T6e/MEgKjb2dOdSCQsw+rs7BgaSECIRVFY+KULoCC7+qCrp/lgIXDJ3gMHw7k5ZSUFyVRq06ZNACDIRqnpU5gGAPT390uKPGnilLo9uzIaRNR29YRm6Ln5hQXFhbZtA8Aslx463tzdFZd40HD0wNFjTW0WoqbOB2KEkyu+fHPpRTdWfvluIKp8pOCowRKWOamiIhgIuJAW5OeqgYDruslkStfMgpx8x8po3U1SIF+QYXt7p2lYE8ZVaKbR1t6ZSqUgRqO0xUl62ovMFixYMH/+fF9Q3Ve/G/ljghzK9ux1CY6Gg/G+fhewVCoViwRmlBcbxO7t7MvNzYlFQyJGPA+N3lZT8atF48qv+iYT/Iahwda9IsQ8z+/YWdfdE0+nhiBG6VRWlvy2Yxw+fLioqIiXfHp/gxCqVcPFyYHegYGhSZMm/X35ysrKiX6/nzEGwad7ea7rYgy3b9+alxdDkGtvbIZKEFkDhmFgXuiPJzCGPIaJjMYzCJgJHbOjI+vzqY7NOjo6CovHxDv26/3dRkkz0DMsmBM2Bljzbl0JMRd293R297RD4OlcFAxEAMTptBYK6YrkG0plkw07OOJAiJvbOy67eCG1LY5DCGPIAGUUjlAin4D2coorV765ffv2e+65Jzk40J/UxWzCxT7TtAHgIYcpIAzgnvbOQCw6ZuJ4XTMdxyW2RSkIhgJ6yogFwxktld+2FbpuU6PNfLJOkGRpocJwODeMAaMUUAgIsTuamijjLDubTCYRpgw5rkE4URRFvjfeV1Radsc3bnlx6XN9fX2/fvi//QF1pIR8Atqbx9Gjx88//wK/P9Dd3ZnNJgEhrgEM0xZEATKHImhkMxWTJ9/3yE9CAR9FCDJEHXtwaEAWpaajDdlEhnIolYjLnDxPFDVNS8QHZs2fWzym2HYcCABFkDGmiNLql//51MO/sh2ntbGxYuI4DDnKCIRQFMVsOiMr/vsffED9059//4c/fGXJdQsvWMAYOA3T3ilRFDHGlmW5ruu4lAFIASOOhXiFMExty2X4hru/OdDVBUju3p11sbzc7Zu3bt28ubRkzPd+cn8slvPq0r9t2fSRGgzd9YN71y5/q66urqe3647v3u3z+QRZMnWN5wSG4FfuvO34kaMrXnlZkn0YQwgxhcRLUHlOqezzl5WVYQwd2wUAMeaeRnt4dYZ0Oq1pGsYYQgwZggwAylyKXEoYJYRQUeaGhgbefmuVpuvvrvrX/n31e+rq/uvhhzpamrdv+Gj7xs1r31n73f+8r7+jc9O6Dw8fPvzTR365b9deRNnxY0f/9vRSPZXd+tGm5cv+wRgMRgMQUJeYPIcAANAlEADOy6ohxPEiYdR1XYQ4cHKaD41iurS09MnHn2hubPL7/YIgENNwGaGUuKZj27brupZhR3Ki37nve/l5eVXTqwuLi+acPz+ak1Mzb8702TPzCgtq59VG83Jr5s8rLi4UeeG91Wsrp0zAolA5YSLm0YvPPb9nZ92MubMBcM2siYBYXFLGYQEiHBo3G/ICY8wfUAOBgGMarU3NAAJZ4sDJQdcnoL33cscdd9x+++3r1q0LRKJ+iSehchQqg4BktGxFRYUkScSyecwxxrKa5rmOsixrpiHLMnVIIpGQfYrtEkGRPAFta2lRFEVV1aP7D6aTqcmTJ7uO09feBQC2HFv2yVOmTKOMQMGvhEp4nncJyysooJR861vfevnV12+7/fZJkyZ9KujhccsttyQSCUBJQUGeIwZReKxPki1dJ4TKso8wCiHECKVTqU0bN7Y0NTcfPW4k09s3b8no2uH6/Q1Hjtq6Ubd958F99WXjzrvhGzd3tncAAM6bWMmLQktb69jx43bt2nX00EGJwzmhCHNd0zSxP2plB3kEKSPTpkxrbGzc8OGGn/78Fy88/0IoFBiV3RsNmjH25soVu3fvtgxzUtVUs/uI5VJfKOZQp7Ozs7g4nwccxMiFiFI6vaamcsqk9vb25/74dPXMmpra2VOmTs0mUkt//+epU6aMHT9u15Ztf3z8yZpZM13X3Ve328xqAb/a2dpmmmYgHKJQyCsooMDNappSWAlcg2NEkuWp06bsqdsrSkpuXh4A1HXdUbWY0caF4zhVVeMD/U1NTbNmz+Gfe4m4tqjGfD6uubnxvIpKBkHjwWOlpaX5BQUXLLpIEITF115t6sbU6mlHDhwMhEMLL1uUTqerZ86QfMqXFl1CKZ06u2awL97f0zdj9qyS88oP7tlXWFai+hRHMyrGj+vqbjcIUhBvp/so4IqKc0uKCrds2xqORJqaG+CJ+GXk+GQGXnIWADB16tRIJLJx44aqqdX5hYFUTweIlEYjsXRycO+uXQTAt//xum1addt3NB9rMC0rHI3MOn+uHPCnhhKZTGbWgnkXLLqopaEpHA5PnTVjYtXkvLy8zs7OCVMmMcZ6Ojp9qn9K9bSPVq/f/uEGXdd6ezuF3HHYTCA3qxMyZ84cQ9f37dsXi8XGnVcBADqR7T4Z9HA6xwNdWlpaUVGxbdNm4JLFl16Z6awXRH8oFBE5GB/q5wDs6eh85IGfmKZ58RWXaYlUYWFhIj4gStJgX39qYCibyRBCfKo/mJvT3dZhGAZjTFXVhiPHTNPkeX76zJq3X3596e+eSutaOjWYsEF4wpzsUJeIeQnz11x19fvvbRhMDJWUlNTW1oLTpUdPBGEnoHslyiVLlhxrbNi0eeNXv3ZjRBGT+9/NZtOI411bS6fTkMM7PtxkpDKCLJWNOy+TybQ0NZuGYThWJD+3rblF4gVCXdswDU0/sLde17S0liW2nc1mRUWWZHn98re6ejpnzZ5+rLFJT2et5r283mfazuzZ08rHlL7y2uvBQHh6dXVJSRk4XWA1Wk97n7W1tUWFJc8/+3wslnfbrTd19HQPDSVdRgC0LTNt26bf73/6kcdWvfIGY5DnueramelEYsqUyYVFBdNmTBcEnuc5nyiNHV9RO39OfnGJLAu1C+YXl5RhjH90212767ZVV1cPDQ0NxvuplU41buN5niJ46x3ffP+DD/bt21daXDZ3bq0o8i7zqo/uSNCnSdZ4+mX16tV//tMfbrzxxsuvuOKWW259//0NatCPITJ1gwIWDsWICzACY8aP50URYg5jjDgMAOA45BhW1shEo1EEOegSwqggCY5DZFk4VFd/9Ojh2bNqksl0T0+Xz+czbcsn+3lBWHzFZQ888MDXvrakpaXjpptueuSRh0+UQ0czfRLo4Ss8j6+1ueVvLz5/y+13mKZ+45IbjrU0qGpQ8Qfi3V0Y8z5/EEHOSCYCtVfgwlKSTli2YSLMBD/ubbPDeY6AsJYFSGACR1JJtmcDsBI+OVA9Y5ooC7t37SHElNWAIvoFgYuEgy8sfXHbjs3f+ta3f/nLh++//35R5D8razp8dvg3hBADdP/BA9FIKJlMhsPhX/3qv79x512O7fZ19ymK37asVGpIkWU5GLCPbaHHdyqqP0dRSkpKCNUslYh4yHWgCczOto6saVDT5kTgyx9bXlRg2vbhI0eAwPnlMHEszoc4UbjnnntycqORcBBCqKqqJAkeceDTsqandjdQSjHiuru7V7/zzoyaml7DLCwtC4ej3e1t06ZVZQ2SHOzVbN3UdEIdDsscICZ1p0+cePklC4dSaV5EHC9GgqFEIvWb3z4GtKwkCcHcfEXmunt7mpubAQCBYNjikc+vQkBvvP762tradDoZCgWDweAHH3xw333fO1U9fwJ6JPmfOKwcBwC4+66716xZ+49XX7nphptcAufMrIFza++77wd1dXVP/+HxTKeNOegSYjlZyFzOFHfu3LZnTx0FDDLA8zxjDGKEsOsPqTyHEkN9cZdoWWNsxXkP/vih1oYjr61YYenavNmz5s+dlcmkMENP/M/vksnklVde+dlV0NF5j+FBKUEIvbhs2VVXX1FeuuXCBQstQ6+aXGtqhp7KFBUUNza1lY8tozbp6umFSLBsYyDRxaDIQQ5CBCGFHIaUOQwAaPOQGz9uUnNbK3XTd9x+Z8XYMltLzJ5eU79/b1lZSTabFXnplVdeefvd9d///vfvuuvOk6WCjnI3PjU/jRBHCAmHAs89s/SBH/2gtKSkatqUvy19loeopflYQ0ODaWiTxk8KhENHjhwZGBgAjBmmo2lpCKgNAGSIg8gfDhTk5uXn50fC4enTp/9l6fOZZGLbti2lJUU9fb2d3R2UEkBcyzTWr13z9AtLl3z1hieefBKcqVZ0hpKcV75IpRKr3nxD4PmVb6/Zsn0HQigUCvlVZcumzUXFpdXV1ZzIjS0ewyAIhUKHDh8OBoOiIg/1D+TGYn3xuCL5EqnU7t27h1KDiqJAl/jVICdKbW0t58+eveTqxelU4s2318xbcPGj//PIsDf3OUGzE81gGOOhwf7XX3m5uKiot69vcHAwPy+vcsKEPfsOvrb8jV179rqu4/cHcqM5Y8vLEsmkqqqBQKC7uzeVzXR1dXmWPOAXKsdNmFk9LRqOHG88lkwm83JzqyZNFmRpy0cf+XPynv7LX8AJMJ+zJDc8GYwxpTQSjamq2tbUkJNfEA6FGGOtLc0Txo3505O/a+vo2lm3a1/9gZaWlu11u1zX9VrFJF6QZXlMaWFBXn5FaenUaVMKi4qCaohSOm/+HE1Lm5qZGBoYGBo81tR09fQaCABxCCecuX/sbFsnGAATJk/51/JDgOMDPlWSJEmSs5q5c807Bbmxyy++8KvXXmU7TiqVSSQShBAKAY+gLMsBxaeoftcliaQWiUWASzVNowwCyDFB9AXDLW2t3X1xr5voLLvFzqqg76VJxldOjOQVyIIIGbNtO5QTXb/hw6d+/+dIJBLLyRlXMaaifGxhYX4oFJIkCQGo61Zv/0Bvb29Tc2tLS0tjU8ukqilP/e5RkVFBEEKRHH9ANfTs/v31ffGBnJwcBgDDXxBoxhiEjFKmqmrGsI8fO3b1VdeqwVAwHN658zHCqE1ZU3vH8eYmAN6HGAmCwCHMQeQ4juu6FnEw5mVBVBT5YP3+FSveuve7/8txSTAYHBoYfG/92g82bXNd16/4IADw7NrtzlxmhhAC8LGfNXfe+dc++vixpq7FV166ZMmS6hnTN23bDpjLQ8BLEkAQQQ4wBiFyAeVEgafMh30YIYHjGQSmYza3d+XkxtrbO5e/+cY/Xvr77r17MBL9fn84HAZnDfoztQcAgLkQ4hPFJcoYuvyKxbt378YYl5eXW5Y1ODgYjUZN0ySEeLzSE5EGhBDznMLLogAQxyuS3NrWEYvFFl9x2cYtm9tb2gVBAJiztKxJrA3r36uaOpWdqT3lzExDAADE4EQ5zHUZxmDO3Nn76vdEI9GBgQGvliwKnCyFeB4P98h6D/a+QggxhrZtAwTzC3LjfQMr33pbkqSioiJCiKZpCcMIBoPhcBgCwM6ue+1TmT7VJnl+9v6DB665+jrGGGGUUgpcCiFkwIUQchzndV15BxBgxhhgjEHqui4hxDIdxpiiKJ5a9KbU1tY2ZsyY+n17VFU9y768c+gW86peU6dUXXft1f9avSaqqo7jWJb1ceaJuKZue8deQd/rLUSMeiGzl7vJz8/nBSxzIocFjPHQ0BBDMC8vz+fznQXFZwJ92ml4r+Xmm29et26dF9xLkiSKoigIAI1uHfiENoYYY5iDuq4jBBRJJoQAgBijCCFV8RUWFnpdWl+knh4JhVJaU1Mzd975Gz/aEAwGiQN0XXepQ5yPqR2O7Uf2bHihPkQMMsBjAQCIMSKEYARc183PzwcnxO/fEo/PwA0A+N69321qPJ5OpwVBwBhD9HFjPQJw2BX2mmK9WponvoyxTCajKJJ3CWNM13Vd04qKisC59E9/HtC2bVdVVS1e/OWHHnpIkmXGWDQa5ThuuCl9JM3eNw8Nz3Guy1pbOwkhmpaxbTsUikiyXFFRAUZJ1OcD/VmBA8cBAGbPmaX4fAzBbEaz430cRBBCiNgIkwQAABBg76Q3JUPTdV0HAACIg8EgA0BV1XHjxoFz2dfwOdvrPWT33nvvhg0bFEVJJpOm5Xh226Gf9CQPt+eM9Bn9fr/P5/PLCs/z3d3dqqpu37YlEAiMXAOfPT5P//Qw6AcffLChoSEej4dCoUAgUFhYSAjhed6rsBJCLMvy+/2WZXmvnjFmWVYikfDcXcpYNpu98sorA4GA57Wf5dM/5z4XeGL3Sjwef/bZZ+vr67PpjGGZCKH8/HzLsgBAjDFCiCyLHlyO45LJ5ODgoLc9QxRFRVF4nn/66acrKyvP2F/674IeHsPtUZTSRCLR2tra399vmqZpmrZtE+oSQphLh7cwQAi9duVAIFBRUZGTk1NQUHD2BH8xoMHJu2vAOW5oGqVnzv6hX8A+FzBi58Kof4Nw9P8P33U2Aeynjc+5EEeNYbN39gZieIya/Nncfs4bGdjJAfOp1I667IxjlMdyNrf8H+A3ZdvUfUQnAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXPklEQVR4nO2aaYxl13Hfq+os9769X2+z9KzkrKQ4XEakRFOSYZGKLCeyZTsBYwQIEiAIEOiDAwdC8iGwgXxIDCRwgCQOFEMREiQ2lA+xEEoGDVGRBImiRCo0hxxyOMPh7D0zvb793eUsVfnwevaFQxqmY4SFBvq9fqfv/d16/3NOnapCEYG/akZ/2QAfxD6C/rDsI+gPyz6C/rDs/UMLgAAAX3t73UfMLAAiwiCTMXLrsFvfvk9739CCAHjDW5ENPhYgIpCIiAQYBUQEJ4h4DVXghit8GNAILAACNEFAYERkhsiAGN+5mH/xK3/y9/71D49cGikkRGS5hojXqPkOl/+LgQYhnNweJ/cmL0BEiuCPX+388j9/4acvn/rbT279o/8z+ncvdRiEkKNs6ESQAQCR5c85l+QDGYuIRGZ2LMLCIr/zX45u+43ntvzKH/7pS2dF5M2V4ql//86X/+js8qBkkRCFQ7zun+MdL30Phu87YBKYeJgRNIsQrq4V//A/vPLSG4OaiX/wW4c/98Q2RiHAr/1k8B9fWN5qs3/x7I7HdrcBGIQiMgFBZFQf3NnvG3qiC9lQCC+N41e++safvXt5uprs3pz86qe3nro4OHWpW0tNzdJzPz1fm5lPlf+Fh+Yf2bP5gW2NXbPNP98k/EDQABCiHF3LL3TL44uDE5cHFy/1Rp1ePuy5cT4cOWMxQtBCYG0l9m17M4uO0Teqyaa55r5dm5/82NYnd7VnG8lfAPR1s/6617w4iN880T/fD2trozMnLpe5ywb9YtArs35SbUnIQ94P0aX1uZD33bhPSU0ZS4AYQ2QgozdtX3j88Qf/1qfvf2p389qEFhJkvLcJejdPCzAKCQKIICIAfOd09sLpXn8Y1i4PF0+ej8gmsaBNvro6WL+gbS1pNMvuevCZTiohBCgzldTIaImMAAqDNQq8p7Q6d/+ef/Ls4c/vazMgTbQm97p+3+XJGK8sxgIIAC+vlH9yerS+XvbWx4G9qZlKoxkFfb+XtuqNqc1+uEyRdb0JqDkSoqKkxhzLUS8MO27UKUb9bDhwYZwo4NHg6y+cON31JBje525zR+iNpRQBAQh57Pg7p8YKJM+CqiZrF84Wg05jtm1BVGptbcr5XCVNTKqhGEM5jGUvjro+73E2CHm/LIZ+1A35uMyyrOTBONp6M8v91777DiDo90MMcLfxDEKAEAEU0LfPZavDOFjPkpRWLi7lg1EEGfd6/e4lcWHtrZeHi6+LG63+eC3EQlea9YVDSX2q0t49Wl1M2/Nlv4uxdIMVO7UTR90x4fLipZlNm156Y/zdQ5uf2T8TBQjpHv19R2gEAgQBJqB+we92XDEu01QPshIqlekdu8br3XPf/4YkSX1uT+f4D1v3HR6vXUTnZnZ9llBqu58oV8+qxpwe9ZVObbXF4iVXmoIr+rG72Fda6Zi0Zr/90uln9s8pZAAGRrgH8jt7WgAQRIhE1gL3RhEYsQLi1WDx7OkffnPz/sdc54LE4eLrz7f3HG4t7FczuzAGNCmXQzdYFpOMlk6LKN8fYGpHx55zw/WgNQA0dz4Se5dPvvbtfV/4+6eWWz9+p/vUvnaIohTei7PvPBHxSkxDeGEYLlzqRSXMevnYO8ee+8P5XQfc6unRuZ8VF475zoVi+R2hqJQhrQySMja4wC5XxFqJ0qiMpqSOHERE1VrN+x6tNtJKo3n0v//2+WOvfOvNVQbRCvHeAqn3mogAAHx+uSxCbDatKzyW3b2HD+N4+fKRF2zaoPpUbcsel418IK11KHPmoNEigngnIhGJmYFF64S0IkKiNOsu5/3lhSd+ccuhZ1bf+N6bx989ulQCcLjdKnLronxnT8sk7o0AdHopazSqTKbore99YO/hL/1NXxbaVlEB6ZRsSqZKHNmVSsD7kqVMSYxJQDSyC1KyEJsqcBTUocz6p47YdDpfPputnO6fe/u1//n7Ry7lIngrjVzZIu4JGlGABVF1CznTydOKvXzqfAgRUcpht7ntwMzuxyrNeVKK+6tpa0Yl1RBLEdEAIjgsY+4DgaMYNSqSoJRiZlQkXNg0URjXT/2Z6CRptNaO/uiV19+KiAQ3e3WD+Ma/3kUewIgAcGE9z1lrq1ZOvZ1gKUqbpLr9wAN2ZsE2ZgRKrCa6Ni9AxFEUCcT1Tv+zj+360qcf6I1y0goAnMsEzMRzsSyS5nzeXVTVaQnlws89i7b65k9+tOYFAAQEbieJ6+0u6/TG81wecuFKZgtlRhBjXpZY1mdm01q954u0vgUh2FqTUBhAE43H41//zMGnH79vYa791ulL755fSgwQo6BCpcUFXW2IiA8cy3Lzx34+adX2fvEfLy1dPnGp3LwjnRxvJg6+pg28HdmthgAIAgArWfROQuFivxujlN4pIZXoSr1mmvNJtcWuoFpbEIzCcjx65vE9Hz+4aTTOj5y88AuP7mYGCRGA0GgEBRJ1tZZOL0iMC4c+3dp5oLj0rjGJjAe/9/Vv/tev/wEBxhgnnr6Kfnt33tZYEABGJbPz2Wg8WjmTKpNW66hwNBxTWt9y8AmWUI47xjSIoMjy+7dPHbhvtj/O1wdFZzBOrP6Nzz1ceIeIgiZKEIS0sY2Z5/Y9XpvZWgzWRhdPCbuiuzJ29iv/8muvv/76RP1XcW+diHeUh0RWio4dO/bSW14ndtjtapvYmanhpWWsaJeH5tx8LzhXFJTU2Kau18XoltZ6//vF40WMwl6BFnCFC1pZjiWZCpFWSGXebU8/XmlNu2Lkeut53m0qPRyseF9uOvTXrbVXQW/FvRu0iKCicea+/E//FT3xD6a2bRv2ejZN3agoi6zVni+zftJqdM+XnPcIkKIC11dKDUbDXq8AjETEzBgdKmMQApPSCQGFKPWkKSL9S+dmdtyfd5a1ScWNfG9l7fKlTz31+MGDB5mZaCIBBiCQCKjuTR4Cy73uUq6zcWAAHnRckY07nbTZZCGTJMF53Zhm50iZSIAo/UHvUw/t/b3f+pV6av7Nb37pqYfvf/qT+3/3N381sBALk4pIgAy11vrbr5A1+WgQfIG6SiZJK43BhbfOH/mJSJwATxIVDAKoROK9QSMgc7XePv3810fLZ32UvNeN3ifGIohNdPfiRQKiShLQIJAb932IzWqya2EGUS3MNlrNamoqW9tNABZwiArQoDL56oUYBlL68dpFOzWNEm29bed2Ub765vG3z1/sRCAGwQ2+iU7u0dMAuxdmfvGXf627sjS6eFzAuOCzQZ+VaK3H/Ww8GA87K4TGVqaD98KBAF3wziOQ9gGiK8ui8EEAOPqALEAqxlj2l9iHcrAKAL0zR1sL+8mXtfn78tI989c+16iltJHWYdxQCNyU3LkjNDMD2mgbtdmt1dmd5agXgwzXVtbPX3LOBcBYDAZnj+Wjrmlu4lCCqSIisBg9yS+wUgpRkopRKkEWRgRlJRYYXcz6lZmtvbNHKbpkeluR9atzu9yoJ9O7+qzwhsTZbQhvD42IhHRpFE+th0Nf+DWTtE/84AUCLAfL4DKljcvG5Xg0XD2tlPFuhDohVAyijEZUMUYBIp0KGRIQicBOgFinwBjd2M7uilr3F09M7XhQfIhlUZnZbhHe7MQXjg8EIeIVto3z3g2cd9P0bKIO7p6b2n/Ij9aG775sp2bjeFydnRXCkI+p2kBQAEFXZyEEASaiiBqFiAhESAG74IOgMqKqCrUxJkpAUK2dD3aOvaisMfM7x/2L2iqstpAqMO77qBFgI+16jeUePA0AwGINNKYq9Wbl3e8/hwiVuYXa7CbUFQ0cnWgkU5sFABHxUqqkoiptjl6QgRQjReaIQiQQSxERiaBScWV9x4Mo2D/zamvrvpCNwrDjS6dIUDOHcktbgwAJCTJvHKnvLg+57jdhFoIz9dM/+u7qO0dq03O12a3jznpwnskOVxfLUSedmlZJDXVCQsrWERlQsaD4QoK3hKIshCjei9KCjEqTTSpz96++9X1ETNtbR2eOMYjrr0jWjeUYGAfjjaAagehKnvWu0DeaUfrc28eO/q//HIuVmd2H6gv71y+eXD17fH3x4mjpbNpoAOrqpv0qbYJMEgHkyigcRKKLgQA5RDAoyCwBgEB0pTHfX3wzjLo6bbELZdklk4qyxeqZYvVi9/SrR8+sA/DG3rKxgNwd+oYhbBBWj73qhquk7NTeR1TMG1v2rL371nhtubGwa7i0OL1jT6U+LZp0xWBklAjCCgFRBUZALstSgUVEKYpYjHRrzsXgOpc9sHAYLp0wJjFJmkzNjRZPijLDM0fyGJ1jAAhXMN6Hp4UZAKqpij4opWpTC72TRyqJ2vLIz4/W11ZPvdGanc+GK6VDnbS4cKHIfT7y0fnIwBijEKFIZGKtEgQRiVhtpwsf1405Ga0pQFcMWFRldntjerOtVHV9Khv2UIK1hBsBBsG1NO17QSOAMALAnvu2i07FZZhWxFTIWOGgk2TnoSexNq+nDtT2fYJdWbpx9E6CDy5GBmAXYxQBQZLgmSMgGVsjQDRpuv3nzMJhIWxve7gYri0d/YGEqNtb0vpc6C8dfe3I73xr8WfnugAgwJMc/k1L3h2jPAYhgB1b5lFRohL2vXzlbCWx9UZa1mpZSSZtUYzDUydCcFCM2VgiEhFFgAgAbHTiXXAlAxnQgW0K2VB8QRVo7PxEnN/DPEhb82lrbvXsm/nKufqmbZw0WsXS3zi85Xuvndo/125UISIroZuivTufXAgBoF6t8Hjloc980oyWB53luUOP1rbvKzuF0YVzPuv1AICIfD400EBtSCtERKQQWBtyZaE02nrTMWqhUgQRmUh8nm4+CHkvO/6n2tqkOm3qLYXY3v+Zqe17P77VPL71AEOECe6VOsl7yAOuFHXIqkO//o/ydCFbvbjtsU+pTQ9kwWCSDnqjzuIiBzb1aUREhpj1gSyj1SZBBBHhECWWSJqUBiTvMtRaRAAVmZqEQtXnage+MOis9d7+YdqcVY1Ng0vvzD7wiIvAAgRqUiUDuc2OyAB8YzUQWECRAuCjPTv38C8lC/u2Pfn52gNP6alZIhLH5ahX9LuVVqPanmYGtEkMI5/1VFIxFpXSAASRhRARUYDITr46Dl4pY2wCqCSWyjaaB38pmqlysOLH3Vpr6tjJxa8+/yZNKn2TUy7evIDQ5AevFjWBZaOABX/8yuJ3v3/05Hf+R3Vmi975YCwdMoQQIojLCwGotaaUBim8aAJKQtYXX6a2wjoRZCQQRmARrZlQKUUqiTEiCqV1BBYRtCSazPwBau+zjQZ4WH333H/71is/O7UMiLyxCN+c3qOrFVUBARERJMAiwsuL+Te+9/alt17dtOcAtndkgwEjSASOUYJsnJOtjZFdtm7TlrYNinmZ9a02yqZApLUGICDUSMAsaCQGDRIFySaEOviS0BpSoCiKrd73KZWkHPKh52//4LiAIES4nelJvQeQCESQEOBCP/zu8xdOr0bkytz+w3s+8VBRFOxc8Bh91GRFcnalThtaa+99KEdmal7ZqijtXBElJEmCqLQmADRGATD7QpuEqAQU8CNla7HIwOXB1q1KbHWG8xGgThd2+sEwbUz/9I0z/eypdlVP6ho3pxAEr/qbgAMA/KfnT33nxTPo/fJSp9luMkdEFaOJXAIAg4ggoUajgwclwszAkdIKmopwACCtLaJCrZC0tRZilBBUUmVtGW0Y90gZL8AhiC9EBK2WxHrnTNousrKa1i4srx09vbah1lu28g254EZxGwHg2cfaC02Te6cIVLUuAqF0HCMIiUiZF4qStN2OMZb9QdJoEZH4Ak2qbMM7ERE0FhBJK9AGEYFDABClkZSpTiGqiBE4ciw5FCKitEXQwXllNBpdlCPv6bXj5661BNycFtvYJREAlFIM8aF989/4Z0/umUIwqdbEHBkItIoRy7J049KJTxtTqFQ2XK9Ot21S9cUQSOukCqZSlqVSChG11khaEYlEpQwAoJD3pW7MICjggD6IF+cz0QmZGnvv8iyMeggqac+cWlybCAFvaVqYyGNSWmEAQFAhyuaGPrS9CjZFjcI6xsiuDJ4JlC+DL4NNq4mx9Zm5vN8Xk3L0yILK2MYMMzOz1YkCrZRG0kohkRaJkA8wZPWt+4ADkJ3kChkIRaHWEHyM0WdZOR7ppF6IBQECFIk37YhX5TFZ/gABFAEgLI1CUrFcRobovYSCBcHH4MvcZ2VQkFRreX98+fg7je37SSWgSCUVZbQxRjh4Zq2NoAIViSyDp+CLfFDd9oBK6yHLgFBCABJNhCgKIMQijPrV2dlysFaWcX56ShAEAUHdFDDdZhtHRBEZ9EfGGJ9nqkzEBUEQgeiZg48+VGqbOoOeG+eVVqvSmi47S4iE2ggorTULxhittaSVAo3GKpVgFES0jbliMEBFMR+yOFRaUAEpJtakXdY11WlxWTbumGQ/AkMEUYj3eEa0GoIrc+fj2JWl8z54l+fDgcvGSSUVYVutIaIxibbGziwAIqoEEYnIKA0ARAQqNVZpZUCrQKCTik5qQIhgkEDbBlXaG8kklBgjAkAsTX0qDLtKIQCJus0x4DbQk42jkmgOUg5GZekhOBZ0mctWVkyljkqN+r1Ka87UGtGHIsuFydbaYJIoikCSJBFCIgKjNKFK6mBqBKxrbUFFRMGNVNpMZnaAz0lZVIbQRFcUaxcFlLYJMwszCESRWwsxd/T0I3tmA0cuMjfs+9J1zp2EyGDQ5YWLbEwSnK+0pgtX+lGGikBYAwYWIq2M9WxsakUQUZlK1aQNBKNq7RgFYhBhUJaSmtI2OO+G64JAxojLlbEMlCTJJ+9vAgLJ1aTePUB/7mPzW2cqtlUniOxzNxjGsmhs3hK8B+9CcPmoH50n1CGMASgIaa0zH2NAo6h0XLXJZGkXEQYyzRmdVCR4FtSqQjZBYDFWyCsyyiQ6ral6S5GEEPfvWfjso7thowWH4D01PZmIrar98uf32vrMePlM0Vmb2bHHOVdpTNmkkvf74/6AQMUiJyKIihmADOjERS0Kp6rVUZnXE3JASFpbAwCoLKEGZFQEFEUwCkMMKm3qxjQpY5Q1tRYKj138O59/RCmMKOp2nWW3WT0mmo4Snj44ffTwln/72ov3PbwHbTNJde/82Xx9BbQCVGX0UsYoBYGK7MmNmWHFpC++dsJAefLs6uZmvbO8eu5Sh1xW9pfJGNQJacPAIEYhsICq1sFHDpmY1FRqbtAfhMoXn973d58+CMAK6Upnwg2HgDu2TkzQs5K//NUXf3yyF8cu+sLlI3Z5HHVDORCXQTEORTeGTIUoHDgWAlHpRGuN4JMkGY6KRsW6Mi/LHIDIVkhXWCdKJ2QrSAaULsuc0KYzu9PpWT1aOfzox37/t5/dVDVMQCDCxMRK6PoI5O79HgAAwvzKiU63N+itXlpbXlnrd30+dmVe5kWZ5eNsmJU5lx6YI0QAZs8AEMEjolUpc9BakyGl1OR+KKAUiQhpZaii00p9amr7jr0Lu3c/emj//u3tyX3xinc3jrf3Ci0RNmoIdH2jzdWikzCULMFHDsFHjMwCUeKkG4yFEUQQBREn4w0pUkCEREBkQKFVhIja0PXx5w0FTxbAm0PTu7UDTa4TAYABkFEAkRCZAVEAgWHyPBu3kSuyYxG5KQ1+3ZpFV6+/UT4DQAEBYRCFdP1Hdyru373xalLy2KAHgUmb0dXLycQPkwHXJzknkRAz4sbXutFPd0Pgw4jqhtIbXOs7AgCQeNUp9w7NV469JCIIeOUL5Ktq2aC/7qkArj3QlddXJv71Arv2kgFg0sZ03X3ham4Jb1w33hMaRCKiEoFrAgOh6xqkNpw3ObDdeyfmJE9+s1BveBoBBhEEtfHkN2rlPfvyNvwtgneq6l037H19tNFudP18mBxIrsbJADBxmcAN3W8fpJnwL93+P+lU/3/APoL+sOwj6A/L/kpC/19XsFdsNksaCwAAAABJRU5ErkJggg==",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXPklEQVR4nO2aaYxl13Hfq+os9769X2+z9KzkrKQ4XEakRFOSYZGKLCeyZTsBYwQIEiAIEOiDAwdC8iGwgXxIDCRwgCQOFEMREiQ2lA+xEEoGDVGRBImiRCo0hxxyOMPh7D0zvb793eUsVfnwevaFQxqmY4SFBvq9fqfv/d16/3NOnapCEYG/akZ/2QAfxD6C/rDsI+gPyz6C/rDs/UMLgAAAX3t73UfMLAAiwiCTMXLrsFvfvk9739CCAHjDW5ENPhYgIpCIiAQYBUQEJ4h4DVXghit8GNAILAACNEFAYERkhsiAGN+5mH/xK3/y9/71D49cGikkRGS5hojXqPkOl/+LgQYhnNweJ/cmL0BEiuCPX+388j9/4acvn/rbT279o/8z+ncvdRiEkKNs6ESQAQCR5c85l+QDGYuIRGZ2LMLCIr/zX45u+43ntvzKH/7pS2dF5M2V4ql//86X/+js8qBkkRCFQ7zun+MdL30Phu87YBKYeJgRNIsQrq4V//A/vPLSG4OaiX/wW4c/98Q2RiHAr/1k8B9fWN5qs3/x7I7HdrcBGIQiMgFBZFQf3NnvG3qiC9lQCC+N41e++safvXt5uprs3pz86qe3nro4OHWpW0tNzdJzPz1fm5lPlf+Fh+Yf2bP5gW2NXbPNP98k/EDQABCiHF3LL3TL44uDE5cHFy/1Rp1ePuy5cT4cOWMxQtBCYG0l9m17M4uO0Teqyaa55r5dm5/82NYnd7VnG8lfAPR1s/6617w4iN880T/fD2trozMnLpe5ywb9YtArs35SbUnIQ94P0aX1uZD33bhPSU0ZS4AYQ2QgozdtX3j88Qf/1qfvf2p389qEFhJkvLcJejdPCzAKCQKIICIAfOd09sLpXn8Y1i4PF0+ej8gmsaBNvro6WL+gbS1pNMvuevCZTiohBCgzldTIaImMAAqDNQq8p7Q6d/+ef/Ls4c/vazMgTbQm97p+3+XJGK8sxgIIAC+vlH9yerS+XvbWx4G9qZlKoxkFfb+XtuqNqc1+uEyRdb0JqDkSoqKkxhzLUS8MO27UKUb9bDhwYZwo4NHg6y+cON31JBje525zR+iNpRQBAQh57Pg7p8YKJM+CqiZrF84Wg05jtm1BVGptbcr5XCVNTKqhGEM5jGUvjro+73E2CHm/LIZ+1A35uMyyrOTBONp6M8v91777DiDo90MMcLfxDEKAEAEU0LfPZavDOFjPkpRWLi7lg1EEGfd6/e4lcWHtrZeHi6+LG63+eC3EQlea9YVDSX2q0t49Wl1M2/Nlv4uxdIMVO7UTR90x4fLipZlNm156Y/zdQ5uf2T8TBQjpHv19R2gEAgQBJqB+we92XDEu01QPshIqlekdu8br3XPf/4YkSX1uT+f4D1v3HR6vXUTnZnZ9llBqu58oV8+qxpwe9ZVObbXF4iVXmoIr+rG72Fda6Zi0Zr/90uln9s8pZAAGRrgH8jt7WgAQRIhE1gL3RhEYsQLi1WDx7OkffnPz/sdc54LE4eLrz7f3HG4t7FczuzAGNCmXQzdYFpOMlk6LKN8fYGpHx55zw/WgNQA0dz4Se5dPvvbtfV/4+6eWWz9+p/vUvnaIohTei7PvPBHxSkxDeGEYLlzqRSXMevnYO8ee+8P5XQfc6unRuZ8VF475zoVi+R2hqJQhrQySMja4wC5XxFqJ0qiMpqSOHERE1VrN+x6tNtJKo3n0v//2+WOvfOvNVQbRCvHeAqn3mogAAHx+uSxCbDatKzyW3b2HD+N4+fKRF2zaoPpUbcsel418IK11KHPmoNEigngnIhGJmYFF64S0IkKiNOsu5/3lhSd+ccuhZ1bf+N6bx989ulQCcLjdKnLronxnT8sk7o0AdHopazSqTKbore99YO/hL/1NXxbaVlEB6ZRsSqZKHNmVSsD7kqVMSYxJQDSyC1KyEJsqcBTUocz6p47YdDpfPputnO6fe/u1//n7Ry7lIngrjVzZIu4JGlGABVF1CznTydOKvXzqfAgRUcpht7ntwMzuxyrNeVKK+6tpa0Yl1RBLEdEAIjgsY+4DgaMYNSqSoJRiZlQkXNg0URjXT/2Z6CRptNaO/uiV19+KiAQ3e3WD+Ma/3kUewIgAcGE9z1lrq1ZOvZ1gKUqbpLr9wAN2ZsE2ZgRKrCa6Ni9AxFEUCcT1Tv+zj+360qcf6I1y0goAnMsEzMRzsSyS5nzeXVTVaQnlws89i7b65k9+tOYFAAQEbieJ6+0u6/TG81wecuFKZgtlRhBjXpZY1mdm01q954u0vgUh2FqTUBhAE43H41//zMGnH79vYa791ulL755fSgwQo6BCpcUFXW2IiA8cy3Lzx34+adX2fvEfLy1dPnGp3LwjnRxvJg6+pg28HdmthgAIAgArWfROQuFivxujlN4pIZXoSr1mmvNJtcWuoFpbEIzCcjx65vE9Hz+4aTTOj5y88AuP7mYGCRGA0GgEBRJ1tZZOL0iMC4c+3dp5oLj0rjGJjAe/9/Vv/tev/wEBxhgnnr6Kfnt33tZYEABGJbPz2Wg8WjmTKpNW66hwNBxTWt9y8AmWUI47xjSIoMjy+7dPHbhvtj/O1wdFZzBOrP6Nzz1ceIeIgiZKEIS0sY2Z5/Y9XpvZWgzWRhdPCbuiuzJ29iv/8muvv/76RP1XcW+diHeUh0RWio4dO/bSW14ndtjtapvYmanhpWWsaJeH5tx8LzhXFJTU2Kau18XoltZ6//vF40WMwl6BFnCFC1pZjiWZCpFWSGXebU8/XmlNu2Lkeut53m0qPRyseF9uOvTXrbVXQW/FvRu0iKCicea+/E//FT3xD6a2bRv2ejZN3agoi6zVni+zftJqdM+XnPcIkKIC11dKDUbDXq8AjETEzBgdKmMQApPSCQGFKPWkKSL9S+dmdtyfd5a1ScWNfG9l7fKlTz31+MGDB5mZaCIBBiCQCKjuTR4Cy73uUq6zcWAAHnRckY07nbTZZCGTJMF53Zhm50iZSIAo/UHvUw/t/b3f+pV6av7Nb37pqYfvf/qT+3/3N381sBALk4pIgAy11vrbr5A1+WgQfIG6SiZJK43BhbfOH/mJSJwATxIVDAKoROK9QSMgc7XePv3810fLZ32UvNeN3ifGIohNdPfiRQKiShLQIJAb932IzWqya2EGUS3MNlrNamoqW9tNABZwiArQoDL56oUYBlL68dpFOzWNEm29bed2Ub765vG3z1/sRCAGwQ2+iU7u0dMAuxdmfvGXf627sjS6eFzAuOCzQZ+VaK3H/Ww8GA87K4TGVqaD98KBAF3wziOQ9gGiK8ui8EEAOPqALEAqxlj2l9iHcrAKAL0zR1sL+8mXtfn78tI989c+16iltJHWYdxQCNyU3LkjNDMD2mgbtdmt1dmd5agXgwzXVtbPX3LOBcBYDAZnj+Wjrmlu4lCCqSIisBg9yS+wUgpRkopRKkEWRgRlJRYYXcz6lZmtvbNHKbpkeluR9atzu9yoJ9O7+qzwhsTZbQhvD42IhHRpFE+th0Nf+DWTtE/84AUCLAfL4DKljcvG5Xg0XD2tlPFuhDohVAyijEZUMUYBIp0KGRIQicBOgFinwBjd2M7uilr3F09M7XhQfIhlUZnZbhHe7MQXjg8EIeIVto3z3g2cd9P0bKIO7p6b2n/Ij9aG775sp2bjeFydnRXCkI+p2kBQAEFXZyEEASaiiBqFiAhESAG74IOgMqKqCrUxJkpAUK2dD3aOvaisMfM7x/2L2iqstpAqMO77qBFgI+16jeUePA0AwGINNKYq9Wbl3e8/hwiVuYXa7CbUFQ0cnWgkU5sFABHxUqqkoiptjl6QgRQjReaIQiQQSxERiaBScWV9x4Mo2D/zamvrvpCNwrDjS6dIUDOHcktbgwAJCTJvHKnvLg+57jdhFoIz9dM/+u7qO0dq03O12a3jznpwnskOVxfLUSedmlZJDXVCQsrWERlQsaD4QoK3hKIshCjei9KCjEqTTSpz96++9X1ETNtbR2eOMYjrr0jWjeUYGAfjjaAagehKnvWu0DeaUfrc28eO/q//HIuVmd2H6gv71y+eXD17fH3x4mjpbNpoAOrqpv0qbYJMEgHkyigcRKKLgQA5RDAoyCwBgEB0pTHfX3wzjLo6bbELZdklk4qyxeqZYvVi9/SrR8+sA/DG3rKxgNwd+oYhbBBWj73qhquk7NTeR1TMG1v2rL371nhtubGwa7i0OL1jT6U+LZp0xWBklAjCCgFRBUZALstSgUVEKYpYjHRrzsXgOpc9sHAYLp0wJjFJmkzNjRZPijLDM0fyGJ1jAAhXMN6Hp4UZAKqpij4opWpTC72TRyqJ2vLIz4/W11ZPvdGanc+GK6VDnbS4cKHIfT7y0fnIwBijEKFIZGKtEgQRiVhtpwsf1405Ga0pQFcMWFRldntjerOtVHV9Khv2UIK1hBsBBsG1NO17QSOAMALAnvu2i07FZZhWxFTIWOGgk2TnoSexNq+nDtT2fYJdWbpx9E6CDy5GBmAXYxQBQZLgmSMgGVsjQDRpuv3nzMJhIWxve7gYri0d/YGEqNtb0vpc6C8dfe3I73xr8WfnugAgwJMc/k1L3h2jPAYhgB1b5lFRohL2vXzlbCWx9UZa1mpZSSZtUYzDUydCcFCM2VgiEhFFgAgAbHTiXXAlAxnQgW0K2VB8QRVo7PxEnN/DPEhb82lrbvXsm/nKufqmbZw0WsXS3zi85Xuvndo/125UISIroZuivTufXAgBoF6t8Hjloc980oyWB53luUOP1rbvKzuF0YVzPuv1AICIfD400EBtSCtERKQQWBtyZaE02nrTMWqhUgQRmUh8nm4+CHkvO/6n2tqkOm3qLYXY3v+Zqe17P77VPL71AEOECe6VOsl7yAOuFHXIqkO//o/ydCFbvbjtsU+pTQ9kwWCSDnqjzuIiBzb1aUREhpj1gSyj1SZBBBHhECWWSJqUBiTvMtRaRAAVmZqEQtXnage+MOis9d7+YdqcVY1Ng0vvzD7wiIvAAgRqUiUDuc2OyAB8YzUQWECRAuCjPTv38C8lC/u2Pfn52gNP6alZIhLH5ahX9LuVVqPanmYGtEkMI5/1VFIxFpXSAASRhRARUYDITr46Dl4pY2wCqCSWyjaaB38pmqlysOLH3Vpr6tjJxa8+/yZNKn2TUy7evIDQ5AevFjWBZaOABX/8yuJ3v3/05Hf+R3Vmi975YCwdMoQQIojLCwGotaaUBim8aAJKQtYXX6a2wjoRZCQQRmARrZlQKUUqiTEiCqV1BBYRtCSazPwBau+zjQZ4WH333H/71is/O7UMiLyxCN+c3qOrFVUBARERJMAiwsuL+Te+9/alt17dtOcAtndkgwEjSASOUYJsnJOtjZFdtm7TlrYNinmZ9a02yqZApLUGICDUSMAsaCQGDRIFySaEOviS0BpSoCiKrd73KZWkHPKh52//4LiAIES4nelJvQeQCESQEOBCP/zu8xdOr0bkytz+w3s+8VBRFOxc8Bh91GRFcnalThtaa+99KEdmal7ZqijtXBElJEmCqLQmADRGATD7QpuEqAQU8CNla7HIwOXB1q1KbHWG8xGgThd2+sEwbUz/9I0z/eypdlVP6ho3pxAEr/qbgAMA/KfnT33nxTPo/fJSp9luMkdEFaOJXAIAg4ggoUajgwclwszAkdIKmopwACCtLaJCrZC0tRZilBBUUmVtGW0Y90gZL8AhiC9EBK2WxHrnTNousrKa1i4srx09vbah1lu28g254EZxGwHg2cfaC02Te6cIVLUuAqF0HCMIiUiZF4qStN2OMZb9QdJoEZH4Ak2qbMM7ERE0FhBJK9AGEYFDABClkZSpTiGqiBE4ciw5FCKitEXQwXllNBpdlCPv6bXj5661BNycFtvYJREAlFIM8aF989/4Z0/umUIwqdbEHBkItIoRy7J049KJTxtTqFQ2XK9Ot21S9cUQSOukCqZSlqVSChG11khaEYlEpQwAoJD3pW7MICjggD6IF+cz0QmZGnvv8iyMeggqac+cWlybCAFvaVqYyGNSWmEAQFAhyuaGPrS9CjZFjcI6xsiuDJ4JlC+DL4NNq4mx9Zm5vN8Xk3L0yILK2MYMMzOz1YkCrZRG0kohkRaJkA8wZPWt+4ADkJ3kChkIRaHWEHyM0WdZOR7ppF6IBQECFIk37YhX5TFZ/gABFAEgLI1CUrFcRobovYSCBcHH4MvcZ2VQkFRreX98+fg7je37SSWgSCUVZbQxRjh4Zq2NoAIViSyDp+CLfFDd9oBK6yHLgFBCABJNhCgKIMQijPrV2dlysFaWcX56ShAEAUHdFDDdZhtHRBEZ9EfGGJ9nqkzEBUEQgeiZg48+VGqbOoOeG+eVVqvSmi47S4iE2ggorTULxhittaSVAo3GKpVgFES0jbliMEBFMR+yOFRaUAEpJtakXdY11WlxWTbumGQ/AkMEUYj3eEa0GoIrc+fj2JWl8z54l+fDgcvGSSUVYVutIaIxibbGziwAIqoEEYnIKA0ARAQqNVZpZUCrQKCTik5qQIhgkEDbBlXaG8kklBgjAkAsTX0qDLtKIQCJus0x4DbQk42jkmgOUg5GZekhOBZ0mctWVkyljkqN+r1Ka87UGtGHIsuFydbaYJIoikCSJBFCIgKjNKFK6mBqBKxrbUFFRMGNVNpMZnaAz0lZVIbQRFcUaxcFlLYJMwszCESRWwsxd/T0I3tmA0cuMjfs+9J1zp2EyGDQ5YWLbEwSnK+0pgtX+lGGikBYAwYWIq2M9WxsakUQUZlK1aQNBKNq7RgFYhBhUJaSmtI2OO+G64JAxojLlbEMlCTJJ+9vAgLJ1aTePUB/7mPzW2cqtlUniOxzNxjGsmhs3hK8B+9CcPmoH50n1CGMASgIaa0zH2NAo6h0XLXJZGkXEQYyzRmdVCR4FtSqQjZBYDFWyCsyyiQ6ral6S5GEEPfvWfjso7thowWH4D01PZmIrar98uf32vrMePlM0Vmb2bHHOVdpTNmkkvf74/6AQMUiJyKIihmADOjERS0Kp6rVUZnXE3JASFpbAwCoLKEGZFQEFEUwCkMMKm3qxjQpY5Q1tRYKj138O59/RCmMKOp2nWW3WT0mmo4Snj44ffTwln/72ov3PbwHbTNJde/82Xx9BbQCVGX0UsYoBYGK7MmNmWHFpC++dsJAefLs6uZmvbO8eu5Sh1xW9pfJGNQJacPAIEYhsICq1sFHDpmY1FRqbtAfhMoXn973d58+CMAK6Upnwg2HgDu2TkzQs5K//NUXf3yyF8cu+sLlI3Z5HHVDORCXQTEORTeGTIUoHDgWAlHpRGuN4JMkGY6KRsW6Mi/LHIDIVkhXWCdKJ2QrSAaULsuc0KYzu9PpWT1aOfzox37/t5/dVDVMQCDCxMRK6PoI5O79HgAAwvzKiU63N+itXlpbXlnrd30+dmVe5kWZ5eNsmJU5lx6YI0QAZs8AEMEjolUpc9BakyGl1OR+KKAUiQhpZaii00p9amr7jr0Lu3c/emj//u3tyX3xinc3jrf3Ci0RNmoIdH2jzdWikzCULMFHDsFHjMwCUeKkG4yFEUQQBREn4w0pUkCEREBkQKFVhIja0PXx5w0FTxbAm0PTu7UDTa4TAYABkFEAkRCZAVEAgWHyPBu3kSuyYxG5KQ1+3ZpFV6+/UT4DQAEBYRCFdP1Hdyru373xalLy2KAHgUmb0dXLycQPkwHXJzknkRAz4sbXutFPd0Pgw4jqhtIbXOs7AgCQeNUp9w7NV469JCIIeOUL5Ktq2aC/7qkArj3QlddXJv71Arv2kgFg0sZ03X3ham4Jb1w33hMaRCKiEoFrAgOh6xqkNpw3ObDdeyfmJE9+s1BveBoBBhEEtfHkN2rlPfvyNvwtgneq6l037H19tNFudP18mBxIrsbJADBxmcAN3W8fpJnwL93+P+lU/3/APoL+sOwj6A/L/kpC/19XsFdsNksaCwAAAABJRU5ErkJggg==\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "from IPython.display import display\n",
+        "\n",
+        "\n",
+        "results = search_images_vecstore('blue bag', index)\n",
+        "\n",
+        "for (img_idx, dist) in results:\n",
+        "    display(images[img_idx])"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Native lookup without vector store (it should be not as fast as vs)"
-      ],
       "metadata": {
         "id": "diWviyadHNbL"
-      }
+      },
+      "source": [
+        "### Native lookup without vector store (it should be not as fast as vs)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2rYXOdgtdKTi"
+      },
+      "outputs": [],
       "source": [
         "def semantic_search(query_embed: list[float], embeddings: list[list[float]], top_k: int = 5):\n",
         "    scores = []\n",
@@ -3195,18 +1126,11 @@
         "\n",
         "    results = semantic_search(query_embed, embeddings, top_k=top_k)\n",
         "    return results"
-      ],
-      "metadata": {
-        "id": "2rYXOdgtdKTi"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "x = search_images('blue bag', image_embeddings, top_k=10);x"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -3214,10 +1138,8 @@
         "id": "Xrxqumz7mhls",
         "outputId": "48a652f9-e48e-49e5-a6df-023b0bf58f40"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "[[0.22824887931346893, 4414],\n",
@@ -3232,19 +1154,18 @@
               " [0.1786075383424759, 1301]]"
             ]
           },
+          "execution_count": 72,
           "metadata": {},
-          "execution_count": 72
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "x = search_images('blue bag', image_embeddings, top_k=10);x"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "from IPython.display import display\n",
-        "\n",
-        "for (score, im_idx) in x:\n",
-        "    display(images[im_idx])"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -3253,118 +1174,2197 @@
         "id": "HLy-GjKxfylH",
         "outputId": "722aa524-bc88-4cfc-8c0d-a3c51be78dbc"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAIAAAC1nk4lAAAPe0lEQVR4nNVaW29c13Ve+3puM5wZzkiyrpQli7IsK22toKkkB65RBQiMPhRGC7QP/QdGX/oDGqSvLVAUaB8CA0UeCvTBNeK0RRALLQrLdmzEUWrHli1LtkiTIsXhZTi3c/bZt9WHTR4xkmVSopyiGwPizGBz7++s/a21vrXOIYgIj2horaWUAGCMI4RwRr0HSgEAtLFS8qIokyTa/UZ090tUg3MOAGVZck45p6NxThk4j6rUUnIASJLIez8cDne5EXlUllZKxXGc57mUknOO6AghxhjGGKUUABBJURRpmgKAMUYI8X8PGgC89wGf95YQ4rzhjDvvGGVlaaIoCgeLiISQ3Wz06OjhkQLx1qm8oIQTQrxFALq20vvZ2+9458pCA0JZKAKkLNRutnp0oAnRWiNinCS6NIB0OCj/4qW/PH/u9//xH17+sz/987fffgcAojhWRRHF8W62emSgtS5kFDHOl253GRO91eHf/s3fXXr9v7/1u89+76/++tkLz/3gBy/r0jhr4yQxZleWfmScXrm9OD8/3+2uxFFNa7O60o+iJJIxACzeXqjXM4+6Vst+67dPdzqTcZYBeXh7PTDoMJsAGOPAEyHp4tztubn5LxZuraysdLvd0WhkjCnLUilljIkjjohZVm81J5Mkm5hoTk9PP3Xq6f0HG0CgyFWSxgBQ5HmSphtLfx2gx6NRrVYLX968/LNf/c/7N2/eXFzuFkWhlEJExtid+V4b4yilQkTOekSyb9++w4enzl84e/78+fpEbTzKo0jwKgJ+HaABABEIgbI0P/7Ra2+++fbi4mJZllyyEMsopSHwhQt01hiDiISwoijH4zFnolarUYYXLlx48cUXjx6dAgLWGC6Ed45yti2ABwZdliaKxPz8wo9/9NqlS5e63e7+/QejKNK22LwldM5578M9CMGMMdZ67721XmtNKRVCUCCMsQMHDrz00kunT5/6mi2NMDsz/8Mf/tPly5e11u09HQCIosi5EhEDVgAghIQMIoRQSg2H48CcKIqSJJEyllwURQEA9Xr9+9//3qFDhzbi4A5AP4wLv/LKKz/96aVms0k5azQahJCyLLwH78E5tNZ7H1am3kOeK2s9AGz8SikAWKvX1tYajUYcx1rrl19+GRFLtdM4+MCgr3306X++fqnRaEgp6/X64uJiliUekBDCGBNCcM4ppYhorTXGqNIgUCFjGSVCxkLGlAnrcGJiYnl5uSgKRPzwww/feOONnWecBwb9+uuXEFEIsbraY4w1GvW19R4AFEVprQegjAlKOSEsfKSMhYgIYcY4pZS1FgA459ZaxpiUMhDm1VdfVUXhndsV6Irr4SL87Xa77/7i57kux8VIxkIIoZTOkho4JnhkjTfaAVJKOHoCSKWIvTOlyo1WjFBOhSmdVtZbcJ4kWerBjPIhodHySv/nv7hCOYbxkKArIRaWMMYAwNWrV2dmP2ecMMaMMYPBgHPuHSCiR0WoI9QBsZR5IQkXQCgiuvX1tW739mi87tFShkkq252mlGI0Gjjnms2m1uXS0tLs7Gxg/7aDf4WlCSGV2gz54oMPPnDOGIPD4bDRaMRRyqgoyzLLMuep1jZENyklIB2Pi9FolOe59z6J6+12u9VqEYpKqfX1dfQEADzaPB/1ev3RaPTZjZuc850Es/uC9t4zxqqTCqCvX7+utWq19iOOuksrExONNM0oZYPB0DuaZfXOvubkZGdysl3LJpxzRVFY6ycnm+12O8syLuhgMPj000+vXbu2sHhTSGKtWVhYKAqTptnNmzcB6KZQeCjQgR6EkGByRBwOh7du3UqSpNfroWcTE63JVicf21areeTIkWNHn26397Tb7TiOCWEAAEi99yGeWGtDVG7UDk02pk4+8c1L//Wv1298VOqx1ho9jeN4bm5uZuaLqanDDw86jM1KCQkhCwsLeZ4bYwD4RL0ZR7WT06ePHXvi+PHHGSeTzcNlWQ6Hw9XVntba+5ACreARpTRJkizLOJfeGwJ8T+ex71z8w16vd+OzXpplziqllHP2o48+2hXo4MWVvQFgZmamLMtGo7WyvF6vNc6fe376xKlOp8M4XVpauvzGvywtLd1amBsOh947RGetNbasZROIRMqo2ZicmGi2Wu2DBw7t379/ot45f+751dXlcb7OuShLwxj55JNPXnjhuw8PuiJ00BKc85mZmX6/X6vV2u3O6dNnnnnmmwT4eFxeufLeT37yH4QPAIALmtUFIcQjMialTEejnHOBvljrf7G49BkAi2QSRdGFb/3Rc8//3nu/eOv9DxYmJzt5nnvvZmZmtkX8VaCdc8H5yrKM4xgA3nvvSpbVAXmrceDZ8991hicZfe3f/vnKL99Na3Gj0cnzPIqiUhnBhTEGPAEfxZEI0i9NeFhWa2OMevXf/35m/sJ3Lr5w9erHziskI0rlynJfKZUkSYhaAcO9hfB943RgM2x2M9bXB/1+33svZXzx4kWtNRf0nXfefvfdd+v1uuDR2uq6Li0BFvJ5FEWUUqWK6qystUH9hQmPPfbY9evX3n//l1NTU/lYZWldCLG2tqKUgs3kUGHYqaWruBFAz87OLi8vO+eytNFu76EUbt9eeOuty1Es6vX6gQMH0zQty7Isy5s3P8/zPIqFjDihDhGCUwL6SvpRSqVk3bw3Nz978uT0zOw159A5dM6Ox+Nms1lJxQDmLmN/lfbYmk7n5ub6/T4ifuPM7wDQJEk+vf7x4u35AwceG4/zsCUiIYQIIYRkhKBzxlod1vHeu80R5OtomHc6k3k+rNfrhw4dGfRzpRSCy/O8urfKfDu1dDXbWss573a7xpgkSY4fezJN6krlt27NxgkfjYaIeHuxSxlYa6NIeO+FFM6ZgI/SO3e+qStIkKlRJLvd1aIYf+PMMx9fvVafiNfXN+jxpQbekaXDCBusrq4CQK1Wi+OaUlprvbK6lGWxNiqKonq9kSQRgNdaW2udReeQEJamtbtOLCwYqoG8GFlbKqWOH5smhKdpqo3K83wr4i8VT9vTI9zr2toaIjYajSxt6NIaY4bDPmU+TeOiKKIoHo9HShXeO0op5zwIPWt+DTHZMkJ8SLO43+83Gq29ew5QyoTg4/H4Xgx3Qd8edAh8o9EIEbMsQw+EkPlbc2VZcs6l5IyJUhnKgDJAcKF/4JxDROc8bLKi2jgUvMaYWi1ljCwszgsRTU1NKaW8t0qpqr68C8n2oIMlvLeUgvc+iiICPE0aCD5JRaH6qhxxLgeDnFIgTFtrAxQZcSAewXm0Ho33NtiYMiAUg49RSoAZpYBQ57EoC5hs7UEsvOGB0wGxMSZEvbuYfV9HDLOd88EwBw8eZIwNh0PnDBAMhxhimdZ6NBpVFqKUhtPfLArBe7xT7cKdqAdbQngIrISQoihCUQObKeJeS28jmDjnAcqRI0eyLIvjOBAyz3MhRGAnegxCKiSOsHegx+ahbTCEUkrJHct5740xBKAsSyFE2GirI1XT7soy9wVd9b0JIYTQxx9/PI5j7z0QTym11goRhcoKGGitGGOVs1ckDr+E/FL9tHHifGNysHSapuFrvV4P5nDOhUMLd7sj0AHx5l2Sw4cPE0J6vZ5zTgjOqCDAgp9RSp0znIsqcVTcCKYKaMM5IGxkcs4h5HNA4r2v1+uMMQLQarUqStyv974NPUIngHOJiEmStNtt7y2lstlsBtqFAFcZMlxUGoMQEiqRLZFrgwBoHKfOe+89McakacoY44y1Wi1rrRDifsJje9CMsdC+GAwGSZIcOXLEOQcEO50OYwJxQ58QimWpK1YES4fuh/cuTNtqOUQ0xgCzISxaaycaiRBCinjfvn2V7AmTKaV30Xob0LDhwrTSD6EqCc97Ah2DhtRaw5ZuWDW89wH01h/DNLoxkBCShBFne/furUgFmyTZqTR1aBG8cy7MiaJoPOovLsx+MX/NlDyJOknKSrPmPWrtjCmdRUBKgAFS9KS6AOQE2J2vm5bmwK3pEQSnCaVaCiF568DBvfDrmfhhtEcVECilQSIDAGNEShn8PUzw3hKKQHxIK9Xf6pfwqa6BbPQpA/WdM4zRNE3DAW47tgW90S3mnKZpaowxRhGKXNAkSUKPq4oVcE8WwC0DNjXq3dcEg+8Sgvv3798VaEJY9dgPAILM6PVWCzX23gJ4xmh4nIXogPitTnYv9LtuI2xtraWUeO8JxeGw3+v1pqendwcaCMIdFxZCxHG8tramdQHgAaAqn7z3AEgIAnhEh+gA/F3XAH7rBEKQEGatZ4xZqxmD1bXlwWD91KkndwUaACq/AQAp5USjZmzpUTMOAF4pxTkPQQW25JH7WmHLBEII4IafBX8YDvvtzuThw9s3PbYBvXVEkeh0OrVazVoN4BF8URRSys2Y+qUE+BIxXV2H5lPQBQCA6M+ePZvszBG/uty6g4NS2mg0JiYmtFHOOe9JUDno6NYG2r2W/tLIRQjxHgSPnCuDAOacP/XkmZ0ghq/kNFByZ1cAevLJp7iInMqMGY/HS5GIGKScEUa91VDp0qCcQt4BAHQUHfWWgGcUBCOSgkBHCcudN5QkjCZcEKDFH1z8dlXcPCRo2BS71SrHjx/PsqzUxeTkpFJqYWHBOUcpZFlWr9fDGxNVquOcSymllEKijEBIpMwC0YQaj0qbUZbVnXNSSin5+vraqVOn2p1OPi52ZWnYZB4AhAR+6NChZrPpnFEqVyqv1TPnzHg8TrMYAMKjlookQV0opazVIWI4ZwA8Y4RS8N6urq4KHjFGQp/yzJnTgDTNsp2A3r4ICCbXWidJcuLEic+vf4Hoxvmo0agXReGcQcQ4jj2SIEJgswgwxhhjOJebL4H4cALOubIsszQK8wlBQvDo0aNGa0opE9vHhvtrj015GRpqQV4/++yzcRIxDmtrK3v27Hn66ac6eyZD05oxUn04p1Ly8CEQEYgApXfcGqpL0CUYTcJ7QZzzEP4ppUJKxrcXcNtbGjYfCQT1PD09ffLkCWNK7+1oNLBO7du3z1pblmW73Q7WtdYGp+ScM8aOTT0Jm7p8Sy2D6/1VKbmU8vbSwp697a2P0x8edLXK1gqUc/7cc9++cuXKEyeO/fGfvDgYDG7cuNFqtaIoqtXrAFDhDoRWSqHbkNcI3vnQc6JCiPBfhRqmaXru3DnCAB0Q8igeM9/VbA15ZHZmZuroUQBA7wmlAGC0LpQKAQQ2+rl6NBqNx2NThqdHNlBZa80Yi+NYyhTA1yeSbvf22bNnhYgoFQBf21sIDzQedP1tgzT8BkB/HeNRvkz4Gxv/L0H/L/JG1d5HCpBSAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x60>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAIAAAC1nk4lAAAPe0lEQVR4nNVaW29c13Ve+3puM5wZzkiyrpQli7IsK22toKkkB65RBQiMPhRGC7QP/QdGX/oDGqSvLVAUaB8CA0UeCvTBNeK0RRALLQrLdmzEUWrHli1LtkiTIsXhZTi3c/bZt9WHTR4xkmVSopyiGwPizGBz7++s/a21vrXOIYgIj2horaWUAGCMI4RwRr0HSgEAtLFS8qIokyTa/UZ090tUg3MOAGVZck45p6NxThk4j6rUUnIASJLIez8cDne5EXlUllZKxXGc57mUknOO6AghxhjGGKUUABBJURRpmgKAMUYI8X8PGgC89wGf95YQ4rzhjDvvGGVlaaIoCgeLiISQ3Wz06OjhkQLx1qm8oIQTQrxFALq20vvZ2+9458pCA0JZKAKkLNRutnp0oAnRWiNinCS6NIB0OCj/4qW/PH/u9//xH17+sz/987fffgcAojhWRRHF8W62emSgtS5kFDHOl253GRO91eHf/s3fXXr9v7/1u89+76/++tkLz/3gBy/r0jhr4yQxZleWfmScXrm9OD8/3+2uxFFNa7O60o+iJJIxACzeXqjXM4+6Vst+67dPdzqTcZYBeXh7PTDoMJsAGOPAEyHp4tztubn5LxZuraysdLvd0WhkjCnLUilljIkjjohZVm81J5Mkm5hoTk9PP3Xq6f0HG0CgyFWSxgBQ5HmSphtLfx2gx6NRrVYLX968/LNf/c/7N2/eXFzuFkWhlEJExtid+V4b4yilQkTOekSyb9++w4enzl84e/78+fpEbTzKo0jwKgJ+HaABABEIgbI0P/7Ra2+++fbi4mJZllyyEMsopSHwhQt01hiDiISwoijH4zFnolarUYYXLlx48cUXjx6dAgLWGC6Ed45yti2ABwZdliaKxPz8wo9/9NqlS5e63e7+/QejKNK22LwldM5578M9CMGMMdZ67721XmtNKRVCUCCMsQMHDrz00kunT5/6mi2NMDsz/8Mf/tPly5e11u09HQCIosi5EhEDVgAghIQMIoRQSg2H48CcKIqSJJEyllwURQEA9Xr9+9//3qFDhzbi4A5AP4wLv/LKKz/96aVms0k5azQahJCyLLwH78E5tNZ7H1am3kOeK2s9AGz8SikAWKvX1tYajUYcx1rrl19+GRFLtdM4+MCgr3306X++fqnRaEgp6/X64uJiliUekBDCGBNCcM4ppYhorTXGqNIgUCFjGSVCxkLGlAnrcGJiYnl5uSgKRPzwww/feOONnWecBwb9+uuXEFEIsbraY4w1GvW19R4AFEVprQegjAlKOSEsfKSMhYgIYcY4pZS1FgA459ZaxpiUMhDm1VdfVUXhndsV6Irr4SL87Xa77/7i57kux8VIxkIIoZTOkho4JnhkjTfaAVJKOHoCSKWIvTOlyo1WjFBOhSmdVtZbcJ4kWerBjPIhodHySv/nv7hCOYbxkKArIRaWMMYAwNWrV2dmP2ecMMaMMYPBgHPuHSCiR0WoI9QBsZR5IQkXQCgiuvX1tW739mi87tFShkkq252mlGI0Gjjnms2m1uXS0tLs7Gxg/7aDf4WlCSGV2gz54oMPPnDOGIPD4bDRaMRRyqgoyzLLMuep1jZENyklIB2Pi9FolOe59z6J6+12u9VqEYpKqfX1dfQEADzaPB/1ev3RaPTZjZuc850Es/uC9t4zxqqTCqCvX7+utWq19iOOuksrExONNM0oZYPB0DuaZfXOvubkZGdysl3LJpxzRVFY6ycnm+12O8syLuhgMPj000+vXbu2sHhTSGKtWVhYKAqTptnNmzcB6KZQeCjQgR6EkGByRBwOh7du3UqSpNfroWcTE63JVicf21areeTIkWNHn26397Tb7TiOCWEAAEi99yGeWGtDVG7UDk02pk4+8c1L//Wv1298VOqx1ho9jeN4bm5uZuaLqanDDw86jM1KCQkhCwsLeZ4bYwD4RL0ZR7WT06ePHXvi+PHHGSeTzcNlWQ6Hw9XVntba+5ACreARpTRJkizLOJfeGwJ8T+ex71z8w16vd+OzXpplziqllHP2o48+2hXo4MWVvQFgZmamLMtGo7WyvF6vNc6fe376xKlOp8M4XVpauvzGvywtLd1amBsOh947RGetNbasZROIRMqo2ZicmGi2Wu2DBw7t379/ot45f+751dXlcb7OuShLwxj55JNPXnjhuw8PuiJ00BKc85mZmX6/X6vV2u3O6dNnnnnmmwT4eFxeufLeT37yH4QPAIALmtUFIcQjMialTEejnHOBvljrf7G49BkAi2QSRdGFb/3Rc8//3nu/eOv9DxYmJzt5nnvvZmZmtkX8VaCdc8H5yrKM4xgA3nvvSpbVAXmrceDZ8991hicZfe3f/vnKL99Na3Gj0cnzPIqiUhnBhTEGPAEfxZEI0i9NeFhWa2OMevXf/35m/sJ3Lr5w9erHziskI0rlynJfKZUkSYhaAcO9hfB943RgM2x2M9bXB/1+33svZXzx4kWtNRf0nXfefvfdd+v1uuDR2uq6Li0BFvJ5FEWUUqWK6qystUH9hQmPPfbY9evX3n//l1NTU/lYZWldCLG2tqKUgs3kUGHYqaWruBFAz87OLi8vO+eytNFu76EUbt9eeOuty1Es6vX6gQMH0zQty7Isy5s3P8/zPIqFjDihDhGCUwL6SvpRSqVk3bw3Nz978uT0zOw159A5dM6Ox+Nms1lJxQDmLmN/lfbYmk7n5ub6/T4ifuPM7wDQJEk+vf7x4u35AwceG4/zsCUiIYQIIYRkhKBzxlod1vHeu80R5OtomHc6k3k+rNfrhw4dGfRzpRSCy/O8urfKfDu1dDXbWss573a7xpgkSY4fezJN6krlt27NxgkfjYaIeHuxSxlYa6NIeO+FFM6ZgI/SO3e+qStIkKlRJLvd1aIYf+PMMx9fvVafiNfXN+jxpQbekaXDCBusrq4CQK1Wi+OaUlprvbK6lGWxNiqKonq9kSQRgNdaW2udReeQEJamtbtOLCwYqoG8GFlbKqWOH5smhKdpqo3K83wr4i8VT9vTI9zr2toaIjYajSxt6NIaY4bDPmU+TeOiKKIoHo9HShXeO0op5zwIPWt+DTHZMkJ8SLO43+83Gq29ew5QyoTg4/H4Xgx3Qd8edAh8o9EIEbMsQw+EkPlbc2VZcs6l5IyJUhnKgDJAcKF/4JxDROc8bLKi2jgUvMaYWi1ljCwszgsRTU1NKaW8t0qpqr68C8n2oIMlvLeUgvc+iiICPE0aCD5JRaH6qhxxLgeDnFIgTFtrAxQZcSAewXm0Ho33NtiYMiAUg49RSoAZpYBQ57EoC5hs7UEsvOGB0wGxMSZEvbuYfV9HDLOd88EwBw8eZIwNh0PnDBAMhxhimdZ6NBpVFqKUhtPfLArBe7xT7cKdqAdbQngIrISQoihCUQObKeJeS28jmDjnAcqRI0eyLIvjOBAyz3MhRGAnegxCKiSOsHegx+ahbTCEUkrJHct5740xBKAsSyFE2GirI1XT7soy9wVd9b0JIYTQxx9/PI5j7z0QTym11goRhcoKGGitGGOVs1ckDr+E/FL9tHHifGNysHSapuFrvV4P5nDOhUMLd7sj0AHx5l2Sw4cPE0J6vZ5zTgjOqCDAgp9RSp0znIsqcVTcCKYKaMM5IGxkcs4h5HNA4r2v1+uMMQLQarUqStyv974NPUIngHOJiEmStNtt7y2lstlsBtqFAFcZMlxUGoMQEiqRLZFrgwBoHKfOe+89McakacoY44y1Wi1rrRDifsJje9CMsdC+GAwGSZIcOXLEOQcEO50OYwJxQ58QimWpK1YES4fuh/cuTNtqOUQ0xgCzISxaaycaiRBCinjfvn2V7AmTKaV30Xob0LDhwrTSD6EqCc97Ah2DhtRaw5ZuWDW89wH01h/DNLoxkBCShBFne/furUgFmyTZqTR1aBG8cy7MiaJoPOovLsx+MX/NlDyJOknKSrPmPWrtjCmdRUBKgAFS9KS6AOQE2J2vm5bmwK3pEQSnCaVaCiF568DBvfDrmfhhtEcVECilQSIDAGNEShn8PUzw3hKKQHxIK9Xf6pfwqa6BbPQpA/WdM4zRNE3DAW47tgW90S3mnKZpaowxRhGKXNAkSUKPq4oVcE8WwC0DNjXq3dcEg+8Sgvv3798VaEJY9dgPAILM6PVWCzX23gJ4xmh4nIXogPitTnYv9LtuI2xtraWUeO8JxeGw3+v1pqendwcaCMIdFxZCxHG8tramdQHgAaAqn7z3AEgIAnhEh+gA/F3XAH7rBEKQEGatZ4xZqxmD1bXlwWD91KkndwUaACq/AQAp5USjZmzpUTMOAF4pxTkPQQW25JH7WmHLBEII4IafBX8YDvvtzuThw9s3PbYBvXVEkeh0OrVazVoN4BF8URRSys2Y+qUE+BIxXV2H5lPQBQCA6M+ePZvszBG/uty6g4NS2mg0JiYmtFHOOe9JUDno6NYG2r2W/tLIRQjxHgSPnCuDAOacP/XkmZ0ghq/kNFByZ1cAevLJp7iInMqMGY/HS5GIGKScEUa91VDp0qCcQt4BAHQUHfWWgGcUBCOSgkBHCcudN5QkjCZcEKDFH1z8dlXcPCRo2BS71SrHjx/PsqzUxeTkpFJqYWHBOUcpZFlWr9fDGxNVquOcSymllEKijEBIpMwC0YQaj0qbUZbVnXNSSin5+vraqVOn2p1OPi52ZWnYZB4AhAR+6NChZrPpnFEqVyqv1TPnzHg8TrMYAMKjlookQV0opazVIWI4ZwA8Y4RS8N6urq4KHjFGQp/yzJnTgDTNsp2A3r4ICCbXWidJcuLEic+vf4Hoxvmo0agXReGcQcQ4jj2SIEJgswgwxhhjOJebL4H4cALOubIsszQK8wlBQvDo0aNGa0opE9vHhvtrj015GRpqQV4/++yzcRIxDmtrK3v27Hn66ac6eyZD05oxUn04p1Ly8CEQEYgApXfcGqpL0CUYTcJ7QZzzEP4ppUJKxrcXcNtbGjYfCQT1PD09ffLkCWNK7+1oNLBO7du3z1pblmW73Q7WtdYGp+ScM8aOTT0Jm7p8Sy2D6/1VKbmU8vbSwp697a2P0x8edLXK1gqUc/7cc9++cuXKEyeO/fGfvDgYDG7cuNFqtaIoqtXrAFDhDoRWSqHbkNcI3vnQc6JCiPBfhRqmaXru3DnCAB0Q8igeM9/VbA15ZHZmZuroUQBA7wmlAGC0LpQKAQQ2+rl6NBqNx2NThqdHNlBZa80Yi+NYyhTA1yeSbvf22bNnhYgoFQBf21sIDzQedP1tgzT8BkB/HeNRvkz4Gxv/L0H/L/JG1d5HCpBSAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXtUlEQVR4nO16eYyd13Xf75x7v+0ts3KGy5AUd3HTZkqWrN22ZEt2G8Wt7TpOHBSJ26BxW6BLUBhFgSBAGwRJi7ZogcANnBpd4LhF4Ra1jMSyHDuVtdkWKVIUF5EUOZzhcPhm5s285Vvuvef0jzckh5TkOmmgxIDOH+99775v+d3znfs7555zSFXx0yb8Fw3gzyLvgX635D3Q75a8B/rdkvdAv1vyHuh3S94D/W7Je6DfLXkP9Lslq6B/uvYvq6CJ6C8Wx59KfprN46dLrKpesw0RGfy8NvKX02zobZegqg7G107gL48wIJBViBenL3/tq08fO3yOiJiYmCEqIkFF9epM/t80I+84otc+cNN9rulu8CUiXsI7cRqpKAghBGPM73/pf3776y+eXHjxk5/98FNPfKYZjUztGLvx2QxAEFSVlAEoiSqRQgmkAESVAGG2YFVVCqRGAWaBEhQMDT/m7ZEiULAcXZ/MW862SqCrthsja+fL/Wi2r2d/77/85isvnfvbf/Mf3nv/AULUaNTSzBqyaZoyDAhYvRPjhluaNao1IMBe/4euHenVy68dXD8WC/P97x0+/+bcRz/+wNh4M6g3dO0uAGAJgCgxQxFWzOzSqX/wxS9+/lO/eKU9/cSnf+bXfu2fjIwMLRULQ82xZq2ZRHFWT4eyoaxRS7K40WhYjsoq7+c5k4IV0I0bN0+sG10/uWHT1HpjqKjKyKRZlhARyECDtVaVajbuFTkRG8MA9fLckh1q1gXS7Ze/9S++9K2jv/9v6Lf/1i/8XYZRBXCdMOzgFRPMhfMLx189Eix/9OHHwDIxtuVTH/rVf/vav7amlpIWK77bbmUm6VTLCdVE1GuIjY1M5L0QEbMNWqmqc5WKkEGjPuTVO583szFlOFfW42EvBVmbcGoQixYA9yUPUhnhLGpQROpdHNVCqY898gnTnP/jF75x+96HR0frBL5GdFYBiFHWmdfe/FHPx/d+ZMvkOgkMhjXUq7rz7YtV8KxsFCvacSwwSiA2tlFrEBlAIAQ2LkDh0iyznBhEqhqTmKThxSeSxhQFVxHBlCbYKgQPZnWVhoINw2hRdvNOwZGte7/c7v3OF/5dqz/zqc//7K88+Zu/8Vv/mMwa8wDgGRHpD8cmvjW65efu2wwTuyAJsfooMjb3BQVRRCBjbZKKsrKIxCYhz8oI6jkQs0gIQVXgPWCMJyJVFUNGENATVVU1ZD31NCA1mQ95xNYF550zEsVUJyJyQQ0V2qs3bTa6xy9vPP/a4uGXj7/vvv3XNU0QowDxV2cKFP2Rsq2qRgXAQmtZEVuVLE4jm1m2IuKCMxSZOBLxToKIc8GRUmZTQmSYYkotWRFRdQFqhCR4S8xk2bDhLEhJpAAIEdRADRN57xLrgpSeTBTKqvKvnjz5xOMf2b1n22RzLMsyrKFFBsBgCCTv05FvjZ45ilUy4fbCRSmXVZzzhYTS+SJ4Z4lN8N51VUrn++pKVhF1Hp5VVCmIG5j4wDGRMrERGAreh1JDHsFGhIjYaBSzqdt6IxpOuOahqmSZXagWu7NvnD67eOVio+F9xIQb2QNgR4gIH8rmr/Tbr79+TgnGqANOjU21mxNNG1SoUFFxliwFIo69iuWaMZGGkpmNVKUPDv0ap7m4yvdFYCJbSaAk8WVBiAGBBqPKTAQl9FRMLVAFGBUnZRTIqfOVCIKg3LZzd78/f2BzFBa68A5rYgoLhVEPsp+cGvqToebhc6e+9txLn3ng3pmV7pF0Anse7fiiAwMEGCYYJQIi1BuAobynLEiHKM9JCtiIJWiUKgt8STAhjljtwCtpFKkI4hgUk4iJNXQ7IIuiYJ9r6BvHIYLCm35houHNW3dcmTt7+KV0397hfrN2A2glgAxE99559+TU5Obk5Pkf/Hs8cO/pdlh88xKrIdsILGRTsFFOiBOlYOJIlNUmJo4krVPcBZFAJW4OnAsRibHwTsTDGhIlIthESdg5jWNvLEXjcH1qmBAcqkJtpMFDScPpUBv63qnTx77+jO/UdMckbZ640TxUGSSscWY+9/f/2nPfPuVbZ//gm//xWb0HrgcmTZpMTkAEZksaPBkjykqCJAKnsEzNIQ0liTBBELTM2dZC6BEzub4EA2OULUIJDQpBsESV+tJy5lGRMqKUbKLGU1WpajQ59j/+0zeq40fHp0af3Dt3V41uNA8iVWUQIE985MPL7uzCy1/69T/4k5P1hm3WQmuebRYiw1KprYkwJ7FQxAYW7IhEPEoTIk8UETsh1aAAAntSq3BkU7Jg51Ug1lNkNRiCoHAQBNNjRGKZi1IBzmI4FfiUcHnucve2x/NN3SxbGlDHNdBMECICREBW8bmP//L2Ax8ZrnlV9pSqlqKOtFKwWjbECiYrGhkfxQSBKiIiJBS8lgEizGxsSogUjigVa+F8UCgJM8gkTKQqJssIXilSw6QiiUUUifPaaXFiXDzc3vtI9cBT/ZFbjM0AXhvxsa5uXphApB7gDz70BYNbYDUOaC5c1F6LPDiwURILqIcyopqyKpOqauk0eJSlphGRwoUQQdkTImIleE0Sii2yVASKIJYpSQMBNoJhWAYbcEpxRgi6comNcel6sUPozO+cnt61+4O4UZiuhrAEIbZBZWjDpp/7q08hjquZ83vKYvPKoi4vQn3o91QJcaRlgTInRIhiiqyJmDTARqzQICwOPhBZjSLxQQMTWfIgz8RWg5AynCoiTlMA6gLYssvRa9OVOc6v+GwkQ+e+oVef6nz57jjevvf9AJiv7wwtBvGgAkpKKmADLO/e/9DFN83s/MLZ+kZXLOt0p2u5XkfeAYYH/KCqg7gt1FL0e6ReyCCxPomp9EqAOkQKMMAaEaRAEI4yKXOyMYyVAGILCkqBAO13eOlcCGHvSOvJsZN37Gz2lrN1ex4HWETWgh4E9QoCmIjIqEBxajFfeW32qbvT9ZNVr5r//AOdB3dfkryjGkBBYwsjpI6EoAowcUxBEISUSaGGqXAkBEo4kMJBlWILV4rPqVaDsSRQy0gjxJYjSypatKXbGh4xj48dG2vqXNgkd/7ypz/5BOEGxKtRHl2Pw4WIlFACJ+b7vx7et+XApnDkhQztn93dvtgZeXN+yfgcJpVGDckIEkMmQdljlWAjGNayhAU4ZkbQAFVhJiZVowFo1IkZIhx8YEPw5EpBUBeiciUszSmjyfmrP+wYWf/cPe9/ZP+hL6iuxXfdpq/tIa4aNy6XZa0ed+3oMd51etfHprEt9FbiRHnn/VprivRReeoto7sieU5QKDEJMxtSqpQlqLUQJQkQr8QgouCvPTUQg1VhhQ0Fx8G53pLJW4htb7o3f36D0a0lzJkLl7wSgcON+86ralcodMAhUPS85aSJyhnti7XPLO6bXgkIbYGh5nqA0G8j9MkXpqrUi5Q9rbqad4MSEWlZinikCallZhN04DJYrJoYXqBkjIEqQZSM9Lu0shxYDVvbW0yH+WMfXXp0s7+46JaDQG/Ozthr2uVB6EdUqpYCI1BlLQpic0k2fv/Ewdhfot3eSzxalJUv+spic64ZtlAbcVUJPEQhYBfElVpGGhxYJalR2TcQJQOpqY1YWaqcgqN+jtKhfYXyJUobWpad3Q+9cvcHH0+/uSvu/3Ff+04RQYVpDfBV81ACwCACUAnyoi8i2mxwLaMkoiQ6PnTHwpWsOfs8vJPL07ta02nRhmRa9KTM0V5Q57hfUOU0rHILayBLIEN5j8WHKFIKJMLMakBEKB3AXK6gXFKjWpWSNd32uzC264Vi/0zLo9KOdwDkRlWvxqkD1hOCATyIvTdxAkhQJWNVfZVFl3bd/770+OT4d8+MlTIfbVs5TxtXTnU2+R7YIpSlUahVioOKkga1EUgIiTonRlEGjpLAjMpTnksWwQfkK+QKVYIqyh41NgQXx7PPF5dbZzcfwnh/uXqbZMOaKVz9NxDEB5BRMqtESEaglNV+hEOhoof3tmAW+yvzd2XHfum2kzW5EPKSfCGslrwGp75QceQrVE7LJahX57kq0S+59BoqTSJjLIJn1xPXRSioysFMMd2Xfuc3tn3rTpphnyJLjHoARt8J9FVxglBWwhYiliyKkpaXEAjekfpn3jz49Yt72zt2X0JUSLwhWvrswUU0akoGVd+7nCWoCMPAO3UVeSbnyJUIFUIfrsfdvqqIBK6qQEZDABvOhhCP3Df++sc2vLGxkS5S1B5uIE0NMSA3cd71bYxenUEAUFWqit6KrrQkiqn07EohMSJqZKHaugDGlpFjy28MzZ2t1WXElO3xLbRwTjstjRKCaFSnoqBaKk6IBRxBSGoxTKyGEQQKGKVKECVadQMiY3q7Rgui2rfbtz679e5uxLGlemwBVsXaLNN10NeCEGakijYbJKy1GgdIpJqXbJPgK3K5kUp7Jak7eSHjdjwZz+TJEtW3yZb9dOIlLXLElqAwrN6RjbVyFBlopaWSjYktEGtZEBMbBFVDJiCwtW9c8JcPx60DO5b2rqfC1erJkF2TOngr6GtiACNeNSBpKrU0Ti3VBSR5Tuhr6IU8hzioY+mdurL+8vIVN/GGrhtDurUWazpzYWF4k/aWTTIkYI4qFaPqJYERiAtKbCKPKAlqjKlT7KXsQuFgjp2JdnodK5fj+dly3ZYGUxYPeFjWWvI10NdHSQHxrpaQL2EjFHnodbVXoLwClyNUJErkNZCCJYmWarc2i0uxOdN67YK0ToyGwNa0TBxcYFOEokakqkp5U+OUXKkwmjU1ilB1pHTQHKGgMieOo15HN23bu2P2yKwpRzcONZOmIbo5w3qjpgUwABFIBWS0LDkv0O9rewH5CoqO+h6BVR2RJROJiaCVNkdWStqvZ3Zs6F8q8sX5aKxmH76v9sKl6NIZz1lfbMpaalkpjymDjEFvSeMIwaMqVEoS1WSIQl5M3XH4wZ8/uL21udtZUDNVs5YGBs3vCJohAJg5Lbu+KKlfSL9DeQ5XUP+KVn1SUfXMEdir64MFwVBCsNnxC7x5XNLhcnHJtbszO4a3bhm98pWVZGlBUfXVNsGqriAJiDKxlrxX5zRUYNJQwpAOb83X70SaPu+2NxrTqm6qZggSAIO3B81XPyWCxGXwAg0FeYEvUbRVAkSVGapCFhAmoxCQwJdEhixfXBwjSXWsXpbL33/98p4N0aE9u5/tPoHeBb14VE2dCLCRIhixwVgyqhIolGpqAKthdeD2hXJoouJRCrQxSyCDUsSNNr12wwhAVTMyDYYnpjLnbkfKJeRXEIShYhJSQWzBkVQFYEBBvVdWQ5aigNCgquspOjFLHLpdnNShB7Fln6YJTr+MOCMp4UOwOfsIGsgXYgxzrDZRtg+PPf/YVO/kzF1/OHqfSr4lBpigwM2aJhpksxVCgMBEwITrctdTtyPFCsplDqpk1HpECShiMkETcG5EBF5JoAhMDAKpRMMI/YX+5Otvnle6jPgZ9O/HUHODUFn5Jd/mKENRiIkJpOoRJWosNPrApukPjZ/dko6daphO8I3UbFuXAlCIgte6F7tGyQSQKhShxoVUufV9ljJA1cbQAB4CQFGM4AklURzUsfeklShQeTWJEiCOyMBmC+VGXjmjfASc4JyPi4XJaCJKZD4sk8kAUYBMpMzKUZLpremlvKy91Lvl6cVh31zeyLUdzVQhDKa1BYOrSfXrFQwoiIxJGAYUvIhD2UfoIxsyloLEWokQkYH4inxXXa5ERglSqgaAyBdKIEQSZyFd30xWbt385sJi0Z72RYF92+M7tzb/6EUHidkaEYEyKWVF58hz0abm9pfufnBxZYGsrB/2U7WIIIob/eH1jS0EOoioBTA7xkaRt5w4uC5v2IqxKQnJWHX63pHXrI1Pni4vXQAsuqHwUQ1stN8WYUgOw6oBsdVQIVjESUfXnZ2WDaOaD+Vzs2cfu2Xv/QfchTl36nwd1jPFQhT5/mTrsnFxb7Tuqh65ZdXGznrSAALYEG5eiDewBxMpATh0+zZ8781GK52oDS/BLs/NcZJeWfKn5mYObKZ1ppxzJiub6tzK7Q/q+Ba9+OrttcPB2NayXW5r0fMRSaiP6dBuXb601F9yvteNtkfbo+FM/9fM/unICh01GBMK8D1r0st7P3BlvPngxFznwowxdd/pR5WCARWA8Q48LUpMAIih4a7bDn5hxw8unD16bPZsuVzpgXvVNSKWzpVNRxc4GwpPPSWpSZbbxdPtcjmOdMsdsjJ3z8QKbzezM+2Xf1CFkBXV5ZKaNLwzS098aE84caJ6Y2Hpa6fuWBi9A5Mpzrwi84c1bmBoS3/nk7RpQ7pjvDz3H8KRF7Hj4G0PP/J3Pv0IBrWzt0TUdmDHOpiKYpD58FfO7tows3JPoz0z84FPfOzD9236vW/MnnMjl6u5ervlZ7nf00cf2tysmdrM8WWaMnHtdHv70tEfJs0ajW554NFLTY6rfueZcxeWagf76/d8w2b16tlx/5pr18bM+ZWQ/PVf/ext69Nmlv7v//PisL76hjsv7Q237dy2+x/ddc++/R++/Z7NY8O6utIEekPhb1D8lGvhnweMhqd/+J3PfrcMM4vJC1/++feHmOTbz1Lbj4Ywe2lqk8cwLVcbJ+ae3NxKk2GfDL30XGt2Om3Yyng3M3UbHdw3xq2R4fpwfiYpOmprNjFzx1u9E/3M5gt5MbZj5F/9zj83GH3xe8+UnW/v32WnZyna+jN/5RMfn6iNNGxCGPCcvG3Eb0EYsOAgMGGASF+niZXpc4de/dG43378+Pna6Ew2MlJ2lpbDOtPcG8b2kfPt7vwPzj1967rezq162/58pT3dxn6d2JGRa9FEv6Urr12qm9pWf/jRh2ppZKtD+lXlo/xQvGF7O/W/+MUvxyeO1OpbNq0bOXH5YjMZ/6Wn7t88tN76AFVPYvVmU34rewz0DgI08OXvnEZvvl4ve3NFu8j/xkO3pHeaVle/MruvDDvZFyLl0NFvdZ195dxIq9X9wH0Tn/vUxLF2+vXOPp9upXJJ6hnPH876K7Nm8vlXVh68z/ign3mk8Z8Pz0yX2yrb6O/9EPqXdi0enfd3fLf/+G8/tvfAvm1GhY0RUgsDlmvQbnLbFgqQABDQwHACuNk99892H0k29/5wtjN3du7pZ6YfuWe9in4wnP5vL9jQ2Itt98/VMDR3OE6mLr6weKVdfPjeW3bHrXvnfve5xbtpYrciXWzUkL+WqX/55SvtIn3/geZ4yB9IX/+v3z9qbn8qhN4Dt2e3RcO/e3LyV37h0S88+T6oMWCl1cL1dX+iuImnaVCAv06Eokq4MPv6f//qFy9enH329eap7sayPn5o+PymcGT2Is/PpnkROqPmzoP1HVn72IneicVJP3lwy9jyjvT0ueO9Tkv6Q0Pj28f2jyysr4dnXwkz8V1obFpHb24sXm63rO9klIUde7oP3ja5MPHw6MFP/tPH7qnFDWtudHy6io6uBhrXNU2DKs4g56uB2EB1amr/Bx/7e//yq195deoQNMNS90fHZl6fKYazKWjgZOHh7cXu9X65p2dlvBq/i2r185dWLp4vU8+58beOXrxjbFmz7Ngcz9hdGNoA+IWFTutcdzjbPLZu9MCdtUOHpvYcfPSu2x/ft2kj1A40t1afSiAwSAC9ybjfvkllMM+LKwt/9NrJbz5//Mz5+Xj2iG3nHkVUi7Ztx9T4SNaol/Fky22KYrOuTo3M5K0VVxVZM56YGI4B5cxHaSlWqmpyZGS0kVHlDWF8fHz9+o1DSaOWpPQWe/1J5B1Bi8ggv+rFtV3pXOmr4KExm0FoEZk4MTBWiSgoGUUURQpWIlIyRApE7/xgDzUg/OkR/zjQUASCBgUJQxWW1BGMQFeL3kqqCvKqyhSDhK72k1yv6DCreF3TQACAiaE3BZtXn/mTzeGdQa91RHrDClYIga/SDq+euzpyfc7A6s+b9xkQhZLyn7k76se1uPFgdQwSPCS6Cg40uIqwWnRSQBkQXT1n0MMzaP55az8ToMQw/z/9XD9O02ses9qoc02dejXns6bOBFWsDg2mN3hPa1T+5yU/BrQAWGMgGCyamzBctYg1QYJC17Tu6DsA/jOQxk8AWtfo7CdolLwZhCjobaLKPxf5v5UEEgSH728wAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAXtUlEQVR4nO16eYyd13Xf75x7v+0ts3KGy5AUd3HTZkqWrN22ZEt2G8Wt7TpOHBSJ26BxW6BLUBhFgSBAGwRJi7ZogcANnBpd4LhF4Ra1jMSyHDuVtdkWKVIUF5EUOZzhcPhm5s285Vvuvef0jzckh5TkOmmgxIDOH+99775v+d3znfs7555zSFXx0yb8Fw3gzyLvgX635D3Q75a8B/rdkvdAv1vyHuh3S94D/W7Je6DfLXkP9Lslq6B/uvYvq6CJ6C8Wx59KfprN46dLrKpesw0RGfy8NvKX02zobZegqg7G107gL48wIJBViBenL3/tq08fO3yOiJiYmCEqIkFF9epM/t80I+84otc+cNN9rulu8CUiXsI7cRqpKAghBGPM73/pf3776y+eXHjxk5/98FNPfKYZjUztGLvx2QxAEFSVlAEoiSqRQgmkAESVAGG2YFVVCqRGAWaBEhQMDT/m7ZEiULAcXZ/MW862SqCrthsja+fL/Wi2r2d/77/85isvnfvbf/Mf3nv/AULUaNTSzBqyaZoyDAhYvRPjhluaNao1IMBe/4euHenVy68dXD8WC/P97x0+/+bcRz/+wNh4M6g3dO0uAGAJgCgxQxFWzOzSqX/wxS9+/lO/eKU9/cSnf+bXfu2fjIwMLRULQ82xZq2ZRHFWT4eyoaxRS7K40WhYjsoq7+c5k4IV0I0bN0+sG10/uWHT1HpjqKjKyKRZlhARyECDtVaVajbuFTkRG8MA9fLckh1q1gXS7Ze/9S++9K2jv/9v6Lf/1i/8XYZRBXCdMOzgFRPMhfMLx189Eix/9OHHwDIxtuVTH/rVf/vav7amlpIWK77bbmUm6VTLCdVE1GuIjY1M5L0QEbMNWqmqc5WKkEGjPuTVO583szFlOFfW42EvBVmbcGoQixYA9yUPUhnhLGpQROpdHNVCqY898gnTnP/jF75x+96HR0frBL5GdFYBiFHWmdfe/FHPx/d+ZMvkOgkMhjXUq7rz7YtV8KxsFCvacSwwSiA2tlFrEBlAIAQ2LkDh0iyznBhEqhqTmKThxSeSxhQFVxHBlCbYKgQPZnWVhoINw2hRdvNOwZGte7/c7v3OF/5dqz/zqc//7K88+Zu/8Vv/mMwa8wDgGRHpD8cmvjW65efu2wwTuyAJsfooMjb3BQVRRCBjbZKKsrKIxCYhz8oI6jkQs0gIQVXgPWCMJyJVFUNGENATVVU1ZD31NCA1mQ95xNYF550zEsVUJyJyQQ0V2qs3bTa6xy9vPP/a4uGXj7/vvv3XNU0QowDxV2cKFP2Rsq2qRgXAQmtZEVuVLE4jm1m2IuKCMxSZOBLxToKIc8GRUmZTQmSYYkotWRFRdQFqhCR4S8xk2bDhLEhJpAAIEdRADRN57xLrgpSeTBTKqvKvnjz5xOMf2b1n22RzLMsyrKFFBsBgCCTv05FvjZ45ilUy4fbCRSmXVZzzhYTS+SJ4Z4lN8N51VUrn++pKVhF1Hp5VVCmIG5j4wDGRMrERGAreh1JDHsFGhIjYaBSzqdt6IxpOuOahqmSZXagWu7NvnD67eOVio+F9xIQb2QNgR4gIH8rmr/Tbr79+TgnGqANOjU21mxNNG1SoUFFxliwFIo69iuWaMZGGkpmNVKUPDv0ap7m4yvdFYCJbSaAk8WVBiAGBBqPKTAQl9FRMLVAFGBUnZRTIqfOVCIKg3LZzd78/f2BzFBa68A5rYgoLhVEPsp+cGvqToebhc6e+9txLn3ng3pmV7pF0Anse7fiiAwMEGCYYJQIi1BuAobynLEiHKM9JCtiIJWiUKgt8STAhjljtwCtpFKkI4hgUk4iJNXQ7IIuiYJ9r6BvHIYLCm35houHNW3dcmTt7+KV0397hfrN2A2glgAxE99559+TU5Obk5Pkf/Hs8cO/pdlh88xKrIdsILGRTsFFOiBOlYOJIlNUmJo4krVPcBZFAJW4OnAsRibHwTsTDGhIlIthESdg5jWNvLEXjcH1qmBAcqkJtpMFDScPpUBv63qnTx77+jO/UdMckbZ640TxUGSSscWY+9/f/2nPfPuVbZ//gm//xWb0HrgcmTZpMTkAEZksaPBkjykqCJAKnsEzNIQ0liTBBELTM2dZC6BEzub4EA2OULUIJDQpBsESV+tJy5lGRMqKUbKLGU1WpajQ59j/+0zeq40fHp0af3Dt3V41uNA8iVWUQIE985MPL7uzCy1/69T/4k5P1hm3WQmuebRYiw1KprYkwJ7FQxAYW7IhEPEoTIk8UETsh1aAAAntSq3BkU7Jg51Ug1lNkNRiCoHAQBNNjRGKZi1IBzmI4FfiUcHnucve2x/NN3SxbGlDHNdBMECICREBW8bmP//L2Ax8ZrnlV9pSqlqKOtFKwWjbECiYrGhkfxQSBKiIiJBS8lgEizGxsSogUjigVa+F8UCgJM8gkTKQqJssIXilSw6QiiUUUifPaaXFiXDzc3vtI9cBT/ZFbjM0AXhvxsa5uXphApB7gDz70BYNbYDUOaC5c1F6LPDiwURILqIcyopqyKpOqauk0eJSlphGRwoUQQdkTImIleE0Sii2yVASKIJYpSQMBNoJhWAYbcEpxRgi6comNcel6sUPozO+cnt61+4O4UZiuhrAEIbZBZWjDpp/7q08hjquZ83vKYvPKoi4vQn3o91QJcaRlgTInRIhiiqyJmDTARqzQICwOPhBZjSLxQQMTWfIgz8RWg5AynCoiTlMA6gLYssvRa9OVOc6v+GwkQ+e+oVef6nz57jjevvf9AJiv7wwtBvGgAkpKKmADLO/e/9DFN83s/MLZ+kZXLOt0p2u5XkfeAYYH/KCqg7gt1FL0e6ReyCCxPomp9EqAOkQKMMAaEaRAEI4yKXOyMYyVAGILCkqBAO13eOlcCGHvSOvJsZN37Gz2lrN1ex4HWETWgh4E9QoCmIjIqEBxajFfeW32qbvT9ZNVr5r//AOdB3dfkryjGkBBYwsjpI6EoAowcUxBEISUSaGGqXAkBEo4kMJBlWILV4rPqVaDsSRQy0gjxJYjSypatKXbGh4xj48dG2vqXNgkd/7ypz/5BOEGxKtRHl2Pw4WIlFACJ+b7vx7et+XApnDkhQztn93dvtgZeXN+yfgcJpVGDckIEkMmQdljlWAjGNayhAU4ZkbQAFVhJiZVowFo1IkZIhx8YEPw5EpBUBeiciUszSmjyfmrP+wYWf/cPe9/ZP+hL6iuxXfdpq/tIa4aNy6XZa0ed+3oMd51etfHprEt9FbiRHnn/VprivRReeoto7sieU5QKDEJMxtSqpQlqLUQJQkQr8QgouCvPTUQg1VhhQ0Fx8G53pLJW4htb7o3f36D0a0lzJkLl7wSgcON+86ralcodMAhUPS85aSJyhnti7XPLO6bXgkIbYGh5nqA0G8j9MkXpqrUi5Q9rbqad4MSEWlZinikCallZhN04DJYrJoYXqBkjIEqQZSM9Lu0shxYDVvbW0yH+WMfXXp0s7+46JaDQG/Ozthr2uVB6EdUqpYCI1BlLQpic0k2fv/Ewdhfot3eSzxalJUv+spic64ZtlAbcVUJPEQhYBfElVpGGhxYJalR2TcQJQOpqY1YWaqcgqN+jtKhfYXyJUobWpad3Q+9cvcHH0+/uSvu/3Ff+04RQYVpDfBV81ACwCACUAnyoi8i2mxwLaMkoiQ6PnTHwpWsOfs8vJPL07ta02nRhmRa9KTM0V5Q57hfUOU0rHILayBLIEN5j8WHKFIKJMLMakBEKB3AXK6gXFKjWpWSNd32uzC264Vi/0zLo9KOdwDkRlWvxqkD1hOCATyIvTdxAkhQJWNVfZVFl3bd/770+OT4d8+MlTIfbVs5TxtXTnU2+R7YIpSlUahVioOKkga1EUgIiTonRlEGjpLAjMpTnksWwQfkK+QKVYIqyh41NgQXx7PPF5dbZzcfwnh/uXqbZMOaKVz9NxDEB5BRMqtESEaglNV+hEOhoof3tmAW+yvzd2XHfum2kzW5EPKSfCGslrwGp75QceQrVE7LJahX57kq0S+59BoqTSJjLIJn1xPXRSioysFMMd2Xfuc3tn3rTpphnyJLjHoARt8J9FVxglBWwhYiliyKkpaXEAjekfpn3jz49Yt72zt2X0JUSLwhWvrswUU0akoGVd+7nCWoCMPAO3UVeSbnyJUIFUIfrsfdvqqIBK6qQEZDABvOhhCP3Df++sc2vLGxkS5S1B5uIE0NMSA3cd71bYxenUEAUFWqit6KrrQkiqn07EohMSJqZKHaugDGlpFjy28MzZ2t1WXElO3xLbRwTjstjRKCaFSnoqBaKk6IBRxBSGoxTKyGEQQKGKVKECVadQMiY3q7Rgui2rfbtz679e5uxLGlemwBVsXaLNN10NeCEGakijYbJKy1GgdIpJqXbJPgK3K5kUp7Jak7eSHjdjwZz+TJEtW3yZb9dOIlLXLElqAwrN6RjbVyFBlopaWSjYktEGtZEBMbBFVDJiCwtW9c8JcPx60DO5b2rqfC1erJkF2TOngr6GtiACNeNSBpKrU0Ti3VBSR5Tuhr6IU8hzioY+mdurL+8vIVN/GGrhtDurUWazpzYWF4k/aWTTIkYI4qFaPqJYERiAtKbCKPKAlqjKlT7KXsQuFgjp2JdnodK5fj+dly3ZYGUxYPeFjWWvI10NdHSQHxrpaQL2EjFHnodbVXoLwClyNUJErkNZCCJYmWarc2i0uxOdN67YK0ToyGwNa0TBxcYFOEokakqkp5U+OUXKkwmjU1ilB1pHTQHKGgMieOo15HN23bu2P2yKwpRzcONZOmIbo5w3qjpgUwABFIBWS0LDkv0O9rewH5CoqO+h6BVR2RJROJiaCVNkdWStqvZ3Zs6F8q8sX5aKxmH76v9sKl6NIZz1lfbMpaalkpjymDjEFvSeMIwaMqVEoS1WSIQl5M3XH4wZ8/uL21udtZUDNVs5YGBs3vCJohAJg5Lbu+KKlfSL9DeQ5XUP+KVn1SUfXMEdir64MFwVBCsNnxC7x5XNLhcnHJtbszO4a3bhm98pWVZGlBUfXVNsGqriAJiDKxlrxX5zRUYNJQwpAOb83X70SaPu+2NxrTqm6qZggSAIO3B81XPyWCxGXwAg0FeYEvUbRVAkSVGapCFhAmoxCQwJdEhixfXBwjSXWsXpbL33/98p4N0aE9u5/tPoHeBb14VE2dCLCRIhixwVgyqhIolGpqAKthdeD2hXJoouJRCrQxSyCDUsSNNr12wwhAVTMyDYYnpjLnbkfKJeRXEIShYhJSQWzBkVQFYEBBvVdWQ5aigNCgquspOjFLHLpdnNShB7Fln6YJTr+MOCMp4UOwOfsIGsgXYgxzrDZRtg+PPf/YVO/kzF1/OHqfSr4lBpigwM2aJhpksxVCgMBEwITrctdTtyPFCsplDqpk1HpECShiMkETcG5EBF5JoAhMDAKpRMMI/YX+5Otvnle6jPgZ9O/HUHODUFn5Jd/mKENRiIkJpOoRJWosNPrApukPjZ/dko6daphO8I3UbFuXAlCIgte6F7tGyQSQKhShxoVUufV9ljJA1cbQAB4CQFGM4AklURzUsfeklShQeTWJEiCOyMBmC+VGXjmjfASc4JyPi4XJaCJKZD4sk8kAUYBMpMzKUZLpremlvKy91Lvl6cVh31zeyLUdzVQhDKa1BYOrSfXrFQwoiIxJGAYUvIhD2UfoIxsyloLEWokQkYH4inxXXa5ERglSqgaAyBdKIEQSZyFd30xWbt385sJi0Z72RYF92+M7tzb/6EUHidkaEYEyKWVF58hz0abm9pfufnBxZYGsrB/2U7WIIIob/eH1jS0EOoioBTA7xkaRt5w4uC5v2IqxKQnJWHX63pHXrI1Pni4vXQAsuqHwUQ1stN8WYUgOw6oBsdVQIVjESUfXnZ2WDaOaD+Vzs2cfu2Xv/QfchTl36nwd1jPFQhT5/mTrsnFxb7Tuqh65ZdXGznrSAALYEG5eiDewBxMpATh0+zZ8781GK52oDS/BLs/NcZJeWfKn5mYObKZ1ppxzJiub6tzK7Q/q+Ba9+OrttcPB2NayXW5r0fMRSaiP6dBuXb601F9yvteNtkfbo+FM/9fM/unICh01GBMK8D1r0st7P3BlvPngxFznwowxdd/pR5WCARWA8Q48LUpMAIih4a7bDn5hxw8unD16bPZsuVzpgXvVNSKWzpVNRxc4GwpPPSWpSZbbxdPtcjmOdMsdsjJ3z8QKbzezM+2Xf1CFkBXV5ZKaNLwzS098aE84caJ6Y2Hpa6fuWBi9A5Mpzrwi84c1bmBoS3/nk7RpQ7pjvDz3H8KRF7Hj4G0PP/J3Pv0IBrWzt0TUdmDHOpiKYpD58FfO7tows3JPoz0z84FPfOzD9236vW/MnnMjl6u5ervlZ7nf00cf2tysmdrM8WWaMnHtdHv70tEfJs0ajW554NFLTY6rfueZcxeWagf76/d8w2b16tlx/5pr18bM+ZWQ/PVf/ext69Nmlv7v//PisL76hjsv7Q237dy2+x/ddc++/R++/Z7NY8O6utIEekPhb1D8lGvhnweMhqd/+J3PfrcMM4vJC1/++feHmOTbz1Lbj4Ywe2lqk8cwLVcbJ+ae3NxKk2GfDL30XGt2Om3Yyng3M3UbHdw3xq2R4fpwfiYpOmprNjFzx1u9E/3M5gt5MbZj5F/9zj83GH3xe8+UnW/v32WnZyna+jN/5RMfn6iNNGxCGPCcvG3Eb0EYsOAgMGGASF+niZXpc4de/dG43378+Pna6Ew2MlJ2lpbDOtPcG8b2kfPt7vwPzj1967rezq162/58pT3dxn6d2JGRa9FEv6Urr12qm9pWf/jRh2ppZKtD+lXlo/xQvGF7O/W/+MUvxyeO1OpbNq0bOXH5YjMZ/6Wn7t88tN76AFVPYvVmU34rewz0DgI08OXvnEZvvl4ve3NFu8j/xkO3pHeaVle/MruvDDvZFyLl0NFvdZ195dxIq9X9wH0Tn/vUxLF2+vXOPp9upXJJ6hnPH876K7Nm8vlXVh68z/ign3mk8Z8Pz0yX2yrb6O/9EPqXdi0enfd3fLf/+G8/tvfAvm1GhY0RUgsDlmvQbnLbFgqQABDQwHACuNk99892H0k29/5wtjN3du7pZ6YfuWe9in4wnP5vL9jQ2Itt98/VMDR3OE6mLr6weKVdfPjeW3bHrXvnfve5xbtpYrciXWzUkL+WqX/55SvtIn3/geZ4yB9IX/+v3z9qbn8qhN4Dt2e3RcO/e3LyV37h0S88+T6oMWCl1cL1dX+iuImnaVCAv06Eokq4MPv6f//qFy9enH329eap7sayPn5o+PymcGT2Is/PpnkROqPmzoP1HVn72IneicVJP3lwy9jyjvT0ueO9Tkv6Q0Pj28f2jyysr4dnXwkz8V1obFpHb24sXm63rO9klIUde7oP3ja5MPHw6MFP/tPH7qnFDWtudHy6io6uBhrXNU2DKs4g56uB2EB1amr/Bx/7e//yq195deoQNMNS90fHZl6fKYazKWjgZOHh7cXu9X65p2dlvBq/i2r185dWLp4vU8+58beOXrxjbFmz7Ngcz9hdGNoA+IWFTutcdzjbPLZu9MCdtUOHpvYcfPSu2x/ft2kj1A40t1afSiAwSAC9ybjfvkllMM+LKwt/9NrJbz5//Mz5+Xj2iG3nHkVUi7Ztx9T4SNaol/Fky22KYrOuTo3M5K0VVxVZM56YGI4B5cxHaSlWqmpyZGS0kVHlDWF8fHz9+o1DSaOWpPQWe/1J5B1Bi8ggv+rFtV3pXOmr4KExm0FoEZk4MTBWiSgoGUUURQpWIlIyRApE7/xgDzUg/OkR/zjQUASCBgUJQxWW1BGMQFeL3kqqCvKqyhSDhK72k1yv6DCreF3TQACAiaE3BZtXn/mTzeGdQa91RHrDClYIga/SDq+euzpyfc7A6s+b9xkQhZLyn7k76se1uPFgdQwSPCS6Cg40uIqwWnRSQBkQXT1n0MMzaP55az8ToMQw/z/9XD9O02ses9qoc02dejXns6bOBFWsDg2mN3hPa1T+5yU/BrQAWGMgGCyamzBctYg1QYJC17Tu6DsA/jOQxk8AWtfo7CdolLwZhCjobaLKPxf5v5UEEgSH728wAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAVIklEQVR4nO16eXCd13Xf75x7v+Wt2AiAACESpExtlOWIai3blBRrkjh20jZxYmfsuk2cthPPdOpJO81Ml0zbZNKmk0zT1GnaaZJx7Thum5Hs2LXa2I4j2akoRZIlWQspiaK4AiABYnl4+7fce07/+B7ARVwgDaNOpjp/AA94793vd88953e2S6qKv2zC/68BvBl5G/RbJW+DfqvkbdBvlVw30KoKhUJwnvdFB295Vb0gIMj5b0E2/7/1iHH9NE2kBAKDRAERURFRAUBkABCR9wUuBqAAFKRMoM19bhH1dQNNENpYU0WYmdgaYgCZy0VJFWRAAEQFSgolKBQEJQBCRNiasu31Ag0wFCCIgBm9fv7aqdUXXl544omTc8v9PJdtI9F77tz1Yx+4dceOGgMeykpEg50qmK6+/AVC1zv3EA9+5pnjB58+Or1t5Mnnl5994dTYeHm0HB07tba40rv9lm0f/bG7PvzBfYE1HmKIVT2RAQTgjZ9vCehiESIF+Hc++52vfOulofrYi0cWep1WORQbSLVardXKcVxh5qTX3b1r4lf+6YdGR6pKwjAXrrOp+79w0CICJgb9l88f/L3/8XS/l0Vh+p7bh9991+zUjuEoCPs9N3dm9dVja70s6Lro6MunpqaGvvif/la5FCuUQEoorHwrRnIdQBd0xsQP/K8X/sWvPzJU6vzMT97xtz96oD46NvgAQBAFk+Lp7736H3//iTQvL86f2L9/z2/80k/CCwzT1gzjoke+MRFV9bLx0nuvqg987aU7fuC3PvrJf3/s2IniLecy55z33jmXO3HOOZep6OHDx9771z7zkZ/74n0/8q+/8cgrqppJQeR+i89/M5SnUBTOrvAuY+avP/LqH3z5z7//zurnfvvn9uyZldypFzYBMzOzMWSMGjbGBM7Lbbft+dmP3XFqoT06UnvwqwcBBMQXOOK15Q2D1s1foqKwJnz52PL//pNXKrb9iY+9r1SJXabGWjARsOlVBC6s1VoWcX/nY/fumKo6DM3NL7740gIU6gGI6pZ47w2DJoBAICgTkYLclx96OfedyODuu25mMTYkJeA8AV/6FFUyxtxz545mL1GPp587DoJAFbwV6ngzoKF+4OEKIn3su2dXGp2FudP3HbhNAa8eG9FRAZwPkxdsm0iBfTdNCDiI7LHjiwoQma0Hlzdh00YLyxMA/M3vvNZtt9fXmj94/20AmHlzWVIMwuRAzudGpNg2UTEmEE+rKw0ApKLqt4jgDYdxJZCyQsnQ6lrr1ROraefc1ERt5w07AAExMCC5TcodxDxlItGN/8ZxyEZcz+d5ThCYN6C+N2PToIHHPHd4Kc1cp72+c3ZSdaApVd3M2xQAgcgUL6CDBENJJBd4BDHV6jFwUUZ7/UEXPl4c9AuvnBPNmo3W3tntBFJi3WCMCw1UVQlQBUgAKBjgRrPrlCG6bawKocsZ/3UErUxEzATI3HyjHKHT6czumQJB1RfkrRu7IwggREVmAihDvcIT0Ow5o5r088mJMWUSFAb9F8PTG0evee6bnXx8JCTOd0yOYZOVaYM6WKEM8OZTlKBkCt9cW21DNfPJbTfPEMACDA7h2vLG8+lBPNRmq5d5FySJJR7fVlVVIoUCNEisFawqUFYSAhOUSEVZ1QBYXkurVQ7j+jv2bAeEjAG2lC29GdBaWAC43c1EpNFar5RLtVqFiERIIQATFeGCwUwQVSISVRWwSlEs0uJyIuLuPXDz+Piw6kYs0i0Bf8OgCVLUSVnqyuXyoe89Vx+OKuVYASbeyC0l6aVLa51uq53BUqWe5jwR+53TQ8YwBL0sV5/XYv++u/YR4LxYw4otJdNvBjSUHRCwzJ9pJ/1sYf7QU48d+sxvvvvv/4OfPrnUOr3qzi735xZXTp5aXVpYiTUp79xlhidEZNQ14yTZOTv+gfv3xsaXI8MkX/qjr979nl+wlgXKW9TzmwFNQqIgk2S5aBoP33aDHfrCN0+eqh9u9blzbjmG77T98nK3EkYZEZ1Z17m1kM1yiViTQ6+dePLo2cjYPcPxre9613/9z7+zvPKLn//sv4XS1qvEa4Ie5OYeMBAFQ4kHPu7SXnrr7fdMz07kUe3ZR4/Zfq8S4VQziaxVwlorDwLuNNpJDoaBOCanySJ3V862699F9AMHbnr3gR9++tk/+z+PPXffPd+XO1i74QyEgWcPnnVRiXCNymVQtCkUnsjooMrAwccP/4fPPb7/jr2PPz13dv54yZTXO8nU9Gg/V3EaRXa9m9+6Z/TY6XWXeQVy8QGbJElitOojw4srqZpgteE/+IFb9r5jvLe6+MmP3XPr3qkNwJdiwAVZ7rVBD3apDIKDNzDi/e/+/sNff/ilV453J6anfS5Z48Wf+MgPHzmRP33obByFXvrWUaOf3bKnnEs0f6ZlOFRVpzxa9rNT9MT3zt0yOxTHnCSy2m2+6527aqWRuTOrP/Wj7/zIj9+pIMJ5gJctda9M5oqNvhaDRJy3oLlTS7/0a1974KuvvHJsfbgarCwvrzV6i0srh1449p7927udtF4xztNqs8WEV48sz82tekGaCcSruE5z/fhC99Y9tVJZXJ6Uw16y3jt9bI78+u4dY5974Ilv/OkhUhR9qQsVfIlmr6Lp82YkIkz85ItH//RbL3/7qaXOetMrJoaRZby4rp21hV5fdt24pysBiQHQ7+dRAJXEeYKx4tUyK5m0v7ytFo6OlOAlBwJ1pxfWuDJ6z/7JTuJmpsd73fav/vOfGKqXNg16oyuyRU1veIBXx8SnTy994YtPejP08vFGKRDDUTcvNzpUr/HMzMyN75hprXdc5jMvIgBrKbb3H7iRiERZQE7Eq1glp+HJRTq6yPOLWFoPTGmk3TePPtc58trK+nrrHbsnDz5xBJBilQGM12n1iqA3PskMo4Rf+XcPPfXi2oMPHR6KuVSvt72uNKlUiYmD7ZO12V1TvTRjFQMVOCZJUj+3uK5M4nJVVWIRB6Z+RkFgI+tNwJmyOAmtyVKfudKLh0/nSodOrHa6uTFmYAKXa/BdRdMCiPeeiL758HPfeuz42nqWps4Y02hnrSZGa/72m7dFYYUDvu+9N1erZVV1otAAiFOvh4+0cs/WhpYNRAG2xGwp864UsXoSdURERGzhyTbW+4vLLR+Wjx9fwaC3AcC9nr+vah7Kho2I++3ffdgYE4ZqDDggCG0fD265aTrzplRBkvCBu3f93U8cEM3E5cga5Nfhe5DUas7wRZIKUSFYNpbMep/BYtlkYjJx3jmXe2Y++dpCeXjbuWSj7iIQ7OvN44rBhQAvno35428dev7lM9WhMecckw2MVGIbBOFwtbRtON57Q3Tw2aWdE9V//KkDD3zlkWNHvl0OAmOMQAFOcwkr25wZCcq7RD3Bl03a8lINjDKVWSuWKvVyHFIvN61m6fRcY3113d68p8gWN8qcS5n7yhFRwcxQ//n//pRV9nnmvBjWdtckvVzQXltbmZ0ZavX6Nho+vtj6vd98ZHEtqo3dCQopNIEHVEJmT4FFrPDMLFo+18wqkb1xVyWOKEtSa20YWi9uVLOF3C6tdk4cmbv/fbNahOArdPeuCFpUmPnQq0t//syxoQqqtfDcakc0oazSD2IyWOnS4gtdtVov937m0w8urfbqlUiwXYhBhMCSikDhRSQnr9Dcs1GujG6zQ6M1l2X1Uk017XfdateLhGMjwUqjtzjXyFttonG5cnPviqBVvUC/99xJZniyvZyYIiKIZt4ziQmCgI0xijR1ictr5cCBIE6IDVSKxhyg/ry2VDWy/syKP7u66p0YQhixgJNU4ojuunNm/uxap9NfPNfcaJhcvjF5edCqSmQYfPZcc3g4dt12UOHhkUqeZTkogEIFcMxWfK7wpZCNCFgMAWTVC0TAUFUYUSViFjKWQBCDQODfe9fsvluGllf6jz49Z1WE3bPPn858pl5OnOkIiLlwwMskTFcEzcxffnz+4cONieHyQr+j3sOAjdk7WVMDVjS6ebcnnhEIWwMTsHMiHpAM1uTeswF7EjZBSIbEMhHEBBaimbNLK8tji76bOnWOIaSqPi56p+fW8kaiYxErFKQEvmS4cUXQAFabXYpLHFhjUY5du5165TMrpGycQJ2muRSNTu/BTkTUWHhiOOfViIiSGnHO23JMu3ZUmVkd0tw50dMLyYPHTobWlKIoE5LMq/YDa1ymvV6/1ZfRmD3IQhVCF1vI5UEXacqeYYzE+Yl2nmUcBWZm90gnS4+e7CYaMVsVgJmJAEmFUZhwShtfFyICmAznSd7LqO/7UK3H0fgIR4Znp6Lh4aDZVQBjsa2Vo4WVrs9Qq/u03XKtJo2MsUhRZW7JpgEIVCDbg84JzZntiYXs9JmzNrRZ5tkwjBCHKNqjbFQLilRVOZ8tkIp3zEEURSJueS0FsIT+erc0vS0shTpedyNVhZogINig3Ct1sl4/5VJIC6cX9u4aIy2869KC94oRkUHHzvZ33TAUBJG1dsf2GBRlCSsMsZKQqg46kUpQYagKQ82GgZEKE5GqipJlUysFQ/XKUKW23ndHF/Mj89nCCuVUMVHZO3L9/o3TdrQeGPZT4+WTx+f6aUKmODQWuqg3eWXzUMyMDZ/tYHqcllZ0vaPG2jCUKAx3TQ8tNrK5M504jj2EBIOG1wBvMZ+VotMAdSrq2Yoz+28d/YVP3fvdF+bPLHbvvXv3v/nMt598YWX7aLxrOiCltRXX6ttalQPrMkGj2S1NxEURQLgoO70yT0N/9Pt3P36w9bVvvCYuiePy5GhUK9kgtNbSbFRxuZxdS4IgIDIqhU432l8QFH8qQRnwAAnj+ZdWHnr4yKvHVt+3f8eH3r/rr+77+Je+efixpxYOPvNaZDh1oTGqkqy3pLF86gffv3+Q6InSxTnT5c2jgMBKU1Pjna5WQrNnIh6pWmXvXJZkae7Tm3fX9u6sk6iIELvzR7RhMwQGq2WA2Kuo886nn/3DZx59dv7BPz706JNz28aDT33izj/4rb/+0x/+KyvNdGIY48OBiChh//59O3dMUlF5vYFyCwChXI9KkQkrw82Ec0eloGRNZMjCUd5Ld45Fe3ZWHJTkkgHFRmIm5OFIUY4wXGfyXImj4dgsLHX/4S9//Qt/9NL8uSTL8S9//t5f/Wc/FJcoCm2lWsozhEHVBoEUKxH0YgK5miMCqIZxrR63+v7Mmjl+JltZT/ouM8aYkHKSTpJMjUWz0xUhDcIiAyYbkA2Kwo6YwRQws7WWmWFgrBMRa7Dc6P3ir/3JT33qvz3w0PMmwCd+/Pt279y579YZQm4tcp8pCQZDNGyJpwEIC4PK1SgMwyzJt43IiYXewoqM1IKRUjo+Ua6VLTPneb5zPB6qxfDIcy9AVAp7SdpYT3s9TXPnxDNMq02CJLb2hslKEJhmJxdBr5/Nn239q9/4zjcePXLD9rHlZmtuue9yVEo8NFQhMMnl26hXBM0wqmpMENjyLTdt//iH7w5NcPi1xS985ZnlTr7SadSrUTmgamzGJ23ZhN5oHAOAeAnKwXDFZk7yjNbaWb+XZ7l3YjLnTy/0JsfC4VJsA1ojVi/dRB959JTPTleqdnK8bCMFUC1HgEgx18OlPH21DpMSSJQI7VZ3Zmao08xeOr4Eim1o2KWddtr0umOyZsjm4pTg8+J7g5Egq0aBnx4jnqglzq828m4v7SZ6rpnnkG1htH08mhgL+pm0ui5N3Z7pWuJxeq6RJM45p0pcuODrsuqrUB5YCSxpmi6vNj/583/YaObVSqVai7y3jsWCrfFD9RAQj2L2rCJCRCLFmEIkdwCslcDYmYkSuJLn2k9yEHkEAIxBrcS1uBSXTGDoxefXJeek50NjCwYDXaaTejWeBmm7l642eqUw3jlZAczCYr/d7dsoYLZeTJr2V5rp8EjN+0S1mHnCiycFAAMmY7zPxadW4LxIEESBKddDT6xOlVVBcEysKnz4eCPNszLnvaQfl4wCg4sVeinpXblGVCKixlon7SbbJyqjQwHAQ5Xh+XPJ/HKXFUQ0NlbaOT2cdjNVJZEiNqpXEKlqEFj15KGkKpyKBMgpFZeztdZaJqbAq7L1qpymebUaTE/Vuk0yAU9ODA9oQzd/bM08is9VarbRps6yMOVj9eDGmfJIPer280rNDJUCyaTjMyixyGB6oUXaBLJk2TgBoEJErCSZipEAeUZiyQrYGhAxs/fZaN3WylG3jR2T9Z1TkyhmwgPsF8mVeZqg4nbNjN9+047llebCcn9+sdNoeq8YHQ5vmKoMxVGeaZI7FgMvDnBQpyIENsSGnMuJyJggVy9Q771XqKpm4nzinMtc7rLceyWV0IbitZv0xcld+3aSEa+Oi6kvNi/LXUvTAETJAB/4oX0Hnzw6NTMiqXKg4rMsE5/Bq0ihXSrG5Nj0GoExhkxgDNkAJnO5SkZgFVKIqidvvVUhckzWGbE2iEIbWvZwWbp377QqkTJUiVXBl+QeVwPNxkBx/4F9s7v/bG2tXauUkyTJMud8CggNpm5EZASeBcRhEcE8eYFRYrJSqlbY+PVGzwYGlKgyhKBd1pK3TLkjNuyi1OW1Snmt273jlpmbbpqkwW2HIju/1BOv1hYrukIg+ief/pF+r7my1nA+9a6vXrxXr7ChYUNs1DBRwGy9d4loxkjJ9Vy/2e+2Wu1GWIqrtRHvxDAHQQAmMkycs3hjjHPOa26strrNteUzf+9n388w3ivRoJh9PeddsdW7MRdkVQe2L708/8u//sCrR88x1AShuFw0i0uRIfbeB0y55N57VjYmKMp/FaiqV4nCSq0+kuROXFoph3maKYGZSYWD2EOJqNfuBEz/6NMf/Bsfuktk8zYDLnvp7dqTAAW85JYDiH774KEv/c+DZ86uiDe5uDi0hkVcX3zS7bT6nWXnExvVjS3HQTkM436WElHR+oCJBRGTdT5TIYYoGUPEZEslPfDed/7Nj993w9SEiDBf3QSu2VQvmE+hImQ2bhqJgkTVq5KCiVRJoEpEKgT1RFAYIuIB/6k4p96LSK4qnkVQXM4qDj4Mba1WA+BVTHEr4Kp6vNagCCCcH9848cx8wSinmDNQEXIvN7q85HAFUuT1g7cUKPxMRbBxx2VzKVVf1IhbBn3x4y7Y/QUnsDkZAYFEissgRUF+wQWKzUdcvDEZlH8QUi52srGqQFWLC0KXU/t1v2v6Vsj/3zfV30p5G/RbJW+DfqvkLyXo/wutSRJJoQjKIQAAAABJRU5ErkJggg==",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAVIklEQVR4nO16eXCd13Xf75x7v+Wt2AiAACESpExtlOWIai3blBRrkjh20jZxYmfsuk2cthPPdOpJO81Ml0zbZNKmk0zT1GnaaZJx7Thum5Hs2LXa2I4j2akoRZIlWQspiaK4AiABYnl4+7fce07/+B7ARVwgDaNOpjp/AA94793vd88953e2S6qKv2zC/68BvBl5G/RbJW+DfqvkbdBvlVw30KoKhUJwnvdFB295Vb0gIMj5b0E2/7/1iHH9NE2kBAKDRAERURFRAUBkABCR9wUuBqAAFKRMoM19bhH1dQNNENpYU0WYmdgaYgCZy0VJFWRAAEQFSgolKBQEJQBCRNiasu31Ag0wFCCIgBm9fv7aqdUXXl544omTc8v9PJdtI9F77tz1Yx+4dceOGgMeykpEg50qmK6+/AVC1zv3EA9+5pnjB58+Or1t5Mnnl5994dTYeHm0HB07tba40rv9lm0f/bG7PvzBfYE1HmKIVT2RAQTgjZ9vCehiESIF+Hc++52vfOulofrYi0cWep1WORQbSLVardXKcVxh5qTX3b1r4lf+6YdGR6pKwjAXrrOp+79w0CICJgb9l88f/L3/8XS/l0Vh+p7bh9991+zUjuEoCPs9N3dm9dVja70s6Lro6MunpqaGvvif/la5FCuUQEoorHwrRnIdQBd0xsQP/K8X/sWvPzJU6vzMT97xtz96oD46NvgAQBAFk+Lp7736H3//iTQvL86f2L9/z2/80k/CCwzT1gzjoke+MRFV9bLx0nuvqg987aU7fuC3PvrJf3/s2IniLecy55z33jmXO3HOOZep6OHDx9771z7zkZ/74n0/8q+/8cgrqppJQeR+i89/M5SnUBTOrvAuY+avP/LqH3z5z7//zurnfvvn9uyZldypFzYBMzOzMWSMGjbGBM7Lbbft+dmP3XFqoT06UnvwqwcBBMQXOOK15Q2D1s1foqKwJnz52PL//pNXKrb9iY+9r1SJXabGWjARsOlVBC6s1VoWcX/nY/fumKo6DM3NL7740gIU6gGI6pZ47w2DJoBAICgTkYLclx96OfedyODuu25mMTYkJeA8AV/6FFUyxtxz545mL1GPp587DoJAFbwV6ngzoKF+4OEKIn3su2dXGp2FudP3HbhNAa8eG9FRAZwPkxdsm0iBfTdNCDiI7LHjiwoQma0Hlzdh00YLyxMA/M3vvNZtt9fXmj94/20AmHlzWVIMwuRAzudGpNg2UTEmEE+rKw0ApKLqt4jgDYdxJZCyQsnQ6lrr1ROraefc1ERt5w07AAExMCC5TcodxDxlItGN/8ZxyEZcz+d5ThCYN6C+N2PToIHHPHd4Kc1cp72+c3ZSdaApVd3M2xQAgcgUL6CDBENJJBd4BDHV6jFwUUZ7/UEXPl4c9AuvnBPNmo3W3tntBFJi3WCMCw1UVQlQBUgAKBjgRrPrlCG6bawKocsZ/3UErUxEzATI3HyjHKHT6czumQJB1RfkrRu7IwggREVmAihDvcIT0Ow5o5r088mJMWUSFAb9F8PTG0evee6bnXx8JCTOd0yOYZOVaYM6WKEM8OZTlKBkCt9cW21DNfPJbTfPEMACDA7h2vLG8+lBPNRmq5d5FySJJR7fVlVVIoUCNEisFawqUFYSAhOUSEVZ1QBYXkurVQ7j+jv2bAeEjAG2lC29GdBaWAC43c1EpNFar5RLtVqFiERIIQATFeGCwUwQVSISVRWwSlEs0uJyIuLuPXDz+Piw6kYs0i0Bf8OgCVLUSVnqyuXyoe89Vx+OKuVYASbeyC0l6aVLa51uq53BUqWe5jwR+53TQ8YwBL0sV5/XYv++u/YR4LxYw4otJdNvBjSUHRCwzJ9pJ/1sYf7QU48d+sxvvvvv/4OfPrnUOr3qzi735xZXTp5aXVpYiTUp79xlhidEZNQ14yTZOTv+gfv3xsaXI8MkX/qjr979nl+wlgXKW9TzmwFNQqIgk2S5aBoP33aDHfrCN0+eqh9u9blzbjmG77T98nK3EkYZEZ1Z17m1kM1yiViTQ6+dePLo2cjYPcPxre9613/9z7+zvPKLn//sv4XS1qvEa4Ie5OYeMBAFQ4kHPu7SXnrr7fdMz07kUe3ZR4/Zfq8S4VQziaxVwlorDwLuNNpJDoaBOCanySJ3V862699F9AMHbnr3gR9++tk/+z+PPXffPd+XO1i74QyEgWcPnnVRiXCNymVQtCkUnsjooMrAwccP/4fPPb7/jr2PPz13dv54yZTXO8nU9Gg/V3EaRXa9m9+6Z/TY6XWXeQVy8QGbJElitOojw4srqZpgteE/+IFb9r5jvLe6+MmP3XPr3qkNwJdiwAVZ7rVBD3apDIKDNzDi/e/+/sNff/ilV453J6anfS5Z48Wf+MgPHzmRP33obByFXvrWUaOf3bKnnEs0f6ZlOFRVpzxa9rNT9MT3zt0yOxTHnCSy2m2+6527aqWRuTOrP/Wj7/zIj9+pIMJ5gJctda9M5oqNvhaDRJy3oLlTS7/0a1974KuvvHJsfbgarCwvrzV6i0srh1449p7927udtF4xztNqs8WEV48sz82tekGaCcSruE5z/fhC99Y9tVJZXJ6Uw16y3jt9bI78+u4dY5974Ilv/OkhUhR9qQsVfIlmr6Lp82YkIkz85ItH//RbL3/7qaXOetMrJoaRZby4rp21hV5fdt24pysBiQHQ7+dRAJXEeYKx4tUyK5m0v7ytFo6OlOAlBwJ1pxfWuDJ6z/7JTuJmpsd73fav/vOfGKqXNg16oyuyRU1veIBXx8SnTy994YtPejP08vFGKRDDUTcvNzpUr/HMzMyN75hprXdc5jMvIgBrKbb3H7iRiERZQE7Eq1glp+HJRTq6yPOLWFoPTGmk3TePPtc58trK+nrrHbsnDz5xBJBilQGM12n1iqA3PskMo4Rf+XcPPfXi2oMPHR6KuVSvt72uNKlUiYmD7ZO12V1TvTRjFQMVOCZJUj+3uK5M4nJVVWIRB6Z+RkFgI+tNwJmyOAmtyVKfudKLh0/nSodOrHa6uTFmYAKXa/BdRdMCiPeeiL758HPfeuz42nqWps4Y02hnrSZGa/72m7dFYYUDvu+9N1erZVV1otAAiFOvh4+0cs/WhpYNRAG2xGwp864UsXoSdURERGzhyTbW+4vLLR+Wjx9fwaC3AcC9nr+vah7Kho2I++3ffdgYE4ZqDDggCG0fD265aTrzplRBkvCBu3f93U8cEM3E5cga5Nfhe5DUas7wRZIKUSFYNpbMep/BYtlkYjJx3jmXe2Y++dpCeXjbuWSj7iIQ7OvN44rBhQAvno35428dev7lM9WhMecckw2MVGIbBOFwtbRtON57Q3Tw2aWdE9V//KkDD3zlkWNHvl0OAmOMQAFOcwkr25wZCcq7RD3Bl03a8lINjDKVWSuWKvVyHFIvN61m6fRcY3113d68p8gWN8qcS5n7yhFRwcxQ//n//pRV9nnmvBjWdtckvVzQXltbmZ0ZavX6Nho+vtj6vd98ZHEtqo3dCQopNIEHVEJmT4FFrPDMLFo+18wqkb1xVyWOKEtSa20YWi9uVLOF3C6tdk4cmbv/fbNahOArdPeuCFpUmPnQq0t//syxoQqqtfDcakc0oazSD2IyWOnS4gtdtVov937m0w8urfbqlUiwXYhBhMCSikDhRSQnr9Dcs1GujG6zQ6M1l2X1Uk017XfdateLhGMjwUqjtzjXyFttonG5cnPviqBVvUC/99xJZniyvZyYIiKIZt4ziQmCgI0xijR1ictr5cCBIE6IDVSKxhyg/ry2VDWy/syKP7u66p0YQhixgJNU4ojuunNm/uxap9NfPNfcaJhcvjF5edCqSmQYfPZcc3g4dt12UOHhkUqeZTkogEIFcMxWfK7wpZCNCFgMAWTVC0TAUFUYUSViFjKWQBCDQODfe9fsvluGllf6jz49Z1WE3bPPn858pl5OnOkIiLlwwMskTFcEzcxffnz+4cONieHyQr+j3sOAjdk7WVMDVjS6ebcnnhEIWwMTsHMiHpAM1uTeswF7EjZBSIbEMhHEBBaimbNLK8tji76bOnWOIaSqPi56p+fW8kaiYxErFKQEvmS4cUXQAFabXYpLHFhjUY5du5165TMrpGycQJ2muRSNTu/BTkTUWHhiOOfViIiSGnHO23JMu3ZUmVkd0tw50dMLyYPHTobWlKIoE5LMq/YDa1ymvV6/1ZfRmD3IQhVCF1vI5UEXacqeYYzE+Yl2nmUcBWZm90gnS4+e7CYaMVsVgJmJAEmFUZhwShtfFyICmAznSd7LqO/7UK3H0fgIR4Znp6Lh4aDZVQBjsa2Vo4WVrs9Qq/u03XKtJo2MsUhRZW7JpgEIVCDbg84JzZntiYXs9JmzNrRZ5tkwjBCHKNqjbFQLilRVOZ8tkIp3zEEURSJueS0FsIT+erc0vS0shTpedyNVhZogINig3Ct1sl4/5VJIC6cX9u4aIy2869KC94oRkUHHzvZ33TAUBJG1dsf2GBRlCSsMsZKQqg46kUpQYagKQ82GgZEKE5GqipJlUysFQ/XKUKW23ndHF/Mj89nCCuVUMVHZO3L9/o3TdrQeGPZT4+WTx+f6aUKmODQWuqg3eWXzUMyMDZ/tYHqcllZ0vaPG2jCUKAx3TQ8tNrK5M504jj2EBIOG1wBvMZ+VotMAdSrq2Yoz+28d/YVP3fvdF+bPLHbvvXv3v/nMt598YWX7aLxrOiCltRXX6ttalQPrMkGj2S1NxEURQLgoO70yT0N/9Pt3P36w9bVvvCYuiePy5GhUK9kgtNbSbFRxuZxdS4IgIDIqhU432l8QFH8qQRnwAAnj+ZdWHnr4yKvHVt+3f8eH3r/rr+77+Je+efixpxYOPvNaZDh1oTGqkqy3pLF86gffv3+Q6InSxTnT5c2jgMBKU1Pjna5WQrNnIh6pWmXvXJZkae7Tm3fX9u6sk6iIELvzR7RhMwQGq2WA2Kuo886nn/3DZx59dv7BPz706JNz28aDT33izj/4rb/+0x/+KyvNdGIY48OBiChh//59O3dMUlF5vYFyCwChXI9KkQkrw82Ec0eloGRNZMjCUd5Ld45Fe3ZWHJTkkgHFRmIm5OFIUY4wXGfyXImj4dgsLHX/4S9//Qt/9NL8uSTL8S9//t5f/Wc/FJcoCm2lWsozhEHVBoEUKxH0YgK5miMCqIZxrR63+v7Mmjl+JltZT/ouM8aYkHKSTpJMjUWz0xUhDcIiAyYbkA2Kwo6YwRQws7WWmWFgrBMRa7Dc6P3ir/3JT33qvz3w0PMmwCd+/Pt279y579YZQm4tcp8pCQZDNGyJpwEIC4PK1SgMwyzJt43IiYXewoqM1IKRUjo+Ua6VLTPneb5zPB6qxfDIcy9AVAp7SdpYT3s9TXPnxDNMq02CJLb2hslKEJhmJxdBr5/Nn239q9/4zjcePXLD9rHlZmtuue9yVEo8NFQhMMnl26hXBM0wqmpMENjyLTdt//iH7w5NcPi1xS985ZnlTr7SadSrUTmgamzGJ23ZhN5oHAOAeAnKwXDFZk7yjNbaWb+XZ7l3YjLnTy/0JsfC4VJsA1ojVi/dRB959JTPTleqdnK8bCMFUC1HgEgx18OlPH21DpMSSJQI7VZ3Zmao08xeOr4Eim1o2KWddtr0umOyZsjm4pTg8+J7g5Egq0aBnx4jnqglzq828m4v7SZ6rpnnkG1htH08mhgL+pm0ui5N3Z7pWuJxeq6RJM45p0pcuODrsuqrUB5YCSxpmi6vNj/583/YaObVSqVai7y3jsWCrfFD9RAQj2L2rCJCRCLFmEIkdwCslcDYmYkSuJLn2k9yEHkEAIxBrcS1uBSXTGDoxefXJeek50NjCwYDXaaTejWeBmm7l642eqUw3jlZAczCYr/d7dsoYLZeTJr2V5rp8EjN+0S1mHnCiycFAAMmY7zPxadW4LxIEESBKddDT6xOlVVBcEysKnz4eCPNszLnvaQfl4wCg4sVeinpXblGVCKixlon7SbbJyqjQwHAQ5Xh+XPJ/HKXFUQ0NlbaOT2cdjNVJZEiNqpXEKlqEFj15KGkKpyKBMgpFZeztdZaJqbAq7L1qpymebUaTE/Vuk0yAU9ODA9oQzd/bM08is9VarbRps6yMOVj9eDGmfJIPer280rNDJUCyaTjMyixyGB6oUXaBLJk2TgBoEJErCSZipEAeUZiyQrYGhAxs/fZaN3WylG3jR2T9Z1TkyhmwgPsF8mVeZqg4nbNjN9+047llebCcn9+sdNoeq8YHQ5vmKoMxVGeaZI7FgMvDnBQpyIENsSGnMuJyJggVy9Q771XqKpm4nzinMtc7rLceyWV0IbitZv0xcld+3aSEa+Oi6kvNi/LXUvTAETJAB/4oX0Hnzw6NTMiqXKg4rMsE5/Bq0ihXSrG5Nj0GoExhkxgDNkAJnO5SkZgFVKIqidvvVUhckzWGbE2iEIbWvZwWbp377QqkTJUiVXBl+QeVwPNxkBx/4F9s7v/bG2tXauUkyTJMud8CggNpm5EZASeBcRhEcE8eYFRYrJSqlbY+PVGzwYGlKgyhKBd1pK3TLkjNuyi1OW1Snmt273jlpmbbpqkwW2HIju/1BOv1hYrukIg+ief/pF+r7my1nA+9a6vXrxXr7ChYUNs1DBRwGy9d4loxkjJ9Vy/2e+2Wu1GWIqrtRHvxDAHQQAmMkycs3hjjHPOa26strrNteUzf+9n388w3ivRoJh9PeddsdW7MRdkVQe2L708/8u//sCrR88x1AShuFw0i0uRIfbeB0y55N57VjYmKMp/FaiqV4nCSq0+kuROXFoph3maKYGZSYWD2EOJqNfuBEz/6NMf/Bsfuktk8zYDLnvp7dqTAAW85JYDiH774KEv/c+DZ86uiDe5uDi0hkVcX3zS7bT6nWXnExvVjS3HQTkM436WElHR+oCJBRGTdT5TIYYoGUPEZEslPfDed/7Nj993w9SEiDBf3QSu2VQvmE+hImQ2bhqJgkTVq5KCiVRJoEpEKgT1RFAYIuIB/6k4p96LSK4qnkVQXM4qDj4Mba1WA+BVTHEr4Kp6vNagCCCcH9848cx8wSinmDNQEXIvN7q85HAFUuT1g7cUKPxMRbBxx2VzKVVf1IhbBn3x4y7Y/QUnsDkZAYFEissgRUF+wQWKzUdcvDEZlH8QUi52srGqQFWLC0KXU/t1v2v6Vsj/3zfV30p5G/RbJW+DfqvkLyXo/wutSRJJoQjKIQAAAABJRU5ErkJggg==\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAU80lEQVR4nO16WY9l13Xet9aezrlDjWxKphpiaAW0BGtI7AQG5Ey2BDkJDCcIHCMPAWLkIS/5L37MPzBg+8VG7NhW5ACCkygGNFC2WiRFhZObza4eqqvqDmfYe6+18nCqmtWUulliI3ICaOGibt177r3nO9/+9hoPmRn+fzP+mwbwYewnoH9c9hPQPy77Cegflz0WdMVgKGJV9PwdMwGKoYiOMGgBBFDkXA2AAqgiAlRASzagQmFmQBnyMdADVQ0GFIXU859VVRhgMFFY/eFoHjV6bHCpAF08AJiZEREAiAI8Oh5FlWzOHEQGdQ0MfImEYZCQiquNqobIIgDABOICUkMCABQABiY4AGrVkf/woC2rmXFgEBnMTGhCZCMRG5ICpVrw2cQ8NWCFMahDaeEIXKQ4FwqQDMgVzkENkQFRKCSMDBYFIU3rLQYmfDDkJ4AWqEHUxBEBDDiAS0FDAKMwOpGXXz5987Xu2rXlzm73sWvL5Z7tzALgCa7oWMXlke6e3f/ejeGtN93pqnv+Bf6nv/LiwQIOBiUwxIxdJZCBSy3BB7rCNnss6FF7Ih8owGAKMzgnIIWFgbY372x/93e/990b9OYb999992h//3DeHix3808989z15+vqbHv/zk5XV0MfxjO9d3ZLqMZmef2jH3n+4/Tv/8OnP/liXdhStbADgDpUH1oQYAr3FKAheq5QM0xaNoPJ2yf8X/7gta9+9Z1b9ze7zxxs+rpa98MwQHzylrf86//22bfffufrfz5Pi2Lek/jQ+CK5naVPfOITN998vY32xV/6R5//e0ef+cz1NkF0SOxhXobiYoD7QMxPkJAxDEq5UAHN7z7Ajb88efvts2+/sn7nnXdW64F9UK3zGdanufH784UFopPtBn2c0/4i0nzRCNtQKzN0tOV85/j+nd3DGaN+7Vtf/1//M33qZ/MXv/TCZz7dSLRI1bVuGIbGNR+e6YwNYfH6m+NLNx68eavcvNPffdAbcdNg+yA/uLMOvnabe/v7+2yL4/vdWtn0xBXO5b53zXx2vbixaoyWASyW89RQLn1MyXFz7SPXiz8bu63043PP7Hz2k8/97Z9On/iE+/j1mb+KptUyWYCNoASC2siawNoR/87v3/rTr7y72moTAwm6rgNXpjQOQ99vVZWZnQvOOWLfb0ZVnSgwO3eQzMzMTdPEGGutY8lENJvN2rZVdj5KijysrYxxNuODj/T/6jc+9w//Dua6gu7AI1uJFmBZzbF/TzdUbXCWQApAlYmVwFrx23/0zh//6Stn/e6YdRZD4jTkerY5gRUiYgYbVFVATN45Z8oTaKL3Vo+ZUxMBwAgAEZFjERGR2WLPkEvtZ2lWizmmECW1+KV/cP3f/etnvW4Fc7A6YTCMzqPFZJ7sQsHIhGggwbDeNF//ZvfO7RyaTFbymBVaxPq+lzpE50MIzpEZwRSkxuycc869F4EmSqYLMCLCxDqRA5EB3fakSW3kduiLmjSpHccgtfnj/3rvmb3FF7/I3uAhRqwCcYiXUHsmNgUAYiGDCKmTt26NpyP2ntm/f3w3sQ9hluu2Wp0tLK+TaBmGwRFPwiBnVk2cPAQ6KWR6KSLMPKEXsekDzAzrB7UYWlAMzhOcWiGWba5/8Idv/MIvfvpwBsJATCDA/GWq+SJMYzoLMyrab924m+s2NNYmqKKqE5ha8R7L5XLWLmKMzrmJPIDtkuklExFHpLWWcZRSGOrIHBm0kjWSy2Z70s4cBzcMY9uGB6e3fFgfH6c33hjVtiwJ6h2JvywOgE0BBhgqBAURbh2Vb7x0xESrB8fP7n8k8rwUMucNrgyhmjJzim1qZj6kiUWwe7jtLvMNgPDeIeeYmQADzGrLFHzQIT8gNxDXvu8dIuWuVn3l1fueBBJRYSCmzSOgYZOrro4bswroSy/de/3NDYsd3zmSmmfLxs+QZpZSirYoRaqpwIiIiIwd3HtYLxbNLuOedioziZSSh1p60+xiYWbi2bbXpmlC5Du3j2SE9GGUk5df2RbM4IAAkQiER0ATQ00FGQChGuqrL9852xir5rE7Obm9ux+W+/BtL9oBHFJk9mb2CHSCPWoPTzDpxMycc7O23d1dHh7uX7t2mOZrjmR13oSPlpFPT08Xs3YxW3an1Td24zvrN97cwKHSihwg6VF5EJyxt8YKLHQ3j+mV7zRWbp9sHsTm2q17d1ZDt9jfn+9ca+PHzNZai3M0UcvMqlrLtIOl1lprnRA/dH/OiXdtHTxK97eu29/9tP/Ys8MsdZGWKNHHMlty5SMFzXfb47NbwqKjdBv52l9sC8SPO06Q3fGj8oAKnQFGwTLmL31zdXTvtkvtyd2ja3s7ZbtFGZAH2DA/gN8VIlLVi9Xnc6btnPLL/m6yru/NabNszPmju91rrz+4dadfb12vnXlql3E2a5weNHRwcnSPa100u5vtan6w+9++evLmuy6ne3Aa7fAR0LUOjnZRnXEW8Fe+/H3zMdfZvXfvyFA40+03bubNcLi7t9hJ5pvJGQM8iYTA0zuO6H0PBhiYLXcUJaMX8kUWYznohp2TLdR7oZCaudim1uOhv2k6RCzW65658aneX8uX/+z7hmuSGY+mGhx4BmxGEUX6H3+Wb/zlKjZ0ePBcnC3vHd+bzePx8c2jm6/fufXWbOFmi2dDdJPHIPAkac/MeI/p95kpi1aQkOOc/dCHagkcgWa2SCmlWRs327N1d1JV1/kozXlv2ZzeOZVT5TIDYFzx6Pp5MGqNsRkK6gsv7rz44vzbNx7sHOzt7l+/+db3ou+KnNy+1d28/a0vPBP2lj/9YMtVUYuZGsBEMCIl8A8I45wVdaQU2DFc7YuakGffwrv5znIB4bG/f/fea4x5qR+fzz7Wb8tybr/6yy/88hfSz39u4QBjL8gO8RJog/cRoID5xz8+/tZ/+tzv/c7b//n3jk6Oy6I9cC6V4ax0crK+/eqNv/i5n/vsZnZczatUMQU7IjZTIgL/cNCJY83ZBErqPHuCOWXPi3liHmaR3nrr+92xLRonrtvbm/+zL734T76w8+Lzc48KcSAIPSBqH2WaRlgCghUEnyLzb/6bn/3nX9r/o9+nP/yTP/nGt14dh22i+ere/bdev/GLv8DtPKhZKbUO5LxnkBncpJYLu7wdx9qxdxQ8RBWFidjHdrZwUbwb9g/He7fvDLf9p//+c7/269d/9Tc+dbhgAjwqtIMLZq3HwXkEfPj7aiY1excBgHpoU0YKDUA4Wes3vnXzK1/+2n//6o3FPv7xr/382dlnjtdjv80P7ndDr8G1RASp7EgvdPc+B+I8SjVYNKnBmXcMH5vZjp/1qex/6pMnv/Kl8Fd/vvkX//Kze/tb0wWkEnk4EXNgGOAURB1o9h7ox1bjouoYUhyHUWty9s4d/1u//eqD+30e6eidMxU/S21Rcc7lnC9vvgn6ZCIy/cPM3vspysQYeZZY6+c/e/Qff/Pz1eANBFSI5w+utx5bbv2gx621qmrOWcQzM8GZmch5chdjnBLl8yTuIhZOWJ1zD99xzoUQigyO9JM/8wKh1uJCJJRC4QoV4pNqRAA49wnMDGjJVZRm86bfgtikqkCmo0Q0jqNzbuJyij4hhJTSedSsdUI/sV5rhRtCdC88/1PASEwAgQ3Qq3TqHg/6EtNsDMLZqtv0w95yNw+biTYjm0g1oxDCFMadcykl7z0AEZnIvviYqepEvKoQCAqYJJ9ExJGvWq/QQfigy5pEIiI1y+lq1W0zkakqETlPD4+WUmqtIYT5fN40jaqO4ygiIQQzNTsP+xf1AZkRwQ19Xp2upkpsyo/p0WzuRwdN56gBMLNzrhY4n8xMrTITADUxM2ZOKTVNAqyUrCoxhqZJzDSOQwgBQK3lQs2JiEopzrmu64pUGJlNUQruMc7+ffZYeUz19FTPTGGbfWznS+/dRfJJZsZu2mehlGEqEzE1QgHnXNM0IuK9DyEAJCIi1XsfY/QJ5Ji9h0NVRAaKwD3dRrycsKmCGWbmXJj6uRPBwQf2YXIpTZPe1zmYrjylNG1EIp5KgckPusBNE51nwJihWtmxQXCFFtMT+tPmDCDC1IUlVE8ueO99KaVt2+nCch6JEKPvuo6IYowT0yGEpmmIaBiGpmli0xihqhjgQ1AzZzU07bXWQ1tCYfJi7KCPw3Ml0A4X/buLmtd775kAxBiJTLVOWp/25e7urqoOw5BSWiwWfd+fnZ3FGBeLRdd1w9C3bZtSmras934oNYTQNAmGqhUAM66k6A/005ctBheieWeAEvnJx5FzMcZSaim5aZopOo7jOJ/PvfeTD5nP593QD8MQY4zJn1dfPvoIjsC0caZOwYUrebJ9sFe0i6eYODhMIMws5xyjd85NYaVt21KKiMxmsxBC13XjOLZtG2MchsF7P5vNJkfuvVfV4BvVOuYNCMElmMFAV8L8eNAGAc5dHhFAGgN7Z977WisRpZRyzmo1pZTzWGtdLpeqenJyEkLY39+fWPeBm6bJOXfddj6fLxaLMfciUoqBqmq+gKGgRyLahwFNl/IoIgAao48euQxt204OIaVERH3fT/Hv9PR0Nps9++yzm83m7OxsNpvNZrOcs0EODg7m8/lqtZr2pQ+cR93ZWS53GkyLaQZ6Ep7L9oQwrrBHvE+bQoxu7LnWCiClVGtVgg88qWI+n2+3WwCHh4dmtlqt2rZdLBbDMKzXawD7+3siul6vQwhadXdnZzlL5/pjNgD2g3naD7HHM/1ouwww7zl4ngKbQcxkInjKN7bb7TiOi8UipbRarczs4OCAmbfbbUrp4OCAiFar1dTqVVXJAqhBYVNHdTrr08ljOmRQhgprRbi+iwgMA4nmEFiECD55V0pfa13uzA3SDduQ/M7ecsj92fq0nTeLnXk/DJvNarGYzefzvu9qrW3b+mB33+qPx2jVXDWDKnqSq2B+0ka8+ICCwQ4IjmfN1BrAlBMDIKIQAvHkTGJKqe/7zWYzn8+Xy+VqtZJqi8UihNB1g6rOZrPzZall2+e/fqc3NoAMplceH3+Q9wBDGdMQ1Enb0nbTM3kRyTkzs4gMYzehL6WUUpqmmRSyWq2miLPZbJh5Z2cHQM45pbRcLtVsPegrL6/FnZeXjAS+EtWPB23vcU3nOVBNkUUs5+J9aJqm1qpWp1xUVacYvl6vRWRnZ6dpmvV6HWOzXO6KWNd1KaWUmr7vu65j72p1r762HoVAF6ejK42ZHwua6eIQAZcSt/WqS3FuRiVLSgnAMAwhBMdhs+6cC/v7h6XI6enKjFJqJ/c3VQbb7TbnPOXc3ntz7q9vDcdnFQSo4yvfTPXEMG4wMgIpjNkDNuYx59p1A4xDcOM4llKmIdBgw97e3rbvNpvN4eHh5L+JqJm1ZjaMI4za2VxENtutmTlnMcaz9fbo9vj8YThf0KctAsCqmAKVqhIDFu7f3wxDjjFNbcgY4yTrEAIzr9frpml2d3dPT0+7rpvP5znnzXqbx5JiA2Cz2RDRcrl0zrFKTMEMR7czUJkIULvaXnyCn57+GqBKqkAVvXe8KlmmNGhKP0opZjYFdudc3/ellOVyaWZnZ2dTbZtznoJLSmkYhslbS6mOYGRnJ/k8JqLiagp5EtPsK8EX0mjBmd4b8/FxCp5LFufbmGYUYtHiiVhsLLmqEJGIjmP2LqU423bj+nRNSo58GauINc2saWYiNnIbxuPWL156s1QEMpA5fWrQ50cJZIBIXa+G1WpzMQOqD93L9Do4X3OZir+pUMg5e3aTuCd9A5hcBwByqILY2L07m6PjDgaQuqsl1FfREJuBya/XZRhHKE3awDRcI28GMZ2CuSPOOeecpz7B1HmahgRmZqI55yl1IaKxWGpw+mB85eUzMKB2xSrgiaDtUk/R8emplQpTVhGDEptzzrkAYMpDzuHyOdMT62o21YYl55wz2fnQQ1WzCRGzd9/+q60xyLyhPBVoOy/XFCCQmuLoaLsZBoBFRLWaKbN3LojRw5H4w/E48N7oaCJ7GIah72utWqXWaqJG2m+xtxe/+2q/GgBju9o9TE8AbTCYGU0TUcXR7U1RA7jWqlJEipkx+QnZJA9mzjnXXLw/L4HB5/KAqFXJ45hzVlUynW4DSA3unun/fmMNgtHTuTw8UhhrKfXByRhT6+BUoFpVFeBptKKkU931sKNXSymlTLnrOQuPznPZquNZGXOtEhb+O985A0Hsaf00AZjuThCt4zhuN9nHAKNHhoXkABCRlDI1a8oF3OB9LWWq1Zl5Qjz5kForWWG0hpxH3dmPb781gNT0Ss2ax4MWB0IpxVk15tdObEv7ruvM83a9psreGqvO++hc0IE9eVbTWsmUCKpVVH1IKkW0EJlPPgTnYFyrdn2vAXpkbdpumXLufB4tJ+b3zU5/NNBwVQgxNDAPid2pbE/GYVXA1bx0dVVsM8iZoA+Jm52ojsw5IypmVXWsMpY6jIVdYpfgoporBiUWZmHmfvbctZS8SQ9Tkuq3m4CnLAIUUk0ARhYSnJ1sSu0VUkf22uqA5IMDaeEy0LjVmkeoAIAq1Dy76EPwPg/FBAwy0UnopOYJTewPDtcxQPK837phYMUW/kou7/G9PDRMAiiiMruT9QqRuPUuR6DtN6eYC7FFSuQZpIqBmBkEJasCCIxUS+JARICCGeSICKalFGn3z7adi6HZk4Ju281dSKZ6lfjyeNCCafzDDAFWG3JxF2RhMShZ7rsRp+wq0bzUUZHNzDsPYiOYZwQiwIGlVlU1EzDczHt2pZRSu1UZ7txtkRbtcjv2XAcaB6B9/3D2RwMNAkNL8Z74+GxYPejLVoazvFErI85O2AUNCc75MoppqVW812n+4H1lrlMX/XwS4Mhs6l6riOQs+/FBWR1q2mI8Cy555tMj/ehuMvpg1E+6QVb8qJoCoR/rN7+b7z7Iw1n2c869HN8/4qCCRLRbxiGEzlRijFPvuWmaGH0ILoTQzuKFK6zr9XocRwBE1M7bjy4WcW/gAuF6urGf+QgOD1vQeb38oUAbhHpY66CgrmIBqEcBHNSjVkQBkimkwscK9e/7OkhABCrQqWVM5/GKHIBK7LWCO+QdRAxAU4BQzPxTgH549ou8Aper3ae2x8F63006P/y7V8FxOQe6yo/+37Yrgf5/zf7mafsQ9hPQPy77Cegfl/0fYbQLGpke+5oAAAAASUVORK5CYII=",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAU80lEQVR4nO16WY9l13Xet9aezrlDjWxKphpiaAW0BGtI7AQG5Ey2BDkJDCcIHCMPAWLkIS/5L37MPzBg+8VG7NhW5ACCkygGNFC2WiRFhZObza4eqqvqDmfYe6+18nCqmtWUulliI3ICaOGibt177r3nO9/+9hoPmRn+fzP+mwbwYewnoH9c9hPQPy77Cegflz0WdMVgKGJV9PwdMwGKoYiOMGgBBFDkXA2AAqgiAlRASzagQmFmQBnyMdADVQ0GFIXU859VVRhgMFFY/eFoHjV6bHCpAF08AJiZEREAiAI8Oh5FlWzOHEQGdQ0MfImEYZCQiquNqobIIgDABOICUkMCABQABiY4AGrVkf/woC2rmXFgEBnMTGhCZCMRG5ICpVrw2cQ8NWCFMahDaeEIXKQ4FwqQDMgVzkENkQFRKCSMDBYFIU3rLQYmfDDkJ4AWqEHUxBEBDDiAS0FDAKMwOpGXXz5987Xu2rXlzm73sWvL5Z7tzALgCa7oWMXlke6e3f/ejeGtN93pqnv+Bf6nv/LiwQIOBiUwxIxdJZCBSy3BB7rCNnss6FF7Ih8owGAKMzgnIIWFgbY372x/93e/990b9OYb999992h//3DeHix3808989z15+vqbHv/zk5XV0MfxjO9d3ZLqMZmef2jH3n+4/Tv/8OnP/liXdhStbADgDpUH1oQYAr3FKAheq5QM0xaNoPJ2yf8X/7gta9+9Z1b9ze7zxxs+rpa98MwQHzylrf86//22bfffufrfz5Pi2Lek/jQ+CK5naVPfOITN998vY32xV/6R5//e0ef+cz1NkF0SOxhXobiYoD7QMxPkJAxDEq5UAHN7z7Ajb88efvts2+/sn7nnXdW64F9UK3zGdanufH784UFopPtBn2c0/4i0nzRCNtQKzN0tOV85/j+nd3DGaN+7Vtf/1//M33qZ/MXv/TCZz7dSLRI1bVuGIbGNR+e6YwNYfH6m+NLNx68eavcvNPffdAbcdNg+yA/uLMOvnabe/v7+2yL4/vdWtn0xBXO5b53zXx2vbixaoyWASyW89RQLn1MyXFz7SPXiz8bu63043PP7Hz2k8/97Z9On/iE+/j1mb+KptUyWYCNoASC2siawNoR/87v3/rTr7y72moTAwm6rgNXpjQOQ99vVZWZnQvOOWLfb0ZVnSgwO3eQzMzMTdPEGGutY8lENJvN2rZVdj5KijysrYxxNuODj/T/6jc+9w//Dua6gu7AI1uJFmBZzbF/TzdUbXCWQApAlYmVwFrx23/0zh//6Stn/e6YdRZD4jTkerY5gRUiYgYbVFVATN45Z8oTaKL3Vo+ZUxMBwAgAEZFjERGR2WLPkEvtZ2lWizmmECW1+KV/cP3f/etnvW4Fc7A6YTCMzqPFZJ7sQsHIhGggwbDeNF//ZvfO7RyaTFbymBVaxPq+lzpE50MIzpEZwRSkxuycc869F4EmSqYLMCLCxDqRA5EB3fakSW3kduiLmjSpHccgtfnj/3rvmb3FF7/I3uAhRqwCcYiXUHsmNgUAYiGDCKmTt26NpyP2ntm/f3w3sQ9hluu2Wp0tLK+TaBmGwRFPwiBnVk2cPAQ6KWR6KSLMPKEXsekDzAzrB7UYWlAMzhOcWiGWba5/8Idv/MIvfvpwBsJATCDA/GWq+SJMYzoLMyrab924m+s2NNYmqKKqE5ha8R7L5XLWLmKMzrmJPIDtkuklExFHpLWWcZRSGOrIHBm0kjWSy2Z70s4cBzcMY9uGB6e3fFgfH6c33hjVtiwJ6h2JvywOgE0BBhgqBAURbh2Vb7x0xESrB8fP7n8k8rwUMucNrgyhmjJzim1qZj6kiUWwe7jtLvMNgPDeIeeYmQADzGrLFHzQIT8gNxDXvu8dIuWuVn3l1fueBBJRYSCmzSOgYZOrro4bswroSy/de/3NDYsd3zmSmmfLxs+QZpZSirYoRaqpwIiIiIwd3HtYLxbNLuOedioziZSSh1p60+xiYWbi2bbXpmlC5Du3j2SE9GGUk5df2RbM4IAAkQiER0ATQ00FGQChGuqrL9852xir5rE7Obm9ux+W+/BtL9oBHFJk9mb2CHSCPWoPTzDpxMycc7O23d1dHh7uX7t2mOZrjmR13oSPlpFPT08Xs3YxW3an1Td24zvrN97cwKHSihwg6VF5EJyxt8YKLHQ3j+mV7zRWbp9sHsTm2q17d1ZDt9jfn+9ca+PHzNZai3M0UcvMqlrLtIOl1lprnRA/dH/OiXdtHTxK97eu29/9tP/Ys8MsdZGWKNHHMlty5SMFzXfb47NbwqKjdBv52l9sC8SPO06Q3fGj8oAKnQFGwTLmL31zdXTvtkvtyd2ja3s7ZbtFGZAH2DA/gN8VIlLVi9Xnc6btnPLL/m6yru/NabNszPmju91rrz+4dadfb12vnXlql3E2a5weNHRwcnSPa100u5vtan6w+9++evLmuy6ne3Aa7fAR0LUOjnZRnXEW8Fe+/H3zMdfZvXfvyFA40+03bubNcLi7t9hJ5pvJGQM8iYTA0zuO6H0PBhiYLXcUJaMX8kUWYznohp2TLdR7oZCaudim1uOhv2k6RCzW65658aneX8uX/+z7hmuSGY+mGhx4BmxGEUX6H3+Wb/zlKjZ0ePBcnC3vHd+bzePx8c2jm6/fufXWbOFmi2dDdJPHIPAkac/MeI/p95kpi1aQkOOc/dCHagkcgWa2SCmlWRs327N1d1JV1/kozXlv2ZzeOZVT5TIDYFzx6Pp5MGqNsRkK6gsv7rz44vzbNx7sHOzt7l+/+db3ou+KnNy+1d28/a0vPBP2lj/9YMtVUYuZGsBEMCIl8A8I45wVdaQU2DFc7YuakGffwrv5znIB4bG/f/fea4x5qR+fzz7Wb8tybr/6yy/88hfSz39u4QBjL8gO8RJog/cRoID5xz8+/tZ/+tzv/c7b//n3jk6Oy6I9cC6V4ax0crK+/eqNv/i5n/vsZnZczatUMQU7IjZTIgL/cNCJY83ZBErqPHuCOWXPi3liHmaR3nrr+92xLRonrtvbm/+zL734T76w8+Lzc48KcSAIPSBqH2WaRlgCghUEnyLzb/6bn/3nX9r/o9+nP/yTP/nGt14dh22i+ere/bdev/GLv8DtPKhZKbUO5LxnkBncpJYLu7wdx9qxdxQ8RBWFidjHdrZwUbwb9g/He7fvDLf9p//+c7/269d/9Tc+dbhgAjwqtIMLZq3HwXkEfPj7aiY1excBgHpoU0YKDUA4Wes3vnXzK1/+2n//6o3FPv7xr/382dlnjtdjv80P7ndDr8G1RASp7EgvdPc+B+I8SjVYNKnBmXcMH5vZjp/1qex/6pMnv/Kl8Fd/vvkX//Kze/tb0wWkEnk4EXNgGOAURB1o9h7ox1bjouoYUhyHUWty9s4d/1u//eqD+30e6eidMxU/S21Rcc7lnC9vvgn6ZCIy/cPM3vspysQYeZZY6+c/e/Qff/Pz1eANBFSI5w+utx5bbv2gx621qmrOWcQzM8GZmch5chdjnBLl8yTuIhZOWJ1zD99xzoUQigyO9JM/8wKh1uJCJJRC4QoV4pNqRAA49wnMDGjJVZRm86bfgtikqkCmo0Q0jqNzbuJyij4hhJTSedSsdUI/sV5rhRtCdC88/1PASEwAgQ3Qq3TqHg/6EtNsDMLZqtv0w95yNw+biTYjm0g1oxDCFMadcykl7z0AEZnIvviYqepEvKoQCAqYJJ9ExJGvWq/QQfigy5pEIiI1y+lq1W0zkakqETlPD4+WUmqtIYT5fN40jaqO4ygiIQQzNTsP+xf1AZkRwQ19Xp2upkpsyo/p0WzuRwdN56gBMLNzrhY4n8xMrTITADUxM2ZOKTVNAqyUrCoxhqZJzDSOQwgBQK3lQs2JiEopzrmu64pUGJlNUQruMc7+ffZYeUz19FTPTGGbfWznS+/dRfJJZsZu2mehlGEqEzE1QgHnXNM0IuK9DyEAJCIi1XsfY/QJ5Ji9h0NVRAaKwD3dRrycsKmCGWbmXJj6uRPBwQf2YXIpTZPe1zmYrjylNG1EIp5KgckPusBNE51nwJihWtmxQXCFFtMT+tPmDCDC1IUlVE8ueO99KaVt2+nCch6JEKPvuo6IYowT0yGEpmmIaBiGpmli0xihqhjgQ1AzZzU07bXWQ1tCYfJi7KCPw3Ml0A4X/buLmtd775kAxBiJTLVOWp/25e7urqoOw5BSWiwWfd+fnZ3FGBeLRdd1w9C3bZtSmras934oNYTQNAmGqhUAM66k6A/005ctBheieWeAEvnJx5FzMcZSaim5aZopOo7jOJ/PvfeTD5nP593QD8MQY4zJn1dfPvoIjsC0caZOwYUrebJ9sFe0i6eYODhMIMws5xyjd85NYaVt21KKiMxmsxBC13XjOLZtG2MchsF7P5vNJkfuvVfV4BvVOuYNCMElmMFAV8L8eNAGAc5dHhFAGgN7Z977WisRpZRyzmo1pZTzWGtdLpeqenJyEkLY39+fWPeBm6bJOXfddj6fLxaLMfciUoqBqmq+gKGgRyLahwFNl/IoIgAao48euQxt204OIaVERH3fT/Hv9PR0Nps9++yzm83m7OxsNpvNZrOcs0EODg7m8/lqtZr2pQ+cR93ZWS53GkyLaQZ6Ep7L9oQwrrBHvE+bQoxu7LnWCiClVGtVgg88qWI+n2+3WwCHh4dmtlqt2rZdLBbDMKzXawD7+3siul6vQwhadXdnZzlL5/pjNgD2g3naD7HHM/1ouwww7zl4ngKbQcxkInjKN7bb7TiOi8UipbRarczs4OCAmbfbbUrp4OCAiFar1dTqVVXJAqhBYVNHdTrr08ljOmRQhgprRbi+iwgMA4nmEFiECD55V0pfa13uzA3SDduQ/M7ecsj92fq0nTeLnXk/DJvNarGYzefzvu9qrW3b+mB33+qPx2jVXDWDKnqSq2B+0ka8+ICCwQ4IjmfN1BrAlBMDIKIQAvHkTGJKqe/7zWYzn8+Xy+VqtZJqi8UihNB1g6rOZrPzZall2+e/fqc3NoAMplceH3+Q9wBDGdMQ1Enb0nbTM3kRyTkzs4gMYzehL6WUUpqmmRSyWq2miLPZbJh5Z2cHQM45pbRcLtVsPegrL6/FnZeXjAS+EtWPB23vcU3nOVBNkUUs5+J9aJqm1qpWp1xUVacYvl6vRWRnZ6dpmvV6HWOzXO6KWNd1KaWUmr7vu65j72p1r762HoVAF6ejK42ZHwua6eIQAZcSt/WqS3FuRiVLSgnAMAwhBMdhs+6cC/v7h6XI6enKjFJqJ/c3VQbb7TbnPOXc3ntz7q9vDcdnFQSo4yvfTPXEMG4wMgIpjNkDNuYx59p1A4xDcOM4llKmIdBgw97e3rbvNpvN4eHh5L+JqJm1ZjaMI4za2VxENtutmTlnMcaz9fbo9vj8YThf0KctAsCqmAKVqhIDFu7f3wxDjjFNbcgY4yTrEAIzr9frpml2d3dPT0+7rpvP5znnzXqbx5JiA2Cz2RDRcrl0zrFKTMEMR7czUJkIULvaXnyCn57+GqBKqkAVvXe8KlmmNGhKP0opZjYFdudc3/ellOVyaWZnZ2dTbZtznoJLSmkYhslbS6mOYGRnJ/k8JqLiagp5EtPsK8EX0mjBmd4b8/FxCp5LFufbmGYUYtHiiVhsLLmqEJGIjmP2LqU423bj+nRNSo58GauINc2saWYiNnIbxuPWL156s1QEMpA5fWrQ50cJZIBIXa+G1WpzMQOqD93L9Do4X3OZir+pUMg5e3aTuCd9A5hcBwByqILY2L07m6PjDgaQuqsl1FfREJuBya/XZRhHKE3awDRcI28GMZ2CuSPOOeecpz7B1HmahgRmZqI55yl1IaKxWGpw+mB85eUzMKB2xSrgiaDtUk/R8emplQpTVhGDEptzzrkAYMpDzuHyOdMT62o21YYl55wz2fnQQ1WzCRGzd9/+q60xyLyhPBVoOy/XFCCQmuLoaLsZBoBFRLWaKbN3LojRw5H4w/E48N7oaCJ7GIah72utWqXWaqJG2m+xtxe/+2q/GgBju9o9TE8AbTCYGU0TUcXR7U1RA7jWqlJEipkx+QnZJA9mzjnXXLw/L4HB5/KAqFXJ45hzVlUynW4DSA3unun/fmMNgtHTuTw8UhhrKfXByRhT6+BUoFpVFeBptKKkU931sKNXSymlTLnrOQuPznPZquNZGXOtEhb+O985A0Hsaf00AZjuThCt4zhuN9nHAKNHhoXkABCRlDI1a8oF3OB9LWWq1Zl5Qjz5kForWWG0hpxH3dmPb781gNT0Ss2ax4MWB0IpxVk15tdObEv7ruvM83a9psreGqvO++hc0IE9eVbTWsmUCKpVVH1IKkW0EJlPPgTnYFyrdn2vAXpkbdpumXLufB4tJ+b3zU5/NNBwVQgxNDAPid2pbE/GYVXA1bx0dVVsM8iZoA+Jm52ojsw5IypmVXWsMpY6jIVdYpfgoporBiUWZmHmfvbctZS8SQ9Tkuq3m4CnLAIUUk0ARhYSnJ1sSu0VUkf22uqA5IMDaeEy0LjVmkeoAIAq1Dy76EPwPg/FBAwy0UnopOYJTewPDtcxQPK837phYMUW/kou7/G9PDRMAiiiMruT9QqRuPUuR6DtN6eYC7FFSuQZpIqBmBkEJasCCIxUS+JARICCGeSICKalFGn3z7adi6HZk4Ju281dSKZ6lfjyeNCCafzDDAFWG3JxF2RhMShZ7rsRp+wq0bzUUZHNzDsPYiOYZwQiwIGlVlU1EzDczHt2pZRSu1UZ7txtkRbtcjv2XAcaB6B9/3D2RwMNAkNL8Z74+GxYPejLVoazvFErI85O2AUNCc75MoppqVW812n+4H1lrlMX/XwS4Mhs6l6riOQs+/FBWR1q2mI8Cy555tMj/ehuMvpg1E+6QVb8qJoCoR/rN7+b7z7Iw1n2c869HN8/4qCCRLRbxiGEzlRijFPvuWmaGH0ILoTQzuKFK6zr9XocRwBE1M7bjy4WcW/gAuF6urGf+QgOD1vQeb38oUAbhHpY66CgrmIBqEcBHNSjVkQBkimkwscK9e/7OkhABCrQqWVM5/GKHIBK7LWCO+QdRAxAU4BQzPxTgH549ou8Aper3ae2x8F63006P/y7V8FxOQe6yo/+37Yrgf5/zf7mafsQ9hPQPy77Cegfl/0fYbQLGpke+5oAAAAASUVORK5CYII=\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAIAAAC1nk4lAAATCUlEQVR4nL2aW4xm2XXX/2vtyznnu1Z9VV19m+nJeDKe8SUa22RGM44cMwZxS0CgKA8BXnnhBZ55ghfEA0IgEUUoLwQECEWICIJASUgkMomcENtjy/bcx3Pprq6urq9u3+Vc9l5r8XCq257u6ZttvFX66pM+nX1+Z+///q911t5kZniklgXO9V8NpjAFQBQ6gQMcMqDgAJABXW5jUIIDBYAUUAAwD7qr456E6O5f7mz0yNCAqmoWZubb9KpLxx4WQc4AhabOgoNzrgMcxGHZ1ZFcGSKANqfSh58ctMIIZx2bKJmBCMTC6HGRAbYcqAUa6Far6si8437sARCSaSB+pPv+SNAwqKmYknMEAsCAmrqaEAgeRgCUAKjCrHUOAEFDUhKAGYGNQPhJQmcFkzIyLJsagQxEZHAGibBQd7vfeu2NV/4k3Ti6OJqMvvLi45962m9NBFDJwXkATdeWsfoJQitAAEEAALcnff/kYGc8S9/b/Z//9j/O337vuWc+PZttXLu++7Xf/ZMXf+mvfeHv/HV6YmcFEc0D8pHcg5X744QGRKRt29IH5oBVc/LBtfn1G1/7/T8KgvXefP7hLhFtXtixYXFYLy/Pu7m17omdz7z80s+89Pzw0nl4Bj/CsvsxQC+7poqlA1b7h29+/Vuv//GfXf3uW6v50aiLddu0kp2PzjkVkaSkthjlktyIwgDOFXHj6Ss/8wsvf/Yv/Jyvwv8PaF2nNoQyGEEAQnZYQKfZeNn+wX/4L3/2P/4gzZfr9RrRx/GoUIhI13Vd1zGR956ZzczDRJWDd8Gv63rRrItBtbW19eKXv/Tzf/tvpIvTxtmII+UMxwJ15H946CQdMzvyMKgIAAU5z3uvvv6r/+yfH7197WIxLpWKWC3Wq0zmQ3DMZpZzNjNPDMDMiMzMjElV29SlnH0Rq6raX53Y5vBX/sHf++Iv/uWmbWJwt1z/wa5y78dyzAoYwMjeESwIvfvKN371H/2TdlFvxGoUy/pk0Syb4XBY13XKQjF6750PmsX6pioQIjKxpEKGQVGyd8gyLgfvv3v1P//LX5+Ww2d//gVzwaBImUJ8IPQ9H4vAJIYuq2oGFKQHp//t3/wGH9aXhhvtYnWyXIxnG7EMOWc2mOac2pxalUQmt//MTEREhNQciA1O4Y0IeGr7oj9Y/vt/8WuuyWoKMNGdYfLRoAEDM7wnZoNE4Hd/67ff+ca3L26d39+7ORqNXAz7x4fqOSMXozLGSEQiYlkAEJEjDs4XMTpmJvLOEdC2bdu2IrI4WqxOV5txcO2Nd37jX/960D5QPdS6vCe0A8ERHABEIzle/vf/9JuDUNSSQlmwCwCathVGNR4dLA699z10J1lEzMwI5M6UDcAANRORbKqE0XRC3p2s1hvD8e/85m+9+dVXoRDJPxI0AQa0kE5yEH7tD//0aPeGOlp0zXRr1jQNAWWI1z+4ulgvtnd2RFXNDDCzpNLmlFTMzLI4EIAeF8HBcVI5Pj1ZIfN0wD7sDCb/7l/9GhIsPNg6cL+FKJodGTkmgeCV//V7l86dP5kf5k5XsTg33eSESVENLpw/OV14ZoEZm2cGoKomagYlds6FEJBTV9fJxHmfTeu6Ze9OmvV8fzmthu3h/ObR/O1vfPPKi8/9SCOdHYdOSzHHruua/esHw7U9u3m5mlSr9WJ9cjwOwYk1KWNQHeS2RFGiCBZJPaknBBVuG+na3HRZ2LnRkGJRJ2k78a5IeTVicrB9XTXTqk7d11/5I2eqqneQmFnXdQ830gC8AyjltDw6Xp4uKtWmba9sX1oNxl3T3kzrKgYPl9f1QOWo6F8GiIhAMBgZzEwDRMRaY2PNRjmZWc5SDgfWptIHA6ETNOnm3g0HzppvswJwzhFRjB/xwQdrSESObs7XJ4uRC63mk/c+GE1HmaztVqAi5DwW2SyHVARm9s4xs+tjlpqZZZfrul42bS1dTZairhiJ2m0/tcQVs5kG72jo59f2LWf/UVmrKvOdcrgnNN36V4SwOjm1lGM5bHK6cGFHRLBaFI4fn84ujaclUcVsokTknXMgMpCZqkJNg4hYK9qaHqVut15cPT2eN8ta6qhuWA5MOgfyZZjP5ymlGLyZ3c5JmPlu7vuOtKmqee9ODw6dGADzvDyeDzl8duv8E1s7A4ZJrpv6YHGavVGfVhNBjQyqysDKdQG+gosULnC4EDc+Oxt3av/7cI/axID3vm3bJFIfa1N3vix6WffC6Ll/8DHuB82AqRo7AFe/9z5lbdu2cfbEeLxVVJ/cPr/J4fDGXiepmo3jzrYzAGBDj/79uXJsojml3HZQC3BjH4johZ968tqH1/YWSyud984MXdO+/q3vvvDyS3zLgnArDXxYaADGRESS8rtvvoUsTdN0lbtSjoaxzM3qSM0Ni0kYGVtaNQMOfb8/+AkgHde+jL4sU1VlWJe7tq6bpvnp6cXp1jmoNrnJTGVRLZrT3/mvv/3cF79QFMVtYdyGfih5GIydM3C9Wl+/tsuiQpKVrlTT8dbmabM+ODkqy3JSsks6ieWKb3kHEQDBWcpUbW/WJK1JZ4lgleNRKEfg+sNrT1563Kpy/4N39k5OYzlBk772f766t7e3tbU1Go3uM5r39Gk2l6AErZf15imnc2NX2FfGs9HGtK7rerHc2ZhtTzaoM++isgsmXoSzUQdOLiQfEkchlZOcGlUoD6WYJj8kFyq4dhJ21/uzwH9356kNtu/4o+i8rrrXvv7N0XBUp05hTIx+iG/VKh4AfSZJQ9s0bd1omyofNwaDNnXSp9eqmnLOZ5kG0Pff30QBJTYyI3FOHcwpfEuhdmEdy1U1COwAFhEO/sJ0FhQASh+LEAG4M7c33BL3w0HfauvFsl0ttemmsZqNJiklEWFmNvTpRq88u9UVQQnKpAwQGyw4C4xgRqK2Bi99XMQywpOadokIV7bPjTrNpp5RlSUAor4a9YjQfeoDQ71aW8pOdFTEsQ8KEzszTjI45wAYkeL2WjEigNRIDTAmc+YhwTJLIkkmCrBTAEipbVL32HhjhigmuW6j831Uug/l/X2aAaS2i8zmtPKBbgnDEUONPAXnswpgRM5gZErcV2tYCWoQJ2xKpmWvF0IAe5AzZudFukVaT93oUjE80JNm2TbLFYzIYDAmAuDuqkXdTx7943apYWbPLgaXUyu4pQdRzUJE/fT1/tjrRBlC1MF3HDs2gbLl0vIYeWxSaSpzJmMjCiG00hZil8uxMmmWqx98+H2C3j2Z8ZCWd9vK27YFADb2TiwbCIBzzkRFhIjMDEwE9BoxghJl8gleiEjFREjUkaqRgkQ0iwZFVimKmGpF3Ux9TCTO0VtvvAkzZu4RTJXuyj0ePNIppWxZVeFgTGpmTP17Cp15sfUh97ZJKziDE1EHRxogHuJMSMRaycvUHjeNqnY5wbExaZciuDPx3u9+eBVqtyWRPu5d5t7QgtIFMJ596unVRuUXbbnWxBwBp9CsRKzM7H0oYkrt2pZlZz65Ncc0Hh6SND5w5w+DOEOplAKnyDFb2UqWbqE1M6d1UyKsTRcsXhWa5u9e0+NlVhNAVGKIXdviozWd+/m0wQB472OMm5ubVVX1Dt2//xndmg01ACMp5wFGND6tXbOaNPXWYoFhG1SgSTWTiFM452KMw7LyzhGRI2JmZiYiIxBRWzfXr+0yvp8LOOfu8Lz7QYspgKIoqlhszWaDsjLR28oxuhWpzaBWE406tNGOXbd9nKZGq1EedauBJiYxFpiwiiMOIVRF6b2/TXa2MAA4rtfrN777GjOpKhMDcN6rfQT73j5N6ANdGWP0oYqFA/Ue1A9zPzZiqqoEuE7qSegsex+vX9y4ujlgLo+Wi5EakwopqTkxhRnBgzxxH5h6AhE5y5uTvPXa6wBc751moIdOmHBW9Edf5sqSO8nRuT6IGJExmZKZmSiBYulP0vL48OjC05+hl76wWi02j6V49S3XHSghs3llE2SSs4kkkiwZfW3bskpWBVNk9/733kM2HwmAiRD7O+oh93OPfvqO5oeSs4iIKc4CB8gxeQc+8w8Ap1LPxJ07t1Vc3l6s5atXr/3f1cHEVUi2hi0ddTARFTMhYygZNIukrKqq2o80mAahuHFt9/DGPgGwjy+r3q/u4YgA7F69llJyzpF3mc6KysbEzLhdi1HbcdMP0rI9PK7e3JtVgy9//vN/bueCnWcDtcw1uBPKYp1KJiEo+pRLFYCaqaqYElER4+HB/MP3P4DBVPv87qEXIsAgS3k+n4uIL2KIMcn3J5eYbxszgHUrMytmG5uHV6/xn762fbw8rm+sTq4xR2HXOU4GEUvQfFbVQa/p29/7bj3xerE82N83PUuVDGc+9mDoDiBmMn7326+dn223Xbdsa1/G5J0nrp0uvUQxS3lNEl08qGov3k69bG7eWOzmP3xl8uo7q2UjnNdRBwmz5NeeT9mcZO9pKfVWNVhKIyLCOLB24KPjwFVIqW1PTsnAajCDWcRH8ul7v7mIkmOofPHlL39Qfef4228QkeZsRqbqmI25F6LzDsCFegTUbdGSX2+1PF77LrsTrobS7cCp0t6Erl/ZlNxWe+tymQbDweH+gXNuMBisTuvT1XI0mgyoktXi0888G2MEIcMCEd21EXZP6H5PNXv62a98aStOf++Nt2KMtO6EWHOORI64r0M758VsYYtgIqq50wSsVBZB9wrLda60qDgk2JUw0eOT82uNGhaWweRcWDeNMZkjZu5W9cWN2ezyY5ceuwyGOPIEuisDuXfVtLdk7zAqd566ssit856y9qXRPtHrndU5JyLr4akUyjxau/M3ws5BNc5ORnm5kK5rmgW65QDT0bgQ9+7Afv9KbHKqqsrMFqtlHI+UnYhsb2w+fvmx0Wj09DOfVFP2t2KhPpymYcg5Z1gH7aBUhDYnJRj3ZfKkkjwjeiayJN1G6wvxDegUthajmkanbjYnNxmRIbHqtJhujCaDqhyNh9tbLngVQBTsjSkzRsPJk5euNM6e+vSzYWvW5NTjpZTYPZymATjvM4TBSeX8+fP1/tFGEbMJHPfOWhIzs5garFrNslPh9VAWJfygHF/d2nmnOl/l/WcO8nguQ0n16vXV7ny4ufE5d2HNXkxDKFTycb3a2N4K4/H8xj4/ufniX3oZJszs+vLLXZtC94amfiLIAZuT6XA4FJ1TCLnpnHMO1NfBAOScC6JuGNja0rKnNA6RJoNuazLfcJ+5nsfTGJu2pNQcHTQx11tMMxbJIYSuEyPUqaUQzCw33Ut/5eXJ0z/VpqaIJQFQ8yHccWbhfiMtKsxkqmEyaeumUO0zjeAcM6tZL2s1JeKV2/et1SkvGTXk3On66dNu07oqRFm2b+sxCn62Ky/msPfOzeadmzLwhXNd14WyWqtc3X1fpht/8/mf+6u/8stw4H5jzgBReNd0bRmLB0MrizcHAwhgnT11sV2c1PPVILNFL0021bUSJBdmVLhBW5nRe3K86rqnpVp2J0daV+wpE4IPbqDk22KwH/KptUPnNhpbkbXRD40+zGvaGP75z73wpX/6D80TYP0WOggIDsAPEt8Puk88upR98Fzw5198/r35YhCOj67vm0rKOYLLWLlQtCklswEXBbnHmRe5nWgRiCx3btmEjZEU4YnWS6ajkTjV2YrZ2VrTSQlrJJ6fPpbKeu/Gp770s5Px4I7g97Ht3sFFlYid94kQCVs//Yn57JtumfI0OudcNnSyFhPJTSQr4tL54IujarBcLmlej71Lk1Eae5KQPUX2WWyJVDCGhWtzosJphdAENxtvHWIZBk88/xkoyD94g+ue0NKJLzwYBqw1DYeD4aXze+/tDoQrH9kxOTHD2rqWkV1omjZOYrx47oJsT+VGWLdrT6uYZzLounRY8VrzzgJFUSxjXp6uylE5aFwOXjXnk9UnP/3M1uMX4QQfjdiPBu1jNFU1kGdiB4/Ln/vs7lvfo5v7tSqpVGVRDcccXGOpIxnbjJsUa4rRI8Y6d8w8s+Ik2jqnA2YeVdsbw+nm1AWxGwM9Ws4aa4aMVWpT99xXXgS7FcnwR4EGEzoLgTOggDnQlYuXnn/uZPcmmEVE5Cypmo02zk0G63Hk71yzm4uudOuIPKy2i/KJY30LdS7oYuIYx3plCxvTy7WMYvm+vq+azOW6bopPXD730nNIye462PRo0AI4Zig8ozWpiQbR7zz3qfaVV6vBQETWx6fN0akullWbphxWzYK7lhxCLIbBJ6cO1nA6H8ebwYUO4uikTot6jlVS0uoTV9ZHi+rmcV3qk3/rL4bL52A8/LgIfffJkHueQsgAt8LOQXOOXgDJ3YDD8ubeaDyGc3a6aPbm67251HWM0XdJYMtp6cnPDlpnuhizmfpWR6PJ0Tg0bJstNalrKtoaj9Nxd2O+H7769q7vXvjHfz+DAO9bQ3HnQnwE6Hu1H+Ikzse2PjD1NYk+63r4ax9qW/eOmz3qJQ/s7VH7fGToH2O7XUm7e6fwARf+uKb7h2g/9Nmr/we3CGGz51L3NwAAAABJRU5ErkJggg==",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x60>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAIAAAC1nk4lAAATCUlEQVR4nL2aW4xm2XXX/2vtyznnu1Z9VV19m+nJeDKe8SUa22RGM44cMwZxS0CgKA8BXnnhBZ55ghfEA0IgEUUoLwQECEWICIJASUgkMomcENtjy/bcx3Pprq6urq9u3+Vc9l5r8XCq257u6ZttvFX66pM+nX1+Z+///q911t5kZniklgXO9V8NpjAFQBQ6gQMcMqDgAJABXW5jUIIDBYAUUAAwD7qr456E6O5f7mz0yNCAqmoWZubb9KpLxx4WQc4AhabOgoNzrgMcxGHZ1ZFcGSKANqfSh58ctMIIZx2bKJmBCMTC6HGRAbYcqAUa6Far6si8437sARCSaSB+pPv+SNAwqKmYknMEAsCAmrqaEAgeRgCUAKjCrHUOAEFDUhKAGYGNQPhJQmcFkzIyLJsagQxEZHAGibBQd7vfeu2NV/4k3Ti6OJqMvvLi45962m9NBFDJwXkATdeWsfoJQitAAEEAALcnff/kYGc8S9/b/Z//9j/O337vuWc+PZttXLu++7Xf/ZMXf+mvfeHv/HV6YmcFEc0D8pHcg5X744QGRKRt29IH5oBVc/LBtfn1G1/7/T8KgvXefP7hLhFtXtixYXFYLy/Pu7m17omdz7z80s+89Pzw0nl4Bj/CsvsxQC+7poqlA1b7h29+/Vuv//GfXf3uW6v50aiLddu0kp2PzjkVkaSkthjlktyIwgDOFXHj6Ss/8wsvf/Yv/Jyvwv8PaF2nNoQyGEEAQnZYQKfZeNn+wX/4L3/2P/4gzZfr9RrRx/GoUIhI13Vd1zGR956ZzczDRJWDd8Gv63rRrItBtbW19eKXv/Tzf/tvpIvTxtmII+UMxwJ15H946CQdMzvyMKgIAAU5z3uvvv6r/+yfH7197WIxLpWKWC3Wq0zmQ3DMZpZzNjNPDMDMiMzMjElV29SlnH0Rq6raX53Y5vBX/sHf++Iv/uWmbWJwt1z/wa5y78dyzAoYwMjeESwIvfvKN371H/2TdlFvxGoUy/pk0Syb4XBY13XKQjF6750PmsX6pioQIjKxpEKGQVGyd8gyLgfvv3v1P//LX5+Ww2d//gVzwaBImUJ8IPQ9H4vAJIYuq2oGFKQHp//t3/wGH9aXhhvtYnWyXIxnG7EMOWc2mOac2pxalUQmt//MTEREhNQciA1O4Y0IeGr7oj9Y/vt/8WuuyWoKMNGdYfLRoAEDM7wnZoNE4Hd/67ff+ca3L26d39+7ORqNXAz7x4fqOSMXozLGSEQiYlkAEJEjDs4XMTpmJvLOEdC2bdu2IrI4WqxOV5txcO2Nd37jX/960D5QPdS6vCe0A8ERHABEIzle/vf/9JuDUNSSQlmwCwCathVGNR4dLA699z10J1lEzMwI5M6UDcAANRORbKqE0XRC3p2s1hvD8e/85m+9+dVXoRDJPxI0AQa0kE5yEH7tD//0aPeGOlp0zXRr1jQNAWWI1z+4ulgvtnd2RFXNDDCzpNLmlFTMzLI4EIAeF8HBcVI5Pj1ZIfN0wD7sDCb/7l/9GhIsPNg6cL+FKJodGTkmgeCV//V7l86dP5kf5k5XsTg33eSESVENLpw/OV14ZoEZm2cGoKomagYlds6FEJBTV9fJxHmfTeu6Ze9OmvV8fzmthu3h/ObR/O1vfPPKi8/9SCOdHYdOSzHHruua/esHw7U9u3m5mlSr9WJ9cjwOwYk1KWNQHeS2RFGiCBZJPaknBBVuG+na3HRZ2LnRkGJRJ2k78a5IeTVicrB9XTXTqk7d11/5I2eqqneQmFnXdQ830gC8AyjltDw6Xp4uKtWmba9sX1oNxl3T3kzrKgYPl9f1QOWo6F8GiIhAMBgZzEwDRMRaY2PNRjmZWc5SDgfWptIHA6ETNOnm3g0HzppvswJwzhFRjB/xwQdrSESObs7XJ4uRC63mk/c+GE1HmaztVqAi5DwW2SyHVARm9s4xs+tjlpqZZZfrul42bS1dTZairhiJ2m0/tcQVs5kG72jo59f2LWf/UVmrKvOdcrgnNN36V4SwOjm1lGM5bHK6cGFHRLBaFI4fn84ujaclUcVsokTknXMgMpCZqkJNg4hYK9qaHqVut15cPT2eN8ta6qhuWA5MOgfyZZjP5ymlGLyZ3c5JmPlu7vuOtKmqee9ODw6dGADzvDyeDzl8duv8E1s7A4ZJrpv6YHGavVGfVhNBjQyqysDKdQG+gosULnC4EDc+Oxt3av/7cI/axID3vm3bJFIfa1N3vix6WffC6Ll/8DHuB82AqRo7AFe/9z5lbdu2cfbEeLxVVJ/cPr/J4fDGXiepmo3jzrYzAGBDj/79uXJsojml3HZQC3BjH4johZ968tqH1/YWSyud984MXdO+/q3vvvDyS3zLgnArDXxYaADGRESS8rtvvoUsTdN0lbtSjoaxzM3qSM0Ni0kYGVtaNQMOfb8/+AkgHde+jL4sU1VlWJe7tq6bpvnp6cXp1jmoNrnJTGVRLZrT3/mvv/3cF79QFMVtYdyGfih5GIydM3C9Wl+/tsuiQpKVrlTT8dbmabM+ODkqy3JSsks6ieWKb3kHEQDBWcpUbW/WJK1JZ4lgleNRKEfg+sNrT1563Kpy/4N39k5OYzlBk772f766t7e3tbU1Go3uM5r39Gk2l6AErZf15imnc2NX2FfGs9HGtK7rerHc2ZhtTzaoM++isgsmXoSzUQdOLiQfEkchlZOcGlUoD6WYJj8kFyq4dhJ21/uzwH9356kNtu/4o+i8rrrXvv7N0XBUp05hTIx+iG/VKh4AfSZJQ9s0bd1omyofNwaDNnXSp9eqmnLOZ5kG0Pff30QBJTYyI3FOHcwpfEuhdmEdy1U1COwAFhEO/sJ0FhQASh+LEAG4M7c33BL3w0HfauvFsl0ttemmsZqNJiklEWFmNvTpRq88u9UVQQnKpAwQGyw4C4xgRqK2Bi99XMQywpOadokIV7bPjTrNpp5RlSUAor4a9YjQfeoDQ71aW8pOdFTEsQ8KEzszTjI45wAYkeL2WjEigNRIDTAmc+YhwTJLIkkmCrBTAEipbVL32HhjhigmuW6j831Uug/l/X2aAaS2i8zmtPKBbgnDEUONPAXnswpgRM5gZErcV2tYCWoQJ2xKpmWvF0IAe5AzZudFukVaT93oUjE80JNm2TbLFYzIYDAmAuDuqkXdTx7943apYWbPLgaXUyu4pQdRzUJE/fT1/tjrRBlC1MF3HDs2gbLl0vIYeWxSaSpzJmMjCiG00hZil8uxMmmWqx98+H2C3j2Z8ZCWd9vK27YFADb2TiwbCIBzzkRFhIjMDEwE9BoxghJl8gleiEjFREjUkaqRgkQ0iwZFVimKmGpF3Ux9TCTO0VtvvAkzZu4RTJXuyj0ePNIppWxZVeFgTGpmTP17Cp15sfUh97ZJKziDE1EHRxogHuJMSMRaycvUHjeNqnY5wbExaZciuDPx3u9+eBVqtyWRPu5d5t7QgtIFMJ596unVRuUXbbnWxBwBp9CsRKzM7H0oYkrt2pZlZz65Ncc0Hh6SND5w5w+DOEOplAKnyDFb2UqWbqE1M6d1UyKsTRcsXhWa5u9e0+NlVhNAVGKIXdviozWd+/m0wQB472OMm5ubVVX1Dt2//xndmg01ACMp5wFGND6tXbOaNPXWYoFhG1SgSTWTiFM452KMw7LyzhGRI2JmZiYiIxBRWzfXr+0yvp8LOOfu8Lz7QYspgKIoqlhszWaDsjLR28oxuhWpzaBWE406tNGOXbd9nKZGq1EedauBJiYxFpiwiiMOIVRF6b2/TXa2MAA4rtfrN777GjOpKhMDcN6rfQT73j5N6ANdGWP0oYqFA/Ue1A9zPzZiqqoEuE7qSegsex+vX9y4ujlgLo+Wi5EakwopqTkxhRnBgzxxH5h6AhE5y5uTvPXa6wBc751moIdOmHBW9Edf5sqSO8nRuT6IGJExmZKZmSiBYulP0vL48OjC05+hl76wWi02j6V49S3XHSghs3llE2SSs4kkkiwZfW3bskpWBVNk9/733kM2HwmAiRD7O+oh93OPfvqO5oeSs4iIKc4CB8gxeQc+8w8Ap1LPxJ07t1Vc3l6s5atXr/3f1cHEVUi2hi0ddTARFTMhYygZNIukrKqq2o80mAahuHFt9/DGPgGwjy+r3q/u4YgA7F69llJyzpF3mc6KysbEzLhdi1HbcdMP0rI9PK7e3JtVgy9//vN/bueCnWcDtcw1uBPKYp1KJiEo+pRLFYCaqaqYElER4+HB/MP3P4DBVPv87qEXIsAgS3k+n4uIL2KIMcn3J5eYbxszgHUrMytmG5uHV6/xn762fbw8rm+sTq4xR2HXOU4GEUvQfFbVQa/p29/7bj3xerE82N83PUuVDGc+9mDoDiBmMn7326+dn223Xbdsa1/G5J0nrp0uvUQxS3lNEl08qGov3k69bG7eWOzmP3xl8uo7q2UjnNdRBwmz5NeeT9mcZO9pKfVWNVhKIyLCOLB24KPjwFVIqW1PTsnAajCDWcRH8ul7v7mIkmOofPHlL39Qfef4228QkeZsRqbqmI25F6LzDsCFegTUbdGSX2+1PF77LrsTrobS7cCp0t6Erl/ZlNxWe+tymQbDweH+gXNuMBisTuvT1XI0mgyoktXi0888G2MEIcMCEd21EXZP6H5PNXv62a98aStOf++Nt2KMtO6EWHOORI64r0M758VsYYtgIqq50wSsVBZB9wrLda60qDgk2JUw0eOT82uNGhaWweRcWDeNMZkjZu5W9cWN2ezyY5ceuwyGOPIEuisDuXfVtLdk7zAqd566ssit856y9qXRPtHrndU5JyLr4akUyjxau/M3ws5BNc5ORnm5kK5rmgW65QDT0bgQ9+7Afv9KbHKqqsrMFqtlHI+UnYhsb2w+fvmx0Wj09DOfVFP2t2KhPpymYcg5Z1gH7aBUhDYnJRj3ZfKkkjwjeiayJN1G6wvxDegUthajmkanbjYnNxmRIbHqtJhujCaDqhyNh9tbLngVQBTsjSkzRsPJk5euNM6e+vSzYWvW5NTjpZTYPZymATjvM4TBSeX8+fP1/tFGEbMJHPfOWhIzs5garFrNslPh9VAWJfygHF/d2nmnOl/l/WcO8nguQ0n16vXV7ny4ufE5d2HNXkxDKFTycb3a2N4K4/H8xj4/ufniX3oZJszs+vLLXZtC94amfiLIAZuT6XA4FJ1TCLnpnHMO1NfBAOScC6JuGNja0rKnNA6RJoNuazLfcJ+5nsfTGJu2pNQcHTQx11tMMxbJIYSuEyPUqaUQzCw33Ut/5eXJ0z/VpqaIJQFQ8yHccWbhfiMtKsxkqmEyaeumUO0zjeAcM6tZL2s1JeKV2/et1SkvGTXk3On66dNu07oqRFm2b+sxCn62Ky/msPfOzeadmzLwhXNd14WyWqtc3X1fpht/8/mf+6u/8stw4H5jzgBReNd0bRmLB0MrizcHAwhgnT11sV2c1PPVILNFL0021bUSJBdmVLhBW5nRe3K86rqnpVp2J0daV+wpE4IPbqDk22KwH/KptUPnNhpbkbXRD40+zGvaGP75z73wpX/6D80TYP0WOggIDsAPEt8Puk88upR98Fzw5198/r35YhCOj67vm0rKOYLLWLlQtCklswEXBbnHmRe5nWgRiCx3btmEjZEU4YnWS6ajkTjV2YrZ2VrTSQlrJJ6fPpbKeu/Gp770s5Px4I7g97Ht3sFFlYid94kQCVs//Yn57JtumfI0OudcNnSyFhPJTSQr4tL54IujarBcLmlej71Lk1Eae5KQPUX2WWyJVDCGhWtzosJphdAENxtvHWIZBk88/xkoyD94g+ue0NKJLzwYBqw1DYeD4aXze+/tDoQrH9kxOTHD2rqWkV1omjZOYrx47oJsT+VGWLdrT6uYZzLounRY8VrzzgJFUSxjXp6uylE5aFwOXjXnk9UnP/3M1uMX4QQfjdiPBu1jNFU1kGdiB4/Ln/vs7lvfo5v7tSqpVGVRDcccXGOpIxnbjJsUa4rRI8Y6d8w8s+Ik2jqnA2YeVdsbw+nm1AWxGwM9Ws4aa4aMVWpT99xXXgS7FcnwR4EGEzoLgTOggDnQlYuXnn/uZPcmmEVE5Cypmo02zk0G63Hk71yzm4uudOuIPKy2i/KJY30LdS7oYuIYx3plCxvTy7WMYvm+vq+azOW6bopPXD730nNIye462PRo0AI4Zig8ozWpiQbR7zz3qfaVV6vBQETWx6fN0akullWbphxWzYK7lhxCLIbBJ6cO1nA6H8ebwYUO4uikTot6jlVS0uoTV9ZHi+rmcV3qk3/rL4bL52A8/LgIfffJkHueQsgAt8LOQXOOXgDJ3YDD8ubeaDyGc3a6aPbm67251HWM0XdJYMtp6cnPDlpnuhizmfpWR6PJ0Tg0bJstNalrKtoaj9Nxd2O+H7769q7vXvjHfz+DAO9bQ3HnQnwE6Hu1H+Ikzse2PjD1NYk+63r4ax9qW/eOmz3qJQ/s7VH7fGToH2O7XUm7e6fwARf+uKb7h2g/9Nmr/we3CGGz51L3NwAAAABJRU5ErkJggg==\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAYaUlEQVR4nO16W7AmV3Xet9beuy//5dzmzFWj0YyuCCEBBgwEGwguMDFOsJ34JUWVq3DsKpw8uFJ2HvLkPCRxuWySGMdJsJ3CDhVsY2LZgDFgbrIEWAiwQCA0GjS6jeZ6Zs75r91777VWHvqcM+eMGCEhFeUHdnX91fX/f3d/vfrb3/rW2k1mhhdmKFpuy0kZB1agsVGdFyyAMkAZLkVYob05o54CNcDf+5Wex6FXjCRWAqmIBSZA3QQAEQ0cIjlYzeghJ4eMfppw+3wu5V8gyEBwUZRCQdL85q9/6ALSr7zzHx3bd/PETY36DGTAExWWQNx/fsF6wSI9hZbCPJu967c+sHdp8As/+5Zf++OHTl9oBlYOs/oMywbvQeXMAkn4BwGac5sDfvl/3C2X8EvvetsdN+//2Ttu/eXf+auTFwTCoFz7DNImkyOGPL9rvUCYUbf8X37/Uw8//NB/fNe/bNhzO37bjx198YHD7/mjP5mN8swxAAhKRwUUHJ/PtV64iXh6vPi+3/75n3nj8qGyRgNeErT//I3X7v/bz9Gnv1AAKQGgSEjQ6On5XOoFA33pj3737bdc//a3HKvFCAUc1rK79baDv3Lz/tEnP8LIFAKIPFBEX+j3l9MZwGwuaA1zZEQAcYz1lu96wL3m9lJKYYOg4ekeTy4leuvr7O+P69eOe6DlicMcBRrOyAZDzMkAGLr9Z0ma5wyaNaMXnIjmWhhmG+D+5OH7Lj74lXzuKeTWAsO4yn1D2bowGeX9G5f83Xc30hY2yAlICPAzJCEUPpAaFMhSuFA8OwzPWaczPIAieqnhkApbVMXpD31x/W3/Wm943cOXBo+M5s3aRjCq+v2qN9i3+Or0U2859uTaAWMSeNSNtc6mpV9hs9xGXxTGRs5pTMwez4Lu9FzTeIs5aQ1GkVvM+esjPhObx87ymXPf2PjCvfTle4uzJzXMNzyNMaiHh8Itr1p+w4/2+9cv7gtvXpHlQ+UeX8AnRAfHULNAM2QGV2BKivDdH/5zBo2cR973kJ98jD6+wU9efGR4z+fnn/vo8Ny5sLxPh3uzq2rlRaOm2ZjJ/LyP5elTGPanN1w/O/ZivOTVb7rtth9/UcUENjhGFoMjg7GZA+NZ6MpzB90CZbr7jHzuIYuf/eTKJ97fmq299I5T174q1P1c9qZE83am7bxyutiv63Ue44I99fhrvv3o8rfv1Xrw1Ze99tg7f/Gdrz9YAA4ICsxblCUcGkmV/+7C8j1EGo9O0+987J7+nR8sT5166BVv02tuO9/M9w2kGPSYCp2LV4YasUBTrAd65vxT5jjK0mB6wyMnr3nga2flwRt/7l3v+KWfTw6SpSIHAxjCcM8CwnMG3Sh+7y/ufuC9f8JHbr14x8tqzXE0WywHmkvuM7lIKbmyapgdl4h5Pr64MZsViQZ9Wre45pYOMN/+4BdH99+955W3/tvf+40ZUAKlAYDQ8wSdMfdthUAtt+W01H7kaUb/Lz9z/5//5p+uvOJHZjdd6ybzum1pUCUji2pbA4D3HkCMcXLxIhG54J1zxgRjcuycm8f22IfeU/7wy//db/37QaFTKkuCS5Gehe5dFbQaGDkTc8tctpN56Nf6d/ee+u//+X/O77h19brbyjGpkyYIFCkZGwAQEQAzIyJVbZpG2qYsy7IsOXhmJjgxFZH5qYcq7NfP/6/Db/2xX/vVfyMFSgBIwHfn9FX1xQgg822OJSzZIPDJtcn73vP+VK8MDx9rompsp3muIrWxL6sO7uaxZqoqIiLiihCqMlSl956ZiU0ltc0suirt2Tf4J7944mOf+fU7P1M2mEgD1e+K+JlAEyxphvMKIFSi+K/v/v1LOay88Q2DkQuX2lnfJ7LKuI3ZkjhiBkFNs2gWEyWDZ+e8B5GoxpTm8/l0Op3NZm3bDvYeacPFSVqsXvfPPvXb7/nolx8ZMEXFs5ljzwQ6JI4eIYkCd37m49++99tLP/TytVZyBldFmxrX5JRlpJGbJCJ5a3Qx7kjCzKqac5acU0pt21qWwvnRbKyTDc+TS4MjK/tv+oPf+E+n27LwZfegvlfQChSh1RzYzSI+/YcfOHDdLSP2fpqnrDNKBEApTprCqHEppdTB7a7aMUQ7luScU8o5W06aokgyE6Q5NUmRZxtnF25/E6bzP/yDP96uDZ4Z99VzZtY5YcgFHO6791770oOnJGKmtfdZk8W2X1Tol0bOJ21TY7uHbo+UJabcxjifxRhV1cxSSqzmdbDm5gerpfNujOWX3/eRv7wwSs8c4+8G2nEFbgDV/JH3/9lBC6Gs106fHc9GdVX0vI/r49QkXe5NSBbzpmhsR7aLupl1/M4xpTZqFuec954YJapJSXVe3PBjnrE7eoAvFB/80PueF+jsiCIy5g8/de7EJz473LNo9Z45j0aji7lt4FicBdLQtqXjCWmOM2gkS2SJkUkicovc5hxFEpG54F3wzAyAyWkViqJQN3UjphQ3ZmO65tDpD344gYRILG/iMJiZYZeqPMNEzFAUCJ/667uwcfrc9bf7cnFhcTWpzdoYRY1dUps3MSZRo2xIalG0zRJFxaAgsAM7MSTRbFDibhNQSskxmkujhrKpUra0d+/xk+e+9IUvOYCZzUQVINBONX1m0AKDR6H2N399z3KvXDv60no43L//xl49kGxtk0SRxXJWMwKY2IMcyMEYxgoWo+3NyBGcKWUxURB7aF6/sMY5+34BUUdVu7K3Xj36+c/eRQaoKcxoK8C2C+fVI22FeT1+/4nHv/7NPfuuPZWQ8sy5sG91pQxOc7QUmSx49o5Ms2mGCUwYSiYmSXPMsSGTbuu+V0ndluYtM5aWljhp0zTUr129GJf2nzz+CAyqSmQgVoM9rd9w1colAI3w7/6/j+9de2xw+DWXzI5kl6anTJCamYiwdyEEH4KK5mbekRWAbkmHiZqZZTIzIzDzdpI3M1aEstyIbUihHg5Sr+hZuU6uOX02RfgyqCWQbpFjF0Geodxq739g7c8/9cV3lCkvHrDhAjfu4rmHN8ZkZt77oiiKonDBA0gpEdG23pFhG1zO2XvvvZeUk2QzY2bnHBmPxlOmPMzmFoJCZ2sXhfXJixuPnz5/9NheGMOU4MAENewg9lVBq9qffeSvFp86e8Pqwb9duXYhlJpy09TOGzOTY/Le2GcBEYWiTiqbITR0NwAzmBWhDCEwc84ZIuSdcw6AzOf1cGFYhdGFMUYb4m1jNPMXzk8Ux08+cd2xvUyOTDe9F+/i8VVBnxvHOz9x5+ulCUvXnTtw09GicHvDML+e7WLOuWkaETFCzhlAVVVGRESONh9nl7pVtaqqLnt7rwu9Xq/XizlPJpPKuWp1X5FlsLJfzj7x+GMnUh0WNHHZe+Ls2SahH4iIoDBAcSVoRTQ4B4JwFmhhhRju+eoTvB6P1Pr1O/7pwC2eGp2ZHn+cqpuP3biXHPcG/SQWc4KXHNNk1hBtPnfnXJdimNl7nzQlESFU/UE9GOSUm9nMRPqr1wTv5u04Ty9Omma4sroo6cTCkZX2iS+f5p+RiwOsWGDw1JSIe7s4nQFXOGyad0YWODjCiZOTpVLPHHrxqTpwvOAqCweW3GjjzBkZDAb94aAoihCCiOSQRSSltvNJqootS83MKSUzK8u6C/l8OvPOLS8vT2ZNbGUyGkk7i22LHHulP3L06Pihtcl07cLZuHoEJGidFdTn3aH2zkwJRlCzACfgTJCYn3jsgesWW7nph4r+omkDG15XHpmuTNfnoxgjplMXIzM7F7pJGYJLKXUQu1N3cuGcK8sylBURxRidc8SYzWaxmaU2zqdTkwSzFHNu5v1eXaxc++TXv3pq/PoXmWZhuLLrP+0cTJkd1JkyOzIwhQicPf3E2lOPHF28hVduH8Jny+O2baJpv1lZWqiqopuqAIjMTDRH51wIoaqquq7ruq6qqiiKDvHmzBMBUJbBEU0mozSfzSYjk8SwEEIIoYlpPJnygQMbDx1/4KEHYSwFDI4UT0vjTCKymSkF3lBAR3//zeLx+3jppqdceCpdiDOrjM/4aWgiEZGZ5pRSKynlGHOMKaUs0SDs4AN3m/PkPBXe55zb+SzHtplNR+sXR6P1FBuoQCU4NrMYIzMz83w+n+S0uLr/E+9978QsYV4Jg1R5N+js0DjbjFsGMryIe+DEv3joCa+VrJ+n8XpDftjOefytc/N2Op40TdM5zJxj285TalUVOSEnS1HaZuc2GW3k2EhqUzuX1EqOsZ23s+lkMumUR3KK8ybnyAxmtlmrh4+M7rnvo5/9ZAEPhbIw7crcHoCHgyoYFkBiQO6Pp+tanslpqnl56iPPbnji5E+e+vQHDr321MLhqlf3hoO66oMppZTaqKrz8XpnTbc53cm2L8qq3wu+VFV2ADS1TTObw6gsy5yzmYXCOVM4X/a9ZFxK/LKbbvrTd/+3n37TWxDbFMrSduVE7zO8I2RYIck5OCqgoeSPpScXz54oDhxSkGla9fKTk3P/O+lwOGTvCud9YB/KoihyKFS1X/A2Yu99l19EhEPZkVsJEtvpdOqIl5cXHRdlWc7nc5h69nE2jamty8qFsI967sbDzef+5pvHL73sloECuAK0eQCMYGU0OIxcKqIN9l07euWPfuvz//ea3s2zPcM0at5y/uRdvaO0cqjs1SmllCQI4MiM2IfAIYbCRFQEgDB3k88BwTlmVpPYtDEl8qEqC++9Zck5w9SZShtVldi1OYciT8qljfiSRb5r1jxq9HIfgWKX5rHZ1j0QAxbAzXRWHzn4r37hV3s333jqwj3NPN9YnlvND91/8GY7fCyE0DVics4iaas9I8y8rR5lWXrvu0TDzKq5k8IQQlmWzgVVJaKY03w+n7dNjDFtj2nLsVkPGN94fV0sk32HRognAAYigmcICrhp0uq2G19eL//j6uBds3ZjefXHLzzYn+WHX/yipQH5XBJRzNolavahk7NOkp1zXZtGO66Y5Ry7AgxqztMWbUygWVJWISL2nlUZRCA2XxONe2Vzy+1kfXT+1HYVApdb2EYAwxl81cee1aeOj66xhaWD+/YP5Ce+cv5zg6OP7jl8WCv1FMiBN5PIFZ9dCDs2byvM9gW3vwRg0pXu6pwj21Q0ZvahFwpXON4YHpqMBArPKVOx0yR5AFkyM4jZCKTo9YbR6Wg8mzmaruxfBN29fOCDywtBuA0UBF2vSETEFFCzzd5aJ2HbN3DZqXYuimA7vieDI8B5BjQroMxcFEXLYOQq8iiXG+N1cwfIoHSFnzYok2fqZqga2CFBeLZuTdPW5RpW3vuiH57qZKmd5Wnksu/YsXdG0LzZL+iQde6/A73pToGuOFBVMrDjLt4ikifjzX967qhvpGYmZMlsQbgfKZQZBGS6wox6GMwxuhLHsXmwIYDKqY2ToOgPm/Fa1etxHGf0xpUVtrMjszkPtwK8szbZYsWWchNMHQBTUkGczlVVSbuZ3ZULIuIGfQ+KLMNe2Lu/JgDs/G7J486wAoAoAAU0pQK8b5haG+d2NTsldi7XFGc2SB1fu87G9nzruHGZCVu4scPudbHvPKBzbnlhsa4qqOYYJaVuHjOzT4qMDWtd7ZeXSxiMHV9hmCxolQmZETxh5jFjFzDlabH0jZvfvIdT4znESZvg6qXkS1ZxBjIGGGAixyCCEjkzUoVZVwy4DnFiIe2HXLJxS6NWm1mRfvrC1966/o2juegvH8k+NzF6XaySz4V5XzSenYSDtV9eWWwSFBm0q/PEEJiHeBiMpWBUM5dGfb0gYsMBerUQM9EglCGpb1uAxUxhZqaAqibJMXW1lqjmbjPb/IZlbnYppvGGzpCWD+dL/+HLX1ij3tjwc6c+/Pb274rVZapclAsXWDu5JDYi6vWqylfeA09r7XmAATUAxCCvGWpTH2xtlsrBUuOLnBs248KjTWUowGwqKio7fDMAMnQVrZmBLpuyOq3MC6o5VsLzXnzHN7/9yvgVd/722y49eaFofurECdmb71y5jVV77kIP+9QSEdRsYVA5ckRgMPFuw0QOMPZmAhjDEwZpGB9+4rFHzzFKi7koPEFnmhpKAgp5W7O2tLmbbvlp7QlSAFk2IqqCG7F+0c4/vzw4Ub8GUnx2aXEkS8H3zg+tXOqJlP01ynmD0COYJh0O6q5JYyDaXQV4keQogIjIgGzg9nx6z7s/eOrIjUXVn8wzdUxQreuaneWm3ewBEKuqiHaNRpgHdHsiAjBjAK33So0hD8S5tv/hAy9ZnPWz3/AWxBvratWklE8VWepYPVaOFyMDSVWXlvtk1HEAu2eid86JdnqUPSdQgWuqjWMH19qWe0vIahZJ1KEYUJhP1mGsWws1nTIEZiI2MoDMpBPP7kbNDFgdNGcal2o7q1g4dFE3ipNuNGjDY8BA5Mk0buumn+owL+JiHABmJo7c3tUFJjbLoCtbBh5gJXiA2MFIACW84Sde+fhHHpzP2kAgJsBL0vF4ujFeizHmmFJqoZmZvS+8K+D4cqbRvNNVQ473m3Sul2KRl5oV4sw4g9mhOelKnk97GgJLUUZfl4ZxMV5KA5A6V+xZXiDASBmA0q7CNgOBFKowUvYg9KBvfvG1X7m//dZDj08ltZqVKIKFxA0HxcaGs+zMmYKZmUmklWik7ZYwS1c7beY5m86Wj+zXRltEZtQzx9fX3pfEEqZDkXlvIZOr40YzCAfmveRcl2CrulAFTMHAFWncd8LXtY03uUigcrhgF2djc54tWS7hrPCgWUiDpZyzy9lMHcjMWJMXNSx0nkQt01aTSTVrWKyZjHpUozAzK5g598mTGS3BuCImIiqKXsSUpbAUJRA3p0+NXnHTHhGXCYTWdUt2W/T4ziNJbmJeWFloZ9n5QkhVExOZEpFjR6pZzQzG5M2ZMZla55lAampkIGJiAlFXtXeJvuONwRwFeCZiAGbKIGby5EqEOD+/vFKrKMAE8G5PfVXQbTsv6wquJO/LomcmKWtROZLchdCky+HSPTkiEsmdNSXd9CfOObiuVUbbib37c86ZmNm5zW4qGdTMpE2qqqtL5Q1HDzAHkGZNhrCztL0q6Lqg4bA/EXWhLopCc4I670pybGYiTlhIM9R1UFRSZzEACEQJRGTcmVLqYnz57ERFqBTS3UC3CiMiqgbyNp7cfse1C0OnBoJ51t1tj6s31a87tCpxygTvvYnm1BqkM0k555xjzlGzdOYpxphSVBUz7WonVSNigLaXbrsKYHuAtDNWojnl2PGKnGcfKidvfPXLSlK7ytrcVSN9y5G9nGdFtShtTCmqtC5AcjRL3eogNgVOVdVUSY1gIqIpCSyEwLwj0zxtaEpExESac1Rl9r4IIYR5zjcfXHzlbTc6qDFMAbgs8M+GHtfuHbz01hu++uj6xvpaIeTKkCG5ZZN4+e7NaMvaqaQUJasAcBzYoCkrwWHTqWJH2MyMaVMfVRVg88LMQi6L3PGSY8MKmimRemYYX/HiylVB9zx+5LWvuvdbf7GxdqEwv7SyOG8baX2K006GjS6bZiJimIiYagghlJ7gRMREZQvlFRVDcJZS6irIEErmSmLKWcZNc/TIKgRd554BzYBPOwXkO4DuHmmEv+0o3nTHvv/z4JeePD9qRyt5OkrNZJamzjHzZhnL7ItQh1CKL81UcpPTXCQTcVEUoahgOefc1X9dZUlEIYRGqaqKvvOiWaeph2r//v379qzsHfhbDu8TDzbxMIDJs+2WvKu/7xEvcTG4OE733f+t4yceSe28593CsFbKReGrqvCBYSxiKYkKylAzwxEIGYBzzvnCe89kZtaB7jpPXYeE2AfP3ntmMJH3XJZlFYpUDEsPy8okzlFXauyutp7hzRpJMIMrAIAAE5DCFLadmXZ0fbpz8Fb/ygxGmwdu//od9hVmYN4BSaWz51stJFFxzils52tkV+W0cZAMD6jCYKoIIYgKbVK5k9iuCCdTogDbDIIR03b7bTskO2NjZo66KMJMzTY9LYE1tWB2HAComPMOUFVhvsyQq0Y6AgwQNKdYhAKAggVwl4V+e4cN5jdXsa3LJluR75YxLwdpe18t72jgMmx70U0BwLyKEXWlJmy3zbsqaLHMxLSJjE1gRuy2aohuwQ1dJ2tHJHdQ7/LDf/rYJulOzgAAks6DL3dmvW4lcufRV+e0AoCIusCbJ9WOr4rLseyiYgAUZgSmXT17BjI2Wzmdb9r9I9S61Hj5J7cFN+fo/eabY6q7bv4Z3stTYPM1+CQpOOc2g1sAsK3gEKj7J3Vr7tQd2Vm8rrzZHerNxs1OH3L5imYGcjHmovCAqinDbc6RnUdcHfQ/3PHCvV7/fRw/AP39Gj8A/f0aPwD9/Rr/HwzxAHEEsH4RAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAYaUlEQVR4nO16W7AmV3Xet9beuy//5dzmzFWj0YyuCCEBBgwEGwguMDFOsJ34JUWVq3DsKpw8uFJ2HvLkPCRxuWySGMdJsJ3CDhVsY2LZgDFgbrIEWAiwQCA0GjS6jeZ6Zs75r91777VWHvqcM+eMGCEhFeUHdnX91fX/f3d/vfrb3/rW2k1mhhdmKFpuy0kZB1agsVGdFyyAMkAZLkVYob05o54CNcDf+5Wex6FXjCRWAqmIBSZA3QQAEQ0cIjlYzeghJ4eMfppw+3wu5V8gyEBwUZRCQdL85q9/6ALSr7zzHx3bd/PETY36DGTAExWWQNx/fsF6wSI9hZbCPJu967c+sHdp8As/+5Zf++OHTl9oBlYOs/oMywbvQeXMAkn4BwGac5sDfvl/3C2X8EvvetsdN+//2Ttu/eXf+auTFwTCoFz7DNImkyOGPL9rvUCYUbf8X37/Uw8//NB/fNe/bNhzO37bjx198YHD7/mjP5mN8swxAAhKRwUUHJ/PtV64iXh6vPi+3/75n3nj8qGyRgNeErT//I3X7v/bz9Gnv1AAKQGgSEjQ6On5XOoFA33pj3737bdc//a3HKvFCAUc1rK79baDv3Lz/tEnP8LIFAKIPFBEX+j3l9MZwGwuaA1zZEQAcYz1lu96wL3m9lJKYYOg4ekeTy4leuvr7O+P69eOe6DlicMcBRrOyAZDzMkAGLr9Z0ma5wyaNaMXnIjmWhhmG+D+5OH7Lj74lXzuKeTWAsO4yn1D2bowGeX9G5f83Xc30hY2yAlICPAzJCEUPpAaFMhSuFA8OwzPWaczPIAieqnhkApbVMXpD31x/W3/Wm943cOXBo+M5s3aRjCq+v2qN9i3+Or0U2859uTaAWMSeNSNtc6mpV9hs9xGXxTGRs5pTMwez4Lu9FzTeIs5aQ1GkVvM+esjPhObx87ymXPf2PjCvfTle4uzJzXMNzyNMaiHh8Itr1p+w4/2+9cv7gtvXpHlQ+UeX8AnRAfHULNAM2QGV2BKivDdH/5zBo2cR973kJ98jD6+wU9efGR4z+fnn/vo8Ny5sLxPh3uzq2rlRaOm2ZjJ/LyP5elTGPanN1w/O/ZivOTVb7rtth9/UcUENjhGFoMjg7GZA+NZ6MpzB90CZbr7jHzuIYuf/eTKJ97fmq299I5T174q1P1c9qZE83am7bxyutiv63Ue44I99fhrvv3o8rfv1Xrw1Ze99tg7f/Gdrz9YAA4ICsxblCUcGkmV/+7C8j1EGo9O0+987J7+nR8sT5166BVv02tuO9/M9w2kGPSYCp2LV4YasUBTrAd65vxT5jjK0mB6wyMnr3nga2flwRt/7l3v+KWfTw6SpSIHAxjCcM8CwnMG3Sh+7y/ufuC9f8JHbr14x8tqzXE0WywHmkvuM7lIKbmyapgdl4h5Pr64MZsViQZ9Wre45pYOMN/+4BdH99+955W3/tvf+40ZUAKlAYDQ8wSdMfdthUAtt+W01H7kaUb/Lz9z/5//5p+uvOJHZjdd6ybzum1pUCUji2pbA4D3HkCMcXLxIhG54J1zxgRjcuycm8f22IfeU/7wy//db/37QaFTKkuCS5Gehe5dFbQaGDkTc8tctpN56Nf6d/ee+u//+X/O77h19brbyjGpkyYIFCkZGwAQEQAzIyJVbZpG2qYsy7IsOXhmJjgxFZH5qYcq7NfP/6/Db/2xX/vVfyMFSgBIwHfn9FX1xQgg822OJSzZIPDJtcn73vP+VK8MDx9rompsp3muIrWxL6sO7uaxZqoqIiLiihCqMlSl956ZiU0ltc0suirt2Tf4J7944mOf+fU7P1M2mEgD1e+K+JlAEyxphvMKIFSi+K/v/v1LOay88Q2DkQuX2lnfJ7LKuI3ZkjhiBkFNs2gWEyWDZ+e8B5GoxpTm8/l0Op3NZm3bDvYeacPFSVqsXvfPPvXb7/nolx8ZMEXFs5ljzwQ6JI4eIYkCd37m49++99tLP/TytVZyBldFmxrX5JRlpJGbJCJ5a3Qx7kjCzKqac5acU0pt21qWwvnRbKyTDc+TS4MjK/tv+oPf+E+n27LwZfegvlfQChSh1RzYzSI+/YcfOHDdLSP2fpqnrDNKBEApTprCqHEppdTB7a7aMUQ7luScU8o5W06aokgyE6Q5NUmRZxtnF25/E6bzP/yDP96uDZ4Z99VzZtY5YcgFHO6791770oOnJGKmtfdZk8W2X1Tol0bOJ21TY7uHbo+UJabcxjifxRhV1cxSSqzmdbDm5gerpfNujOWX3/eRv7wwSs8c4+8G2nEFbgDV/JH3/9lBC6Gs106fHc9GdVX0vI/r49QkXe5NSBbzpmhsR7aLupl1/M4xpTZqFuec954YJapJSXVe3PBjnrE7eoAvFB/80PueF+jsiCIy5g8/de7EJz473LNo9Z45j0aji7lt4FicBdLQtqXjCWmOM2gkS2SJkUkicovc5hxFEpG54F3wzAyAyWkViqJQN3UjphQ3ZmO65tDpD344gYRILG/iMJiZYZeqPMNEzFAUCJ/667uwcfrc9bf7cnFhcTWpzdoYRY1dUps3MSZRo2xIalG0zRJFxaAgsAM7MSTRbFDibhNQSskxmkujhrKpUra0d+/xk+e+9IUvOYCZzUQVINBONX1m0AKDR6H2N399z3KvXDv60no43L//xl49kGxtk0SRxXJWMwKY2IMcyMEYxgoWo+3NyBGcKWUxURB7aF6/sMY5+34BUUdVu7K3Xj36+c/eRQaoKcxoK8C2C+fVI22FeT1+/4nHv/7NPfuuPZWQ8sy5sG91pQxOc7QUmSx49o5Ms2mGCUwYSiYmSXPMsSGTbuu+V0ndluYtM5aWljhp0zTUr129GJf2nzz+CAyqSmQgVoM9rd9w1colAI3w7/6/j+9de2xw+DWXzI5kl6anTJCamYiwdyEEH4KK5mbekRWAbkmHiZqZZTIzIzDzdpI3M1aEstyIbUihHg5Sr+hZuU6uOX02RfgyqCWQbpFjF0Geodxq739g7c8/9cV3lCkvHrDhAjfu4rmHN8ZkZt77oiiKonDBA0gpEdG23pFhG1zO2XvvvZeUk2QzY2bnHBmPxlOmPMzmFoJCZ2sXhfXJixuPnz5/9NheGMOU4MAENewg9lVBq9qffeSvFp86e8Pqwb9duXYhlJpy09TOGzOTY/Le2GcBEYWiTiqbITR0NwAzmBWhDCEwc84ZIuSdcw6AzOf1cGFYhdGFMUYb4m1jNPMXzk8Ux08+cd2xvUyOTDe9F+/i8VVBnxvHOz9x5+ulCUvXnTtw09GicHvDML+e7WLOuWkaETFCzhlAVVVGRESONh9nl7pVtaqqLnt7rwu9Xq/XizlPJpPKuWp1X5FlsLJfzj7x+GMnUh0WNHHZe+Ls2SahH4iIoDBAcSVoRTQ4B4JwFmhhhRju+eoTvB6P1Pr1O/7pwC2eGp2ZHn+cqpuP3biXHPcG/SQWc4KXHNNk1hBtPnfnXJdimNl7nzQlESFU/UE9GOSUm9nMRPqr1wTv5u04Ty9Omma4sroo6cTCkZX2iS+f5p+RiwOsWGDw1JSIe7s4nQFXOGyad0YWODjCiZOTpVLPHHrxqTpwvOAqCweW3GjjzBkZDAb94aAoihCCiOSQRSSltvNJqootS83MKSUzK8u6C/l8OvPOLS8vT2ZNbGUyGkk7i22LHHulP3L06Pihtcl07cLZuHoEJGidFdTn3aH2zkwJRlCzACfgTJCYn3jsgesWW7nph4r+omkDG15XHpmuTNfnoxgjplMXIzM7F7pJGYJLKXUQu1N3cuGcK8sylBURxRidc8SYzWaxmaU2zqdTkwSzFHNu5v1eXaxc++TXv3pq/PoXmWZhuLLrP+0cTJkd1JkyOzIwhQicPf3E2lOPHF28hVduH8Jny+O2baJpv1lZWqiqopuqAIjMTDRH51wIoaqquq7ruq6qqiiKDvHmzBMBUJbBEU0mozSfzSYjk8SwEEIIoYlpPJnygQMbDx1/4KEHYSwFDI4UT0vjTCKymSkF3lBAR3//zeLx+3jppqdceCpdiDOrjM/4aWgiEZGZ5pRSKynlGHOMKaUs0SDs4AN3m/PkPBXe55zb+SzHtplNR+sXR6P1FBuoQCU4NrMYIzMz83w+n+S0uLr/E+9978QsYV4Jg1R5N+js0DjbjFsGMryIe+DEv3joCa+VrJ+n8XpDftjOefytc/N2Op40TdM5zJxj285TalUVOSEnS1HaZuc2GW3k2EhqUzuX1EqOsZ23s+lkMumUR3KK8ybnyAxmtlmrh4+M7rnvo5/9ZAEPhbIw7crcHoCHgyoYFkBiQO6Pp+tanslpqnl56iPPbnji5E+e+vQHDr321MLhqlf3hoO66oMppZTaqKrz8XpnTbc53cm2L8qq3wu+VFV2ADS1TTObw6gsy5yzmYXCOVM4X/a9ZFxK/LKbbvrTd/+3n37TWxDbFMrSduVE7zO8I2RYIck5OCqgoeSPpScXz54oDhxSkGla9fKTk3P/O+lwOGTvCud9YB/KoihyKFS1X/A2Yu99l19EhEPZkVsJEtvpdOqIl5cXHRdlWc7nc5h69nE2jamty8qFsI967sbDzef+5pvHL73sloECuAK0eQCMYGU0OIxcKqIN9l07euWPfuvz//ea3s2zPcM0at5y/uRdvaO0cqjs1SmllCQI4MiM2IfAIYbCRFQEgDB3k88BwTlmVpPYtDEl8qEqC++9Zck5w9SZShtVldi1OYciT8qljfiSRb5r1jxq9HIfgWKX5rHZ1j0QAxbAzXRWHzn4r37hV3s333jqwj3NPN9YnlvND91/8GY7fCyE0DVics4iaas9I8y8rR5lWXrvu0TDzKq5k8IQQlmWzgVVJaKY03w+n7dNjDFtj2nLsVkPGN94fV0sk32HRognAAYigmcICrhp0uq2G19eL//j6uBds3ZjefXHLzzYn+WHX/yipQH5XBJRzNolavahk7NOkp1zXZtGO66Y5Ry7AgxqztMWbUygWVJWISL2nlUZRCA2XxONe2Vzy+1kfXT+1HYVApdb2EYAwxl81cee1aeOj66xhaWD+/YP5Ce+cv5zg6OP7jl8WCv1FMiBN5PIFZ9dCDs2byvM9gW3vwRg0pXu6pwj21Q0ZvahFwpXON4YHpqMBArPKVOx0yR5AFkyM4jZCKTo9YbR6Wg8mzmaruxfBN29fOCDywtBuA0UBF2vSETEFFCzzd5aJ2HbN3DZqXYuimA7vieDI8B5BjQroMxcFEXLYOQq8iiXG+N1cwfIoHSFnzYok2fqZqga2CFBeLZuTdPW5RpW3vuiH57qZKmd5Wnksu/YsXdG0LzZL+iQde6/A73pToGuOFBVMrDjLt4ikifjzX967qhvpGYmZMlsQbgfKZQZBGS6wox6GMwxuhLHsXmwIYDKqY2ToOgPm/Fa1etxHGf0xpUVtrMjszkPtwK8szbZYsWWchNMHQBTUkGczlVVSbuZ3ZULIuIGfQ+KLMNe2Lu/JgDs/G7J486wAoAoAAU0pQK8b5haG+d2NTsldi7XFGc2SB1fu87G9nzruHGZCVu4scPudbHvPKBzbnlhsa4qqOYYJaVuHjOzT4qMDWtd7ZeXSxiMHV9hmCxolQmZETxh5jFjFzDlabH0jZvfvIdT4znESZvg6qXkS1ZxBjIGGGAixyCCEjkzUoVZVwy4DnFiIe2HXLJxS6NWm1mRfvrC1966/o2juegvH8k+NzF6XaySz4V5XzSenYSDtV9eWWwSFBm0q/PEEJiHeBiMpWBUM5dGfb0gYsMBerUQM9EglCGpb1uAxUxhZqaAqibJMXW1lqjmbjPb/IZlbnYppvGGzpCWD+dL/+HLX1ij3tjwc6c+/Pb274rVZapclAsXWDu5JDYi6vWqylfeA09r7XmAATUAxCCvGWpTH2xtlsrBUuOLnBs248KjTWUowGwqKio7fDMAMnQVrZmBLpuyOq3MC6o5VsLzXnzHN7/9yvgVd/722y49eaFofurECdmb71y5jVV77kIP+9QSEdRsYVA5ckRgMPFuw0QOMPZmAhjDEwZpGB9+4rFHzzFKi7koPEFnmhpKAgp5W7O2tLmbbvlp7QlSAFk2IqqCG7F+0c4/vzw4Ub8GUnx2aXEkS8H3zg+tXOqJlP01ynmD0COYJh0O6q5JYyDaXQV4keQogIjIgGzg9nx6z7s/eOrIjUXVn8wzdUxQreuaneWm3ewBEKuqiHaNRpgHdHsiAjBjAK33So0hD8S5tv/hAy9ZnPWz3/AWxBvratWklE8VWepYPVaOFyMDSVWXlvtk1HEAu2eid86JdnqUPSdQgWuqjWMH19qWe0vIahZJ1KEYUJhP1mGsWws1nTIEZiI2MoDMpBPP7kbNDFgdNGcal2o7q1g4dFE3ipNuNGjDY8BA5Mk0buumn+owL+JiHABmJo7c3tUFJjbLoCtbBh5gJXiA2MFIACW84Sde+fhHHpzP2kAgJsBL0vF4ujFeizHmmFJqoZmZvS+8K+D4cqbRvNNVQ473m3Sul2KRl5oV4sw4g9mhOelKnk97GgJLUUZfl4ZxMV5KA5A6V+xZXiDASBmA0q7CNgOBFKowUvYg9KBvfvG1X7m//dZDj08ltZqVKIKFxA0HxcaGs+zMmYKZmUmklWik7ZYwS1c7beY5m86Wj+zXRltEZtQzx9fX3pfEEqZDkXlvIZOr40YzCAfmveRcl2CrulAFTMHAFWncd8LXtY03uUigcrhgF2djc54tWS7hrPCgWUiDpZyzy9lMHcjMWJMXNSx0nkQt01aTSTVrWKyZjHpUozAzK5g598mTGS3BuCImIiqKXsSUpbAUJRA3p0+NXnHTHhGXCYTWdUt2W/T4ziNJbmJeWFloZ9n5QkhVExOZEpFjR6pZzQzG5M2ZMZla55lAampkIGJiAlFXtXeJvuONwRwFeCZiAGbKIGby5EqEOD+/vFKrKMAE8G5PfVXQbTsv6wquJO/LomcmKWtROZLchdCky+HSPTkiEsmdNSXd9CfOObiuVUbbib37c86ZmNm5zW4qGdTMpE2qqqtL5Q1HDzAHkGZNhrCztL0q6Lqg4bA/EXWhLopCc4I670pybGYiTlhIM9R1UFRSZzEACEQJRGTcmVLqYnz57ERFqBTS3UC3CiMiqgbyNp7cfse1C0OnBoJ51t1tj6s31a87tCpxygTvvYnm1BqkM0k555xjzlGzdOYpxphSVBUz7WonVSNigLaXbrsKYHuAtDNWojnl2PGKnGcfKidvfPXLSlK7ytrcVSN9y5G9nGdFtShtTCmqtC5AcjRL3eogNgVOVdVUSY1gIqIpCSyEwLwj0zxtaEpExESac1Rl9r4IIYR5zjcfXHzlbTc6qDFMAbgs8M+GHtfuHbz01hu++uj6xvpaIeTKkCG5ZZN4+e7NaMvaqaQUJasAcBzYoCkrwWHTqWJH2MyMaVMfVRVg88LMQi6L3PGSY8MKmimRemYYX/HiylVB9zx+5LWvuvdbf7GxdqEwv7SyOG8baX2K006GjS6bZiJimIiYagghlJ7gRMREZQvlFRVDcJZS6irIEErmSmLKWcZNc/TIKgRd554BzYBPOwXkO4DuHmmEv+0o3nTHvv/z4JeePD9qRyt5OkrNZJamzjHzZhnL7ItQh1CKL81UcpPTXCQTcVEUoahgOefc1X9dZUlEIYRGqaqKvvOiWaeph2r//v379qzsHfhbDu8TDzbxMIDJs+2WvKu/7xEvcTG4OE733f+t4yceSe28593CsFbKReGrqvCBYSxiKYkKylAzwxEIGYBzzvnCe89kZtaB7jpPXYeE2AfP3ntmMJH3XJZlFYpUDEsPy8okzlFXauyutp7hzRpJMIMrAIAAE5DCFLadmXZ0fbpz8Fb/ygxGmwdu//od9hVmYN4BSaWz51stJFFxzils52tkV+W0cZAMD6jCYKoIIYgKbVK5k9iuCCdTogDbDIIR03b7bTskO2NjZo66KMJMzTY9LYE1tWB2HAComPMOUFVhvsyQq0Y6AgwQNKdYhAKAggVwl4V+e4cN5jdXsa3LJluR75YxLwdpe18t72jgMmx70U0BwLyKEXWlJmy3zbsqaLHMxLSJjE1gRuy2aohuwQ1dJ2tHJHdQ7/LDf/rYJulOzgAAks6DL3dmvW4lcufRV+e0AoCIusCbJ9WOr4rLseyiYgAUZgSmXT17BjI2Wzmdb9r9I9S61Hj5J7cFN+fo/eabY6q7bv4Z3stTYPM1+CQpOOc2g1sAsK3gEKj7J3Vr7tQd2Vm8rrzZHerNxs1OH3L5imYGcjHmovCAqinDbc6RnUdcHfQ/3PHCvV7/fRw/AP39Gj8A/f0aPwD9/Rr/HwzxAHEEsH4RAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAARfElEQVR4nO16TXNkyXXdOfdm5ntVKKDRPT1NkR7qyxYpW3KEFnaEw154LW+88S/x33F47Z1XXmnBhSO8cYQsi0FZokTKIsWPUU/PoAFU1XsvM++9XjwAjW4SZIcHHknhuYFFFaJe1slTJ+9nMiLw983kbxvA/419CfqLsi9Bf1H2Jegvyh4N9Dv+Pm7//l/Yo4Emeffa3Vtv5vZYi79jjymPO7Jbs+m4zFN1f8Tl39gjyyMieu+11lpra63W/q5sIj5/4vCYTK8K6d3NjNQI1lofcf07S4+1EBkAV9wkVQWAma+83lf857dHdnkRoapJC8kIkPxZMXz+DTwmaHd3dxEREXePCBF5FBG/Y495EEWE1Na9u4soyd57bRHB9QPufkPz5/Mqj+mn3yGVJMmVcjyqrB9f0xFvQiGJO9DAPYl/PvyPCPqNfEmSILEy7bcx5rHIfuSIuPK6CgO31N4n+1Hscb0HwnnfAL/DvX7mUch+RO+BOyXcYr6h/NHJfkzQ9w/cO4x+QfI4ri7AgfBuM9ARC/zggcC9fPkGjEfEUnuL6E6DUosZGDowwYSerd2t2C2Wu6fd3b1jXTcANEQ3a8v6bu7oNqPdx/ZzwuyN9QkiIVKRGSgBExyB0zUwxO1uuYrVa+2Hw0QVSMo5K6Mtc1K96ouq7jY7kaSAGbICAG8DTLx5wR6ePVMANoMHVJEYiADv0ftgwtTTJgUO1kNjS6IDs+lWOxCIoAcIMEAARKIkanF3ODro4a1KJ1I6YXfvzAkqLuz0ACNixE1klDsGQDWFAvSs1sGOhMYURHkfpmdgdMA9UpvrccMBWpqkfC8CB+AOEZCYjrXWCnhKaSxJBOGdpE3obpJT3oxQGGBArIu/WWglM0BCLlFPIAWyxqAFIVXye4Huy1XKZ3+9x3eu2g9eX+c0Ho79GMI+kzTSAmbm7qqacz44I4KIUtJYyp2zOw8rgl32Z4Ocqe/Uz0o+HYZFlpzzqFkBBcKdcBILMfQEYEpowBmA7hCHpF8OGubfPsh/+tPP/vilTy0n5WzzeDJiIZOC2qxX6womUVXd7YRkWF8zu1qbQ8xs0Z312do8KCR8LEUdIlJ4WbQMpYyaNaBhOcmQ0zf+wfDPd/jtYUHyhtE6RwVQwfLLQX8y4z/84f/6rjzfbl+0fZ/bYXda9q8+PZQzzSnI2ltEJNGshEdGZFEzI9QspsWYiln4ZtPNej1sTtKQ5WQ7TtO0HKeGoXez5vCIMEEMRcax9O7ffCH/Ytf+zVefDUQUVIBuRfQO24MH8T//FD88+TrSrr6eznbDy/3SfHM2foS+V1dHqJGUrWZFmPelBDK9BREd3hSapDNy/XTMyg23gxKSG6Y92z7Onm6r1S7uIlRQLA2aS/pI9I+O9Y9evpZ+9m8/Sm7XqmOqGSN+OejjBPb5Sc4XmqZX/XwYUvNLR01ZFSSMCZAOAdyIYtojLLIFnMqtBClQ61sIlHDNV1dXmodjLOl8W1Ob+zSe5kRPqhZxcjIE8XLys6SbfP5fLvD7v3lR5MkES6PfDykPgv7mi/n3h6fnEctZPjhsX4/XSx1G2yMkDLa419DG6Og97KKeAbBAa611s3AAjn5MgwBJPBcuecxpOM4pDxlAP9FxUAmIYOmWUnS3OaWXJWI4nR0v+9OPiIHRFPlehH0Q9L98ks+d9Wr/+vuvTkfqcvXkwxeWezxPgBNEKCLx9kQE59VFuXsAIhRJAKKJhFOI6IBCYZU6wDrcKQKzpqruIQkR0hP+5HD4wd7+9G/aJ/vnH51CNBZqvoftwYP4amrzZ6+GAcdXLy+Or69efvobv/t7Z0+/ppZBj7CARGj3iHCKqeY134gICdymSqaJAAQwb6qKkGaWc+ZNnwRmJklVRZVO5KWhGDB++4Ap4Z9tmuDAOMf7MF3kuD35ymuR/7bZ/e/pp7/9a9/4NT33KfJWk0rSJAyEIBx0kGGJBAgEwNvaxOjFARDhoWsalVxEwvtEKElSHE1FAVfYMm4HAyqe1GX2sE0EJNlbSB9k+j9+Et/94Sv08XX2Z2X3/VcXOvv5155xvtyWtCkYQ3JwS80SSt9oExFVFRFNFBFdF28wM+pNnVtKWVOkMdMsSKaUaq3DqGPOhLPIaWrPUX6y4AM5/PrJxiHh0Dce72Gmh8v5Rxqnw9Z7/YdV//tlT6Lz4bhMZTjJYlxaax2SwCSg2zHdloC2MrpWX5syHpdO9VLKNNWzs2TN27zsTsfDYQpiHPW4b6c7Pd9Rk84Hn60+D8tp8+9/k3ChwgL3MD8MmroZYtH9hX81Lj6ZuKvP2/Pri+V8tA1CXObW52rZNskYlOYNa54JkhQJAOE80ap+cMem7GjHcw7GdrTDxtl9yjmf5ELOu8AOweaRcR1YZFiIr+zE3TuspAqc3GF7MJ/+2F1ywZbDp+Py9Fm6LNWuylMyp9DSkKeInuAlmuLY/dhrBz2yVbGqresSqaosXSG7kNPjRMp2Ovac89Pz3dFqUJaKy2vLJx9+NtnF0UNHCflQylX3f/IEqYtQCmCxuY/t4dS0O0KIFEjTtJCiqiEZ4r27R4AiWHUZAHJKndak2xCA0COZbNLQfanePKg5CaLBF/NxSE/H7VHq9dWxR0gec06AT/M8bopV5gh5uKB8ELSZRUg3WvOL6RrCUornEn2urRuCVAdrtyAEXFoRRfNu1gBTkpTWRUXC1R2iyZSt1m4GGTbQkoYk5qLWKVqOS5+n/tUxMSLsJk1cpSp8SxEPgg7v7nRKEIvXzcluGNMCa+v5ogTEgW50uKp+hOXD7e5pHqUtCprqtfl1XTZb+kYtQBVVXWoD/LR41+uT09Npo93l0I6SVKIr2MLgZDAiSIkACcf7HcQkRiYV1VFFy5PNNqPv6wQkJlWkZmHdHViX/km2WetrD7ajIMAyUw6p/8qEnHNQrPeIINQjptq+pvpsm3pOS7fr2pRpHDabpN9pVVXUV2EIgPiZ0c2DoLebrB3Ww72NElkpzQVBEYq2oHtYBMkQBuB2/vIqftyn3kWIxEjCIZ/+8Xw9DEKKmZEOlQi69+9ofdZnBoLegwIrwTTbICbQIHvvYEKA4Dvu4kHQAvXevEdtNmzCrMEja3bA3Ky7WcAD1NUjix0hTJl53CoZrXpt3nwYswhEQCCiJ0ki0lprwcPSBmXK2G4Hs5bpMKsmSu8mc+0PwXsQdJ1qq0iSk2jJsZi629rocvNa3UJijdrmQTRlliwtfOqhKqkg6wJXl9ZdCYFEhKScVRliXdriZES1QYgOLUlDq4RIRsDC39T874KOmzxh7cGt/7XwS0/czGWK5v3g43mPGhzCLq32Q346yEdP8s5jZvzJp9On7flJfDo9waQ2uG8tzFiF1IHaRMSdFiEqFl28p4xCI6O691AsGMu2ee1SVQbIIingOw+neHh6J5w8GFwWVfOUQrfqjYePY/5r6y9rD8PJk/KPn2Zd/L/+eLlo0+9+ePTx4/3mw+V6GI9njtOXSS+3Sbbal6swj1szs25hDkBlLS4pANaBWHNzpPC3OlXvK4/1mY6FEXBFGpZ5j5BN0iean7tuy/XVHn922L7Stq1Dja+fa7taDnNU15PsOrLU4ySKJyFTBMFYhe8wepckSVQ8J1FBa2ZmLQwUSXB3Cj1ueoIr/EDwXm56ry6/t62ISD5vgC7DZd9G698Y/NkWT3Q8OVv+6lKf9/bvPvJLT9KXUeWvwvOz1JfhR9fHPztMPH9aPM1eDxvdxV2dACcQZASrbxISBYn0MAsLgblYEhUJAwT0eEAIDx5Ej23BNEnde/pIym+la+a2t/SXnxxKbK5dro+2Za5Gz9ojH6Yf/d72N76Wti8R37fDSZdTKZEErUZEwENkFYMbFrNCd9ekyElJd4c5avNCdRHcNAzt1l2/pZM3oO8fRJJL3y71aFG30n79tBTan4d97zjTX/yr8fV3pvqtT8fnSWpdKvybiR88O/+Dl68qR5Hds9q4UTrks9dxugkGApQghCQ9IqJZZDMVIZFUO6Jb771bzgqG4MY1IX5W1z+HaZKIKNKWmqjyLB9e7Ma/eZ3+wtNV0xfp8uPrT39nSC+e6kHyRny3uXZJaf76t+yTj3351fFsuNxfnGC/TbuzTe/h4reTAReQSgY91MCIUAYgBpfwCLbak5IqQvKB2cyD8vhgOHwsWXFyhjoyf3cvl5F+VcbWehtPp82HaX/8FX19qOXV8cMx15/o9amyV2s62wle6DBdL13QBXRC1j4uA1SqqK4hnXQg1tariISwuRVPAH7ByCDdbeZOGxEh4FmMU9PdydRyfHt/bLvN7shPri8/2Ina6f98ffG962W7nEyaX8vVV2r/5gc7y6VVpkXddD/I3Oy0Y5ZQ1RRy8xWyFgpuYSopi4o6xVOW6Fyap6EsdTCtZVjoOUJNscC39w7lg346pRrai/eTJabP9m2a29LrJje4gRAtpeScNXFQHYeSYPVwjb6MQyZR6wIgVBSUwFo+Aqi1124W6L4evnAHgqqqqhLIcy0BAy/asjCgoo7SlveSxyi108YoT9P24JeFKfU6JViPKWpEJHdgobFoK6KZUbxvUhmUCIN5EnX3nIRkeDcHAELdonULYbeo5gRFmClOV4msmgQq0juCuial6a22xy/Q9FictYOg5pPtSSnPF5jO26w05ojd2j2NNmqcpmToT7a7DK11dq/DuCEZtWYy59zMp7p0C82FFO8Wgdpckyayu0R3AKWUo9TihuZb6OhoDlGQb2WnD4L++sl2JA6Gn3o9DihRz0uSpOoAPRl2olqQDA4U+L72NG597pd1vzbuwz1KpjfAh5zMzJba6yIpp5R6mFn0Fpa0W/TeUkrDkOfovTvChyGBQII7QH+vIuB5knPVi9mD3dRlmbe+VYslIip6p1IiQUK8+2S2N9v0dr20vZuUIbpFRD7ZlIjWzczKkFX1OC+9NaqrJiDc0S3cjeEQGzA8SaNV7PvcCmdmQrIAlvA+fY9dWp5nebWf2ibT47C0PSAdkbWvPyjRLRywkHC99nScWrewkkUUzVLAe2URCQ/nOmpJQigjjCEqSmhrnURSWmBpNbug+pjsPA+cDxjG8Ey8X424G/zZkL0u3AzqcN1cRVIPeps7bfHuNmuHBHvyIMrgrUGFWTswQrNyPy9iODs7S1qurq72+wOAkgcRqS3WdpSZiYAlAZhrO2aeurzY7v7pizLIBPPFeyrpvjwenrl0/8OfXn3rx8f/sddXPgp021tpx88qoAmAB5ubOYJwYGKWcMLFu5olmpJZ2Zd6ktLZWK4vLqZm6fTplaulUSWBkVJKQoGTMZQ8juVfx/f+0bOz33l+9uGp5uKS0yAD365sf8Ecsc+T//DKfnBZf3g1fXI4zL0647qlCEaEOQyBoCRV1WfRlZKVRSKpjElL0iz6FJ9l4ZOTrbXWHVGGi6WH5H0qAJQUEYRFWEmplPTVs/Fc9Ll4obFAhzFRaO8H+gpzAkqX5IBJC5qoJYyYcTNmBQCKqGZVXQDiZoy2Thdvky/02lK+cbRBtACIDODu8krYeo8IYKUUAK0j3JOEJAGi3x9uPQx6/a/1SpiqggKIO0C5ywrWR9czYmz3DsubKzbC3LuD6o4QisC9J016+zjvfx+BmIAEEJSgrGMLekDe5CIPy6M6VFbG1uyQcMCxtk9uvuYWp4eHkKTcorhbNTpC3nQBCERDBLT8nGtC62wcCkis82e6rkkV3gTFB0Ev2CcMgrwGo8A6Bje753DkBgZxNyN/OzWLQEOovBXQCAQi4ebG5C1uuXlL4vZi1g0D0SKcMvxy0FgH/wEPuqiBFW6IJ7cn4ubHvZPK3b2lt4EHGsG7qT1vdkf5GW97s+uVI0LuXiMsepL3YNoNcqMmowOR8e6vtC7gNzt4N/+9nX17AtYZOm7Qrh9HgLydiq8JN95dygn3SPr29OIXMf131/7/vqn+RdqXoL8o+xL0F2V/L0H/H7ZXz34C2smNAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAARfElEQVR4nO16TXNkyXXdOfdm5ntVKKDRPT1NkR7qyxYpW3KEFnaEw154LW+88S/x33F47Z1XXmnBhSO8cYQsi0FZokTKIsWPUU/PoAFU1XsvM++9XjwAjW4SZIcHHknhuYFFFaJe1slTJ+9nMiLw983kbxvA/419CfqLsi9Bf1H2Jegvyh4N9Dv+Pm7//l/Yo4Emeffa3Vtv5vZYi79jjymPO7Jbs+m4zFN1f8Tl39gjyyMieu+11lpra63W/q5sIj5/4vCYTK8K6d3NjNQI1lofcf07S4+1EBkAV9wkVQWAma+83lf857dHdnkRoapJC8kIkPxZMXz+DTwmaHd3dxEREXePCBF5FBG/Y495EEWE1Na9u4soyd57bRHB9QPufkPz5/Mqj+mn3yGVJMmVcjyqrB9f0xFvQiGJO9DAPYl/PvyPCPqNfEmSILEy7bcx5rHIfuSIuPK6CgO31N4n+1Hscb0HwnnfAL/DvX7mUch+RO+BOyXcYr6h/NHJfkzQ9w/cO4x+QfI4ri7AgfBuM9ARC/zggcC9fPkGjEfEUnuL6E6DUosZGDowwYSerd2t2C2Wu6fd3b1jXTcANEQ3a8v6bu7oNqPdx/ZzwuyN9QkiIVKRGSgBExyB0zUwxO1uuYrVa+2Hw0QVSMo5K6Mtc1K96ouq7jY7kaSAGbICAG8DTLx5wR6ePVMANoMHVJEYiADv0ftgwtTTJgUO1kNjS6IDs+lWOxCIoAcIMEAARKIkanF3ODro4a1KJ1I6YXfvzAkqLuz0ACNixE1klDsGQDWFAvSs1sGOhMYURHkfpmdgdMA9UpvrccMBWpqkfC8CB+AOEZCYjrXWCnhKaSxJBOGdpE3obpJT3oxQGGBArIu/WWglM0BCLlFPIAWyxqAFIVXye4Huy1XKZ3+9x3eu2g9eX+c0Ho79GMI+kzTSAmbm7qqacz44I4KIUtJYyp2zOw8rgl32Z4Ocqe/Uz0o+HYZFlpzzqFkBBcKdcBILMfQEYEpowBmA7hCHpF8OGubfPsh/+tPP/vilTy0n5WzzeDJiIZOC2qxX6womUVXd7YRkWF8zu1qbQ8xs0Z312do8KCR8LEUdIlJ4WbQMpYyaNaBhOcmQ0zf+wfDPd/jtYUHyhtE6RwVQwfLLQX8y4z/84f/6rjzfbl+0fZ/bYXda9q8+PZQzzSnI2ltEJNGshEdGZFEzI9QspsWYiln4ZtPNej1sTtKQ5WQ7TtO0HKeGoXez5vCIMEEMRcax9O7ffCH/Ytf+zVefDUQUVIBuRfQO24MH8T//FD88+TrSrr6eznbDy/3SfHM2foS+V1dHqJGUrWZFmPelBDK9BREd3hSapDNy/XTMyg23gxKSG6Y92z7Onm6r1S7uIlRQLA2aS/pI9I+O9Y9evpZ+9m8/Sm7XqmOqGSN+OejjBPb5Sc4XmqZX/XwYUvNLR01ZFSSMCZAOAdyIYtojLLIFnMqtBClQ61sIlHDNV1dXmodjLOl8W1Ob+zSe5kRPqhZxcjIE8XLys6SbfP5fLvD7v3lR5MkES6PfDykPgv7mi/n3h6fnEctZPjhsX4/XSx1G2yMkDLa419DG6Og97KKeAbBAa611s3AAjn5MgwBJPBcuecxpOM4pDxlAP9FxUAmIYOmWUnS3OaWXJWI4nR0v+9OPiIHRFPlehH0Q9L98ks+d9Wr/+vuvTkfqcvXkwxeWezxPgBNEKCLx9kQE59VFuXsAIhRJAKKJhFOI6IBCYZU6wDrcKQKzpqruIQkR0hP+5HD4wd7+9G/aJ/vnH51CNBZqvoftwYP4amrzZ6+GAcdXLy+Or69efvobv/t7Z0+/ppZBj7CARGj3iHCKqeY134gICdymSqaJAAQwb6qKkGaWc+ZNnwRmJklVRZVO5KWhGDB++4Ap4Z9tmuDAOMf7MF3kuD35ymuR/7bZ/e/pp7/9a9/4NT33KfJWk0rSJAyEIBx0kGGJBAgEwNvaxOjFARDhoWsalVxEwvtEKElSHE1FAVfYMm4HAyqe1GX2sE0EJNlbSB9k+j9+Et/94Sv08XX2Z2X3/VcXOvv5155xvtyWtCkYQ3JwS80SSt9oExFVFRFNFBFdF28wM+pNnVtKWVOkMdMsSKaUaq3DqGPOhLPIaWrPUX6y4AM5/PrJxiHh0Dce72Gmh8v5Rxqnw9Z7/YdV//tlT6Lz4bhMZTjJYlxaax2SwCSg2zHdloC2MrpWX5syHpdO9VLKNNWzs2TN27zsTsfDYQpiHPW4b6c7Pd9Rk84Hn60+D8tp8+9/k3ChwgL3MD8MmroZYtH9hX81Lj6ZuKvP2/Pri+V8tA1CXObW52rZNskYlOYNa54JkhQJAOE80ap+cMem7GjHcw7GdrTDxtl9yjmf5ELOu8AOweaRcR1YZFiIr+zE3TuspAqc3GF7MJ/+2F1ywZbDp+Py9Fm6LNWuylMyp9DSkKeInuAlmuLY/dhrBz2yVbGqresSqaosXSG7kNPjRMp2Ovac89Pz3dFqUJaKy2vLJx9+NtnF0UNHCflQylX3f/IEqYtQCmCxuY/t4dS0O0KIFEjTtJCiqiEZ4r27R4AiWHUZAHJKndak2xCA0COZbNLQfanePKg5CaLBF/NxSE/H7VHq9dWxR0gec06AT/M8bopV5gh5uKB8ELSZRUg3WvOL6RrCUornEn2urRuCVAdrtyAEXFoRRfNu1gBTkpTWRUXC1R2iyZSt1m4GGTbQkoYk5qLWKVqOS5+n/tUxMSLsJk1cpSp8SxEPgg7v7nRKEIvXzcluGNMCa+v5ogTEgW50uKp+hOXD7e5pHqUtCprqtfl1XTZb+kYtQBVVXWoD/LR41+uT09Npo93l0I6SVKIr2MLgZDAiSIkACcf7HcQkRiYV1VFFy5PNNqPv6wQkJlWkZmHdHViX/km2WetrD7ajIMAyUw6p/8qEnHNQrPeIINQjptq+pvpsm3pOS7fr2pRpHDabpN9pVVXUV2EIgPiZ0c2DoLebrB3Ww72NElkpzQVBEYq2oHtYBMkQBuB2/vIqftyn3kWIxEjCIZ/+8Xw9DEKKmZEOlQi69+9ofdZnBoLegwIrwTTbICbQIHvvYEKA4Dvu4kHQAvXevEdtNmzCrMEja3bA3Ky7WcAD1NUjix0hTJl53CoZrXpt3nwYswhEQCCiJ0ki0lprwcPSBmXK2G4Hs5bpMKsmSu8mc+0PwXsQdJ1qq0iSk2jJsZi629rocvNa3UJijdrmQTRlliwtfOqhKqkg6wJXl9ZdCYFEhKScVRliXdriZES1QYgOLUlDq4RIRsDC39T874KOmzxh7cGt/7XwS0/czGWK5v3g43mPGhzCLq32Q346yEdP8s5jZvzJp9On7flJfDo9waQ2uG8tzFiF1IHaRMSdFiEqFl28p4xCI6O691AsGMu2ee1SVQbIIingOw+neHh6J5w8GFwWVfOUQrfqjYePY/5r6y9rD8PJk/KPn2Zd/L/+eLlo0+9+ePTx4/3mw+V6GI9njtOXSS+3Sbbal6swj1szs25hDkBlLS4pANaBWHNzpPC3OlXvK4/1mY6FEXBFGpZ5j5BN0iean7tuy/XVHn922L7Stq1Dja+fa7taDnNU15PsOrLU4ySKJyFTBMFYhe8wepckSVQ8J1FBa2ZmLQwUSXB3Cj1ueoIr/EDwXm56ry6/t62ISD5vgC7DZd9G698Y/NkWT3Q8OVv+6lKf9/bvPvJLT9KXUeWvwvOz1JfhR9fHPztMPH9aPM1eDxvdxV2dACcQZASrbxISBYn0MAsLgblYEhUJAwT0eEAIDx5Ej23BNEnde/pIym+la+a2t/SXnxxKbK5dro+2Za5Gz9ojH6Yf/d72N76Wti8R37fDSZdTKZEErUZEwENkFYMbFrNCd9ekyElJd4c5avNCdRHcNAzt1l2/pZM3oO8fRJJL3y71aFG30n79tBTan4d97zjTX/yr8fV3pvqtT8fnSWpdKvybiR88O/+Dl68qR5Hds9q4UTrks9dxugkGApQghCQ9IqJZZDMVIZFUO6Jb771bzgqG4MY1IX5W1z+HaZKIKNKWmqjyLB9e7Ma/eZ3+wtNV0xfp8uPrT39nSC+e6kHyRny3uXZJaf76t+yTj3351fFsuNxfnGC/TbuzTe/h4reTAReQSgY91MCIUAYgBpfwCLbak5IqQvKB2cyD8vhgOHwsWXFyhjoyf3cvl5F+VcbWehtPp82HaX/8FX19qOXV8cMx15/o9amyV2s62wle6DBdL13QBXRC1j4uA1SqqK4hnXQg1tariISwuRVPAH7ByCDdbeZOGxEh4FmMU9PdydRyfHt/bLvN7shPri8/2Ina6f98ffG962W7nEyaX8vVV2r/5gc7y6VVpkXddD/I3Oy0Y5ZQ1RRy8xWyFgpuYSopi4o6xVOW6Fyap6EsdTCtZVjoOUJNscC39w7lg346pRrai/eTJabP9m2a29LrJje4gRAtpeScNXFQHYeSYPVwjb6MQyZR6wIgVBSUwFo+Aqi1124W6L4evnAHgqqqqhLIcy0BAy/asjCgoo7SlveSxyi108YoT9P24JeFKfU6JViPKWpEJHdgobFoK6KZUbxvUhmUCIN5EnX3nIRkeDcHAELdonULYbeo5gRFmClOV4msmgQq0juCuial6a22xy/Q9FictYOg5pPtSSnPF5jO26w05ojd2j2NNmqcpmToT7a7DK11dq/DuCEZtWYy59zMp7p0C82FFO8Wgdpckyayu0R3AKWUo9TihuZb6OhoDlGQb2WnD4L++sl2JA6Gn3o9DihRz0uSpOoAPRl2olqQDA4U+L72NG597pd1vzbuwz1KpjfAh5zMzJba6yIpp5R6mFn0Fpa0W/TeUkrDkOfovTvChyGBQII7QH+vIuB5knPVi9mD3dRlmbe+VYslIip6p1IiQUK8+2S2N9v0dr20vZuUIbpFRD7ZlIjWzczKkFX1OC+9NaqrJiDc0S3cjeEQGzA8SaNV7PvcCmdmQrIAlvA+fY9dWp5nebWf2ibT47C0PSAdkbWvPyjRLRywkHC99nScWrewkkUUzVLAe2URCQ/nOmpJQigjjCEqSmhrnURSWmBpNbug+pjsPA+cDxjG8Ey8X424G/zZkL0u3AzqcN1cRVIPeps7bfHuNmuHBHvyIMrgrUGFWTswQrNyPy9iODs7S1qurq72+wOAkgcRqS3WdpSZiYAlAZhrO2aeurzY7v7pizLIBPPFeyrpvjwenrl0/8OfXn3rx8f/sddXPgp021tpx88qoAmAB5ubOYJwYGKWcMLFu5olmpJZ2Zd6ktLZWK4vLqZm6fTplaulUSWBkVJKQoGTMZQ8juVfx/f+0bOz33l+9uGp5uKS0yAD365sf8Ecsc+T//DKfnBZf3g1fXI4zL0647qlCEaEOQyBoCRV1WfRlZKVRSKpjElL0iz6FJ9l4ZOTrbXWHVGGi6WH5H0qAJQUEYRFWEmplPTVs/Fc9Ll4obFAhzFRaO8H+gpzAkqX5IBJC5qoJYyYcTNmBQCKqGZVXQDiZoy2Thdvky/02lK+cbRBtACIDODu8krYeo8IYKUUAK0j3JOEJAGi3x9uPQx6/a/1SpiqggKIO0C5ywrWR9czYmz3DsubKzbC3LuD6o4QisC9J016+zjvfx+BmIAEEJSgrGMLekDe5CIPy6M6VFbG1uyQcMCxtk9uvuYWp4eHkKTcorhbNTpC3nQBCERDBLT8nGtC62wcCkis82e6rkkV3gTFB0Ev2CcMgrwGo8A6Bje753DkBgZxNyN/OzWLQEOovBXQCAQi4ebG5C1uuXlL4vZi1g0D0SKcMvxy0FgH/wEPuqiBFW6IJ7cn4ubHvZPK3b2lt4EHGsG7qT1vdkf5GW97s+uVI0LuXiMsepL3YNoNcqMmowOR8e6vtC7gNzt4N/+9nX17AtYZOm7Qrh9HgLydiq8JN95dygn3SPr29OIXMf131/7/vqn+RdqXoL8o+xL0F2V/L0H/H7ZXz34C2smNAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAh5klEQVR4nK2bd5Bd133ff6fc+t59vW1vWOxi0QsJEARAEiLBYlGiHCtjy3Ek94xcJhNPMvb4n8wkGUeTzNgzcTKeUbHk2FalaElsokixgSBAdGBRF9vL6/W+9247JX8sBYO0AIFgzh+7Z96ce8/n/uZ32u98f0hKCR+xSAkIgZQSIQQAQgDGd2rPGMMY41sa3Xz23sode7tNWe/uZ8RCSn6HxlJKSqkQAgA4577v33z2ngv66JYW658qhLhpPCEYxvQOz9xq2o9pZgC4U08/t/iep2oaCMT8QFVVAAAspRACxE2mD+H6vm+aJudcCKEoihCCEPJxoO/F0lJKhN7vlTFGKb71l39ZOJeEoPWRwJigFK/X77l8ZEsDwNmz5+v1pu8xVVUl8EgkrCjEdf1b29y0BUKEc95oNBBCpmkyxvbs2ROPR+8d+R4sXSgVf/LKa0IAxsQ0Tc5Zt9tutupOp/sh3PV6NtszMjIipSSEOI5TLpdHR0cPHNj/cTz7I1t6ZW2tUq9Z4Zjv+I4XaJric9ZxHPRB1pv1ZrO5uLjoeV4QBKqqIoSmp6d37NgRChn3zH17SwsJGAGABBACQHJCEEi+uLJq6oZCMYAMAmaa4YXF5e9877vtLiGEYIzXX4gQCCGEEFOT/Y88dAgkVwgOPN8PGEKkb3DADEd+9oXr/YDrurqu3s0sfHtoCYDe/w/vV8Xy0sIPf/RC27Zdt2uoGkIokc5gRAWgVrPEOeecAwCllFAkhGCMReM5lRK71QoCz+s6WFEBkbGxsc985jOEEM/zdF2Hn82DQRAoivILoe/kHpzz9blJCODMVxRSqzWsUGRwYEAllFJqGEY8nrxy7Vq1Wu+iqCQSCGCMEaUcIAgCT/h+uXzkyJF6tVYqlRRFadmdlXyhUKlTQgFA19Ug8BRFQQjbtm1Z1i8kviM0gvW1QwpBMOYACBFApNmxy/WqYJxS2ul0fJ+l0umDBw/2ZHsVRdE0TVVVRcE3ffWnb7/9gx+94HmeYYQ67W7ICrs+77iB57qarge+rygK55wQsCyLMUbpLx5mt21xc5RwzjHGqqr6vu/7PlVVqmuMCd/3FdNiyFEM8/rs3OyNM0IAf7/I9ccRQl1ficVTrVZL0YyIGgKAqKFKRJvNTkbXEaaA0M3heDfEcAeflgAgJUKSM8Y5X15Zq9ebpXLZYb7v+wKwEIIxXigU0okEIWQln/c8z/eYlBJjjBBZH4j9vTkWCCah3emGw2HLspxON5VKcadjt+u7d+86cGAfen81xUHAFeUXL5Z3+jLGmKKQVqu1sLBQrtR8n3EBmUTS7jpSAJcCAEufKYoSNg0WE77v+z5DCKH3P0kIIQCr4YjheH40ljT0EALRm8kCgEs1l/F/+uGPipXiv3rm05wxSrFC72p5v717gKSUAsiVlZW5ublsrjeVCjeadkg3KFakBM9nCCEt2+u63XQqKUIJxpgQAAAICMZYVTVFUXjXFiClQIqmqlRRFRIJm4Lxmt3tGxxoNuvvvnvikYcOJuMJ13V1Tf9Y0AH4iIMKmm+DaSaIHtIMNeJTPaqHpO533UjID1tJnynVVtlK4wGaqBZWR4eH5uaXc339KwvzWyaHyvm8sWWsVKpZZjJsxDiXXuCGLKPttDGrJIY2T7Ye+emPv/ne6ZePPPo5leggmkB+8Qp/W2iNq0BRl7GyW4xHtXRY9aTKjWxITwSsHUpqsXikVFwywgjK3sw73Ik3Fmo+n5nBwMxCyQ5CF1mHNGrhgkhFsK41AtnGqtKb6/E9qWF9GcL9MewPRi8PTkxfazx5OACkMBK9m5F4+zYSAQg/sBUFG6EIQiZGkrGWiqLRKC8W5k9dcs9ds69Vg6oMcSMdXPdxJJWm7u8e2WnXqy+dnsnFenZvP+S1CgWHzi8T7LVGzPZU3wpCIj44aAH4gkdS5ifu2/Xaqz+uN4JYXAHuADHuHdqHQAXB61XR4UomKzQNeeUIKudrxelj7OgZe6bCbDBpKKNbxFC68RABi6iq9fKl64BIK5q57vqdG4t92b5suL6jnzkinGepH62UY9DZCcue46pGKGKwDX7Pcawvr5VDiSGF3NXu7bbQmILgwHylN91jqILJNkaoXmHffvU810Zv1Mlcs6PFjfFcnHVqY/FoqdaN6Z4BGBlhLRz18ossJBbaqNi9ohuRi3VrzMKbM2RyPFnwEj+ZKw2q0U676bgNKz2248FH28V5OhnxaPxuRuJtoSkgBtpy3QmCroWk78u3Tix/49tv2W7ut75435UXvr13Yrxa60b8pUC2Wvl630Act6/0aNgrtYx2eJspm4VLoFuBknVr3MVK1Oh97QqT3eLkWPTR3WMzS5VvvnR203h2XwrSCePqpQKm993lnvMOuzyQGM6ePR+JaHa7+/fff/0npwqePlBZnVF0bc+eg+2WPdinRPRafzKCfa1ot1ykd3yBqOIK2g6IipghuqpoRS2V6lTNDrdIMpHoH41bVmCbUfXUhUpCd3J4ac/GyXLTGRrrTRom0j7GhsnD4NUL2M1XbPNrz50+er2tZCYcr/3Q4Yevnj0ZFwtbx9VkbvBGOXy0RJoQUJ4uu4Rwr4+0OXgNlEQSZ6Ab4PGFkq2hprl8ZiRtmXZPx9vc1LOC+ZIbO7aOrMx31mwHt6t2XiQnNt+VpQPpU6kAAPAmUNNjCqUAwAKgQXV+/lr5r/7xnRfWghjFOapsGM9cXV7ZNWBOjm44U87PtrICOsh2vVaJNGymgKHx1lKFcx4dSLkuJgwJM4Qtjcejkma17uy45oRpX2ZLUhk90ihVfn2CjeXol1/vDATTjx3aGk4PAwCTgBEgwTDCIAAI5gC3LpWISR8LBSEA5HEhMdIBQRDYRLEuv/f2V7763Leuqb0p1cHhA5vHLp19+8ih3V4sdmympZh9repVVu2GA9mXRaF4qtquUCEyhlQUZbHmYlWLqJFWt95t2pUyd/Ww3t/rBlLrFCZTyNKtqcd+JR6SSj04cij3d69WtpJLk8NxGsu2O53llcWDBx7CQBDGQgJHoNxyxEFS+gAKSAAkvMDXqA4AINqVWufr/+drC3Tjaq29kG/u6Een5pZ+7eknl+v16QoOlCD/3oUkXzz4wC93Am9lubywYre9Om+LXZNKOBx+/d2SlbUwU7NpmuixeiKJmXM/LrRVbfgAirNGvvpwRoYGYsnt/3ZDzElQJZKN/vS7zz/zcJ+hSkSIzwJVNzeMT3U7vhlSf3YguQnNPUBqwAFTQEKA5BgkY+73nnv5L7763o7776/azdpaieD6088cPLmizLcN6U6z+fzBvo1btzmvHS+88k6dhLChRHxhp7TeWv4HYcMk1mEH1bmvYKaiiIiEm3tGUJ/Zf2GxfiK/NrjpM4XFNzclwhNbR/o3H1hda/7RwcFGOPbDl9471FvauX1zIIJ8odI3OJ7N5RgTCoVbj2EUAAECBlIFhDGWzAOiXL629K1XzlVl5O3jp+7bOdwzlonmxmfz9aLXC/UZpVL8pfsPXrhwrnwmttZczqQlFxsY7VAkPNbJ9MQQQl3uYi3QNY0zHsEgOtUa33XqYvng/j49qpx778exvbuv58vGpXdqPPzQ3v1HZ5sCLSzXu80kXcxXh/rTGJCmaV4AmoLhZ5Ggm9BKwH2FqgAAXCCC7a77/KvvvrcsUjqj8f5WcSE5PqnoytVSXDTzoeLq4UOb3n7j2sWlVjjU8BrnItZOF3HJNKBEIqNcDwshrHRICgmgc1nx6ytO98Zlr7ej9j778qlPP3Rw197ImxdPy2z8lL1x2+U3rlO5Gh2Jt93f+dS2F37w8tXZxQe2Dj165BOAVS5ACkAiAKrdhMYAILEEEBjWD7Pi9LlLb564LIXiCG9IbwdaangwejzP1AB1lq49efjg86/MXyjPqiaPkh6DDNnBipAqAp8Q0uF2NDmW7tnU8ZuKrjHuhPVM0a8YyZ6IqkSCbi664fsvHzNzw3tHkiHHralmZY1du3o0ChbJDevMjw7vsVlo+trCyvy82+4QBBjDh+JRWAggiAAI3+WAIHCc986cXy22IgRymWilWj44mTldA8W0irNznzyw5603TixUuzJOQLFaXc6VzUKisL+MkGzaLY5YuRbYXeJLv9PpCB74jqfEEr62yWOKFvVtzuJW9PQ/vTYy1BcC2ucUF0PxIO/a13+6Vlj9n3/74otvnpmeXVvNV77/7D9dOH/2ZpzqA+4hKRApOVIEYQDOylL19Xfnat0gFcEsCHrSmp/oXVsQLH99k3oDPOXdlSCs6GoLBX6VYddzVc16uAnVQSOxa3PWYyUA0CElhGi4FYHp3GpVEw8qVPNgSRdaiKc8aTSs5enFpZh/nnWjNLtvtq35hfdWmwjnxfYhr63T1aqfS9nfefbY8Ggikxn3iKLdCg0AwvdBU1SFgkDnpq9gRT944KHpa7PUl9mBoZVWV8dm13VzQ2NmdGgIv8iDtE1zXihtIZ4x2NLqQgWp+59M7nuwt9OKqxAyDSYF8uREl9vt750ulle6moYM0Wj7MeoqwSJ3zlqhXx3b8XCt47xwcS0SiklpObUCdkLjE5v6Jw59/Utf2jQUxUicOnnpqae2MGDarbMHBhDrQRnBpeufvzJbanVJ2LUsbSCqJvsGZwtuZWXxvuH+dtD8m7/7yUCohwV2x613vUjHWf43v7ZxeGDrN344e+bMmbOnrw0PjnDfxoIJCbbPzGja9XzTiDlOIAE0Krifr+Xnk+H4iWOXB4YS9+8bSM8tNzttzEUqLUnCeu4H379//8FGM1hYXk1Ho9evLj71GKyv0je3SRSBIIrCAJjvte323GpltdSoVFujY0Mm4Wv1NjPSMaWeMMgPTlxzZORaB3pDiaGour0n3LDj56ev/Mc//J1PHXnwP/z3r7z5pnN1uhTgqhWKOF1mhrS1/CINaYHTSUcjG4f7YlHcssurMbVa9ZJacq7QnGjbo9n4laWGQCmD2afOnSSiefn013OpSKHc6k0FudwYKIDBBdBvRhowgACEAUBVSKVcWyrWu4HUVa3dqEsZaLGs3eXSbSgIO4GKgPSmMlsOjD7xuQMP7d3zyU/8Su/kvv/77EuJUPZL/+n3H3lAlaJihvs6qMOURrvdChkCvOaBvSNPPTk5MKzk+rMTW3bt/cQj6Y0Z13WJGqnU3Z6YwYXnCFUVQSyium2mGPGW7QXcmNjYv2Pr1Fq+QuEDcWQsQUqgAIAxKeaL9ZaHqJGIhIGxaG+m7Um7UOvLRuptZ2m5mojwz+6Oq8x68c3Z41fPLZaWy3byH1+4/Jdf/l8vPffKwo0LD9zXLx1H2Cissw1j0VZVPryjl3je9PTyctlR4sl8o7O8XI1oUTNCVSwWFpvRsKIr1EWi67KQjoBjgyJAbGWlZjfKkYh66er5b3ztq7duoSmSwNetzkWj1ux6QkokfI8SHJhau82MgGuUL5camXTfzon4ar594srV7NimhWqdsVCt06Xh8NELJcqvCRkuLZ+d6EtevZJXVCmZls7kOG/OXQvUcE+SBqXCnNthXkcEHVUzOG07rmMYphKipC39AFSNelpEmxjOjG3cfeytZ3UF9470twIsO831K7L12CIFRAImKUWAEGPMcTxBQCM4EByFwrylIMcd6M9evDqNBOJe4eXVjt/1o8sLiLZrVej68W5VKmHDzBhSa4Dd1HHx889MnD7vnJ1uZyac8zeW3a4WZrVqZR65UyFrS36l7EGLOU2d6i4KVasVFHDVUgQoCLq53rgZYtms5Tge83wAoSiKrsTW47EYY4QQBoF16XsgACuN1srBPQ/87tO72536aBZpLi/RkNSc2tl3n9o5PpjpVNvUzNeY7S6szutozWqXqzPXK4WLzUorIeSlBVJqVet+qetWrbDn6zHP7hhB7MC++OR4plyox+LhlcXrjdWLD24cGbB6feQ++UCiUzkncElvp0VAWVBdvrRy9MLKN587FlPSldpifrZcL8/nG3OM+Qi9H17EEq3PJQIATNMqFNaWi9V031CdKToWqNtwPB/06PXVWq2LEmEzu9GiES3V0990ysXWUjydiqSjRs6zSd2KE+b0SZycX66V8ovjo02Fqz6szcx2Z1fopq2fvXKjqIZsK5V558ylfH2JaObxEzMbNj6omUnXryuEYYxVnXNhl25MO24jHk/2jIwlkxldC6/b+H2fFgiIQiggALDCyYWF1y/n87l0SjU0ygJLOp1QMpTJXLxUKNuQiCQnt2ztGao120GjDBgsSaIbk9r2DRtPXD7WbrDhXhP07OVrczqsDA708r5sNNJ7Zb6CwnJk02bwU8XSTCLd72Lbba11HaVpc4ZyviiGLCLB77rMDZpD46PRTZPNmWMdJ1hbXLoxOz8/t0QpXYeWUmIAAAQEsAiCVDIbi5kM62o4EjBJQYYorTq47sr+XLbjw6Wra6m4QJzX6lq07wEttdlj0VQ07Tqzy7M9CSOSyIhOoKQG9mYye0sLuFxr9eWULVtG+4c2VuqdqS27e3MjqoE9hgSOtzt+biDTdHi17SsqIogSrE9MTG7etGVq4wQmrK9vvOV0Mj25L37xi5TSm3etFIOQgCgggWUkGk/F9YUCcjutkKZUKw09MQhGbKW6tKUvpWIodODV18oPP947tIEVK1LTjPBm1rWLr/207naCQ/vdofGNSE8YSsQpcN9bfvHE27OXgrGdQwOpSNf3yuV8KrY12+seP322XLcIciNR38c+qHoQOAhoqWID6wZEyYZjyXikWGwVq7W9+7apinnrVQxFAAwIlUAojkQiiSiIJY+3vVCkt2I7mX6aTJqV/JJBWV9CaTtw6vJSvnx+7/Ydvblwq52vzBlvHL/skHjWaKRj/WsrIYRDhsUcx0goY2NjpT/7zcfXiv5Xv3E0krNiKaVZL1RuzNaXZIDCYY309oUWinmiGhjbmJOAqRD4c1du5DF94kBmabXWfOvooYfuv/UMgBCiIDEgkByA8lQmuXNqsCDIVEadrTkB5wloaVytY8MR/paR9KvvXrt/Z2rP5i3f/9ZZn6Ql5dJhusUwWdq2PVMt0xu1RiokOmslPTmSz9vY7F6eee9XP/MH1bzzP/76WQ+5Aba79lu9UYTV3VFTy8QSR9+7zkncCAun3O4bGktacuPk+InX3ohGZciMJjJpBkADibR/3p1i4AIApAQOkob0vp5ENKxbGur4olCqqU5pMGPReM+V+aXxoewTjzw4lfGp46uRuJP17IRtJLLUJ7vHQvFYKprK1dq40jxdrd3wRaTeWhxJj/3D1y48/91Tv/UbB/7o3z+BQ3UaZtnU1lYRpqYS/bn44swq801VD8fi2srygusFW7aNbN8+noiHhkd7SpXa1NRmBAr6YLAdSS493lUVFXEKPJhdmv3j//zXp2b83GBqMKHHEE4devTYjaZYKcSXX9r34IG/fSnvM0XiwLKQ7/hY0KEMzkVa5aaxUJ4BFtZleXLr4NwKrTY8k9KeTLTbLfy3P/vzTzyc/ou//OGXn1vARtls9iX7ynFSmV4M4Q37A97KoJWEllVi5sO7+q6uOgsnXtnVA5N79/z6F35HEQwh9dbjOAYJhBAOEjAAIalUat/u7XEDOrZQFbi4VBzy81MpIzvQdyOyGRMrnhBEa4Ro2+w0VL8LGi47QcehshW4FRalSQ202lrFxFHqaYag4RjudPU//69funaj+Cd/+GtTOenX1BKUx7Zsx8mdXjanMPdQdpG6bssK9/b2Tk3taa1dmxhLP/LEY7/5+d8OPIGwCugDB1sMIAgmcn2VQTIajTyyf89QUnG6bHrmxuP7py5Ozz+aFVWGMpM73pl3n9q33cTSlVbdDenQ2TvaycTthhbfcWjgs7/1TKSnP7vhvi7NKMnU0PbeZ75wwAz1a7q3vDT3hd/7qx+/8+ojD29gVWP/wZzwvZNzdRkbk3jN6aA9hw+ObRjYlBDH3jk5FsebxtKPPPU0SBJSqATg4H0QGnEAjIAIAAkSENq6cWT/zuFUOv6vn/xEvh6sra2dmy8/tTGiS1YLD+Yb3acPHzIpNDHVk6En7h/ePZxeLQWx1IArfDORjmc2T24/DGaIhNVGJ1ioNUsLfjYmF/Orv/8nz337xZ8+8yujA2b62JkZMzWUwu2dk9EVGC4HsClNP/2pTzYaazvG0o8e2L9crINk0uswCRiUD0JjuCm+QBhAkmgs8snHHtw9pHJpnL5ayE1tO3H5Sipo7U5hYoVPNL2laulzj2/bMtCJJLU3T1fnZhRSV84fXe5NpDcM6mP92qE9wzsm4ht6+q6/V5vPt2KpYV1J7d+3NaInctkJX3Gef3Ma9281JN6WswMbHji8N6eEdFn73z86vWVTLhbSejIDnisvXDiDNI4RfChQigEABCIAGAIAEByBxNu2b35yR+I7L70OSLmer27oDX33+dcfGO8dsYK+oclFN3702srjD45/7sguqcTfvLCMVHTx2tqbx84gGtIM4+rV65iaa8XW5evLMsAdxV8sRwd7+j/9WDqmp187UbO2bNelN5HzaShJ+7YqAp64f2Ksf7xZWx1I0qntu0vlemDXM5kUYMICH30wHI2YDIikACDBQYgypiAAQgO7UPwvX/3WP7xRjKPCwMate0dHTl+/+ktPPn3hWvmGYzbaNpt/c8hob9998Ox87cbyatDEy+UVVWRHs9roeOaNEwuCIIOyeDTQjYH7d+85c/rv11bLofR+qz8nFLItJWk4iGW3FVslA8V3DiJWLO5/cLxTXDSj2asXzh24b9fQph0cAQEBct0N/hmaE4lBAkAHsCqlIgAAfCLVc5eP/eVXXplt0Kf2b3/33JXB4dTi2ZmnPv3YTJefWQmAx/38ksGWcgkaMi2fBR0Xdct8OFuc3Nz78mttRoy+XggFtAl8Pt9sdB29b4jpuQgPtqWDruyu6ckHh8wHe3rKVvzNt27sz7Qf3p3sH9pc44pXW+oJqxAe8BBojAN1AUK3zNN3kE5A4+ixd7/1wwsksfMnx06MjKbTERVVK9nJyLZt+9483boR6L7niOIq79bC2ONCJC1cL6x22n5/37AncMXhvkvcuEWiUUQiJpE70/Ws5pf9tNGTmGvJIb/9uUf2vTN3fTjMJnQ3unFrLpG4uVz/fLA7QDd9J6oYF868V6g3/+abr0zPOZLQ3l5zeGTz2+8c3dqXe/zwoXZIz7c7C2uiQYcCu8BZF1ib2zVd0YEaLQ9Cqd4uiF7DUZiTRrAh5NS8TjU+5CjWI309lumdbPilwtoXxqi07ZYa/8zjD0hE7x26C2AANFbXrlw9oyRzX/32628cu/ipzzx9+drcC68vg2CjY5H79m4d7wmN9iQLttr0Sd3xa4y6oOgIqdwlwlXBtULcaJeNcLLGdGLGIdK7UitnwvZIOv741JaX3vppxNJ++/D+7zz37XB//+M7dlArfGdiuMOdCxLg+V0zrLsuJr73e59/tC+tBY63Z2Lk1Z9cn9o+sGfv6OW57sJsbag/r8TSG02S0PiEFaaqojG36zOumq16xSAh1rNtzXFlTBGe/1Ca7YiF317lpfLy86/mf+O+gZiBTs6W3r66+u+2jiph424uEm8LbSABusKJisMxLRQC2T2yf2d5xf3yiy8mze5v/NJ9ZlxZKNfLjGupZNtj352x901m22XP99qbe2OrTbdCQn3ZPVmFJyIxO79cYkHU1EbiVAVyKl97tH88EvO5hVg0uTB90uRBT3QUwAMw7x0aoA0sIgjQsFqultKRdDZhxvXqH37+cO2Xk1cuz5cda6Ve3jA8tHcsXZhd9uJaT5iUNavaouFwOKdHqNA10ezS2OGkvX9k9OvHi76Dj18vjKfgs5uFBUGrW41MPLiysFJbvpTU3VRvWgBDd6FEvYMcSPO5IBQbCm60PGzpjbZDFBiImqP9oRQkiJnmrOHyqqEP2zSUjIkd432z+armVg9vnlpsBi9dLii6wN3uUhOiojOGm/eNphXRGtkwko6Z52dnEETdmpu/fmNuNr9n12YuOpKGyM8bYx8Sw93+HpFrRGMYvP5kbvXyqtdtkpDaDnTsW+kefdcDm7xity8xZUXNt09e2zWRbTX87splLhPYys3la003GIlrWahNRiPLvj3VS4Z9d2hjCkLDvm0zFsMtrnFvrrF8rDhbrrZ7e8aIqoEXwMe5/KTAkcAIG7EUZmpQblZTSooK0fGa3VLihu+buiGp2Wnx0Q0jVFPbVjMSSQ81GpGI0e12hkMklUrl887IaO76y+eLUUMxBi7NFzBIHviJmH253DA0nTcbhenrCImBkWEpAKk/X1nzIYe5LfR6AEpKqShKIpHI5/O6rhNC6vW6pmm+61bLNc/zAKFas4Ex1TStOzvXbrcppZ7nEUI0TWu32++dPCkxOXrsHcf3IlYMgwiFTFVR6radyWSuTE8vLc5vndo8MDCAMJJCIPSLxYS3hV4XiQEAxri/v79YLLquyzl3HKdYLAeuxxjzPM/zgtVCPp1OG6a5uLgYBEEQBOtvWI++scCJRGII00Bw3/fXtX6aplKQp+dn283W5MYNf/xHf4AQAinRnSXvd2npdaHchg0bpJT5fH5hYSGQIgiaImDr8lHGWKvVMk2z3W6VSwWMse/7iqJIKRljmqYRKQiSGPF6o15nVcuypJQtKVNRc+fWKcuynnjiCcYYxgBApJR3Iz697Yp4U4h+iw5SYIxffvUn169etW2bB4wx0el2bdue3Dw13N/TbrfXNd2apt0Mchqaadv2yZMnK5WKYRgSYSGE6wWbJob+9E//FN2ib+dc3qUY/PYiFYwZYwCwriIGAM/zVFUlSDZqVdd1QUqMKCUomYipFG8cH6eUEkIQQoQQzvl6KoDT9S5dvDjY39uTTmGMBUhCFKIovX05hEjg+5TSda8ghHApyMfxafgXekRN0zDGmXRycmI8FAp1WramGaYVJoSsrq1979kfrHvFemNCyPo3tzudRDx+5LFHKIJWs0koZYw1Gq1UrgcQoQq+GaETwPBdEN8JWgixrrtcn9jXnZsxlkokjlcrjVoVBFBqLy8vJhKJZrMRTaSllDdFm4ZhrHtL3AzFYpFzFy+4nbauKo7jROPxVsvesmM351IIoShEgEQI4btOBfnISnUm+MWLF9djmKqqUko558ePHz/+7qn1BlLK9Xeu/w0C7/HHH7///vs9z2s0GqZplstlz/OefOLIR+r31vKRleqSi/nZuZmZGU3TfN93XTccDhuGMToy9C/zLgAAIbm6svSNy9Occ9M0HccRQhw5cu/E9wKtKMrg4KDneaZpep6XTCZd111aWup07PUGt65e6971wAMPxONx27bX5xaM8f79+z8O9Ed3Dz/wfb9UKjHGXNfVdV1KaVkWF8GHoNcrhJBut7ueSEQIkVKqqjo4NHRvyUz3CA0SAt8nhGBCpBAIIUBICnH7NBcQnOP1mf5nFSkEumMG0v9n6JuyfcdxDMNYT8rCGN8ug2s9aWc9P0BV1Y+fA3Uv0HALN/xsnb81j+tDxfM8TftnCQHn/P0bqrvbZvzc8pGhb7YWUiCEEPxis3Eu10ckIWg9JUoIIPfODP8P5ESJILBgJpQAAAAASUVORK5CYII=",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAh5klEQVR4nK2bd5Bd133ff6fc+t59vW1vWOxi0QsJEARAEiLBYlGiHCtjy3Ek94xcJhNPMvb4n8wkGUeTzNgzcTKeUbHk2FalaElsokixgSBAdGBRF9vL6/W+9247JX8sBYO0AIFgzh+7Z96ce8/n/uZ32u98f0hKCR+xSAkIgZQSIQQAQgDGd2rPGMMY41sa3Xz23sode7tNWe/uZ8RCSn6HxlJKSqkQAgA4577v33z2ngv66JYW658qhLhpPCEYxvQOz9xq2o9pZgC4U08/t/iep2oaCMT8QFVVAAAspRACxE2mD+H6vm+aJudcCKEoihCCEPJxoO/F0lJKhN7vlTFGKb71l39ZOJeEoPWRwJigFK/X77l8ZEsDwNmz5+v1pu8xVVUl8EgkrCjEdf1b29y0BUKEc95oNBBCpmkyxvbs2ROPR+8d+R4sXSgVf/LKa0IAxsQ0Tc5Zt9tutupOp/sh3PV6NtszMjIipSSEOI5TLpdHR0cPHNj/cTz7I1t6ZW2tUq9Z4Zjv+I4XaJric9ZxHPRB1pv1ZrO5uLjoeV4QBKqqIoSmp6d37NgRChn3zH17SwsJGAGABBACQHJCEEi+uLJq6oZCMYAMAmaa4YXF5e9877vtLiGEYIzXX4gQCCGEEFOT/Y88dAgkVwgOPN8PGEKkb3DADEd+9oXr/YDrurqu3s0sfHtoCYDe/w/vV8Xy0sIPf/RC27Zdt2uoGkIokc5gRAWgVrPEOeecAwCllFAkhGCMReM5lRK71QoCz+s6WFEBkbGxsc985jOEEM/zdF2Hn82DQRAoivILoe/kHpzz9blJCODMVxRSqzWsUGRwYEAllFJqGEY8nrxy7Vq1Wu+iqCQSCGCMEaUcIAgCT/h+uXzkyJF6tVYqlRRFadmdlXyhUKlTQgFA19Ug8BRFQQjbtm1Z1i8kviM0gvW1QwpBMOYACBFApNmxy/WqYJxS2ul0fJ+l0umDBw/2ZHsVRdE0TVVVRcE3ffWnb7/9gx+94HmeYYQ67W7ICrs+77iB57qarge+rygK55wQsCyLMUbpLx5mt21xc5RwzjHGqqr6vu/7PlVVqmuMCd/3FdNiyFEM8/rs3OyNM0IAf7/I9ccRQl1ficVTrVZL0YyIGgKAqKFKRJvNTkbXEaaA0M3heDfEcAeflgAgJUKSM8Y5X15Zq9ebpXLZYb7v+wKwEIIxXigU0okEIWQln/c8z/eYlBJjjBBZH4j9vTkWCCah3emGw2HLspxON5VKcadjt+u7d+86cGAfen81xUHAFeUXL5Z3+jLGmKKQVqu1sLBQrtR8n3EBmUTS7jpSAJcCAEufKYoSNg0WE77v+z5DCKH3P0kIIQCr4YjheH40ljT0EALRm8kCgEs1l/F/+uGPipXiv3rm05wxSrFC72p5v717gKSUAsiVlZW5ublsrjeVCjeadkg3KFakBM9nCCEt2+u63XQqKUIJxpgQAAAICMZYVTVFUXjXFiClQIqmqlRRFRIJm4Lxmt3tGxxoNuvvvnvikYcOJuMJ13V1Tf9Y0AH4iIMKmm+DaSaIHtIMNeJTPaqHpO533UjID1tJnynVVtlK4wGaqBZWR4eH5uaXc339KwvzWyaHyvm8sWWsVKpZZjJsxDiXXuCGLKPttDGrJIY2T7Ye+emPv/ne6ZePPPo5leggmkB+8Qp/W2iNq0BRl7GyW4xHtXRY9aTKjWxITwSsHUpqsXikVFwywgjK3sw73Ik3Fmo+n5nBwMxCyQ5CF1mHNGrhgkhFsK41AtnGqtKb6/E9qWF9GcL9MewPRi8PTkxfazx5OACkMBK9m5F4+zYSAQg/sBUFG6EIQiZGkrGWiqLRKC8W5k9dcs9ds69Vg6oMcSMdXPdxJJWm7u8e2WnXqy+dnsnFenZvP+S1CgWHzi8T7LVGzPZU3wpCIj44aAH4gkdS5ifu2/Xaqz+uN4JYXAHuADHuHdqHQAXB61XR4UomKzQNeeUIKudrxelj7OgZe6bCbDBpKKNbxFC68RABi6iq9fKl64BIK5q57vqdG4t92b5suL6jnzkinGepH62UY9DZCcue46pGKGKwDX7Pcawvr5VDiSGF3NXu7bbQmILgwHylN91jqILJNkaoXmHffvU810Zv1Mlcs6PFjfFcnHVqY/FoqdaN6Z4BGBlhLRz18ossJBbaqNi9ohuRi3VrzMKbM2RyPFnwEj+ZKw2q0U676bgNKz2248FH28V5OhnxaPxuRuJtoSkgBtpy3QmCroWk78u3Tix/49tv2W7ut75435UXvr13Yrxa60b8pUC2Wvl630Act6/0aNgrtYx2eJspm4VLoFuBknVr3MVK1Oh97QqT3eLkWPTR3WMzS5VvvnR203h2XwrSCePqpQKm993lnvMOuzyQGM6ePR+JaHa7+/fff/0npwqePlBZnVF0bc+eg+2WPdinRPRafzKCfa1ot1ykd3yBqOIK2g6IipghuqpoRS2V6lTNDrdIMpHoH41bVmCbUfXUhUpCd3J4ac/GyXLTGRrrTRom0j7GhsnD4NUL2M1XbPNrz50+er2tZCYcr/3Q4Yevnj0ZFwtbx9VkbvBGOXy0RJoQUJ4uu4Rwr4+0OXgNlEQSZ6Ab4PGFkq2hprl8ZiRtmXZPx9vc1LOC+ZIbO7aOrMx31mwHt6t2XiQnNt+VpQPpU6kAAPAmUNNjCqUAwAKgQXV+/lr5r/7xnRfWghjFOapsGM9cXV7ZNWBOjm44U87PtrICOsh2vVaJNGymgKHx1lKFcx4dSLkuJgwJM4Qtjcejkma17uy45oRpX2ZLUhk90ihVfn2CjeXol1/vDATTjx3aGk4PAwCTgBEgwTDCIAAI5gC3LpWISR8LBSEA5HEhMdIBQRDYRLEuv/f2V7763Leuqb0p1cHhA5vHLp19+8ih3V4sdmympZh9repVVu2GA9mXRaF4qtquUCEyhlQUZbHmYlWLqJFWt95t2pUyd/Ww3t/rBlLrFCZTyNKtqcd+JR6SSj04cij3d69WtpJLk8NxGsu2O53llcWDBx7CQBDGQgJHoNxyxEFS+gAKSAAkvMDXqA4AINqVWufr/+drC3Tjaq29kG/u6Een5pZ+7eknl+v16QoOlCD/3oUkXzz4wC93Am9lubywYre9Om+LXZNKOBx+/d2SlbUwU7NpmuixeiKJmXM/LrRVbfgAirNGvvpwRoYGYsnt/3ZDzElQJZKN/vS7zz/zcJ+hSkSIzwJVNzeMT3U7vhlSf3YguQnNPUBqwAFTQEKA5BgkY+73nnv5L7763o7776/azdpaieD6088cPLmizLcN6U6z+fzBvo1btzmvHS+88k6dhLChRHxhp7TeWv4HYcMk1mEH1bmvYKaiiIiEm3tGUJ/Zf2GxfiK/NrjpM4XFNzclwhNbR/o3H1hda/7RwcFGOPbDl9471FvauX1zIIJ8odI3OJ7N5RgTCoVbj2EUAAECBlIFhDGWzAOiXL629K1XzlVl5O3jp+7bOdwzlonmxmfz9aLXC/UZpVL8pfsPXrhwrnwmttZczqQlFxsY7VAkPNbJ9MQQQl3uYi3QNY0zHsEgOtUa33XqYvng/j49qpx778exvbuv58vGpXdqPPzQ3v1HZ5sCLSzXu80kXcxXh/rTGJCmaV4AmoLhZ5Ggm9BKwH2FqgAAXCCC7a77/KvvvrcsUjqj8f5WcSE5PqnoytVSXDTzoeLq4UOb3n7j2sWlVjjU8BrnItZOF3HJNKBEIqNcDwshrHRICgmgc1nx6ytO98Zlr7ej9j778qlPP3Rw197ImxdPy2z8lL1x2+U3rlO5Gh2Jt93f+dS2F37w8tXZxQe2Dj165BOAVS5ACkAiAKrdhMYAILEEEBjWD7Pi9LlLb564LIXiCG9IbwdaangwejzP1AB1lq49efjg86/MXyjPqiaPkh6DDNnBipAqAp8Q0uF2NDmW7tnU8ZuKrjHuhPVM0a8YyZ6IqkSCbi664fsvHzNzw3tHkiHHralmZY1du3o0ChbJDevMjw7vsVlo+trCyvy82+4QBBjDh+JRWAggiAAI3+WAIHCc986cXy22IgRymWilWj44mTldA8W0irNznzyw5603TixUuzJOQLFaXc6VzUKisL+MkGzaLY5YuRbYXeJLv9PpCB74jqfEEr62yWOKFvVtzuJW9PQ/vTYy1BcC2ucUF0PxIO/a13+6Vlj9n3/74otvnpmeXVvNV77/7D9dOH/2ZpzqA+4hKRApOVIEYQDOylL19Xfnat0gFcEsCHrSmp/oXVsQLH99k3oDPOXdlSCs6GoLBX6VYddzVc16uAnVQSOxa3PWYyUA0CElhGi4FYHp3GpVEw8qVPNgSRdaiKc8aTSs5enFpZh/nnWjNLtvtq35hfdWmwjnxfYhr63T1aqfS9nfefbY8Ggikxn3iKLdCg0AwvdBU1SFgkDnpq9gRT944KHpa7PUl9mBoZVWV8dm13VzQ2NmdGgIv8iDtE1zXihtIZ4x2NLqQgWp+59M7nuwt9OKqxAyDSYF8uREl9vt750ulle6moYM0Wj7MeoqwSJ3zlqhXx3b8XCt47xwcS0SiklpObUCdkLjE5v6Jw59/Utf2jQUxUicOnnpqae2MGDarbMHBhDrQRnBpeufvzJbanVJ2LUsbSCqJvsGZwtuZWXxvuH+dtD8m7/7yUCohwV2x613vUjHWf43v7ZxeGDrN344e+bMmbOnrw0PjnDfxoIJCbbPzGja9XzTiDlOIAE0Krifr+Xnk+H4iWOXB4YS9+8bSM8tNzttzEUqLUnCeu4H379//8FGM1hYXk1Ho9evLj71GKyv0je3SRSBIIrCAJjvte323GpltdSoVFujY0Mm4Wv1NjPSMaWeMMgPTlxzZORaB3pDiaGour0n3LDj56ev/Mc//J1PHXnwP/z3r7z5pnN1uhTgqhWKOF1mhrS1/CINaYHTSUcjG4f7YlHcssurMbVa9ZJacq7QnGjbo9n4laWGQCmD2afOnSSiefn013OpSKHc6k0FudwYKIDBBdBvRhowgACEAUBVSKVcWyrWu4HUVa3dqEsZaLGs3eXSbSgIO4GKgPSmMlsOjD7xuQMP7d3zyU/8Su/kvv/77EuJUPZL/+n3H3lAlaJihvs6qMOURrvdChkCvOaBvSNPPTk5MKzk+rMTW3bt/cQj6Y0Z13WJGqnU3Z6YwYXnCFUVQSyium2mGPGW7QXcmNjYv2Pr1Fq+QuEDcWQsQUqgAIAxKeaL9ZaHqJGIhIGxaG+m7Um7UOvLRuptZ2m5mojwz+6Oq8x68c3Z41fPLZaWy3byH1+4/Jdf/l8vPffKwo0LD9zXLx1H2Cissw1j0VZVPryjl3je9PTyctlR4sl8o7O8XI1oUTNCVSwWFpvRsKIr1EWi67KQjoBjgyJAbGWlZjfKkYh66er5b3ztq7duoSmSwNetzkWj1ux6QkokfI8SHJhau82MgGuUL5camXTfzon4ar594srV7NimhWqdsVCt06Xh8NELJcqvCRkuLZ+d6EtevZJXVCmZls7kOG/OXQvUcE+SBqXCnNthXkcEHVUzOG07rmMYphKipC39AFSNelpEmxjOjG3cfeytZ3UF9470twIsO831K7L12CIFRAImKUWAEGPMcTxBQCM4EByFwrylIMcd6M9evDqNBOJe4eXVjt/1o8sLiLZrVej68W5VKmHDzBhSa4Dd1HHx889MnD7vnJ1uZyac8zeW3a4WZrVqZR65UyFrS36l7EGLOU2d6i4KVasVFHDVUgQoCLq53rgZYtms5Tge83wAoSiKrsTW47EYY4QQBoF16XsgACuN1srBPQ/87tO72536aBZpLi/RkNSc2tl3n9o5PpjpVNvUzNeY7S6szutozWqXqzPXK4WLzUorIeSlBVJqVet+qetWrbDn6zHP7hhB7MC++OR4plyox+LhlcXrjdWLD24cGbB6feQ++UCiUzkncElvp0VAWVBdvrRy9MLKN587FlPSldpifrZcL8/nG3OM+Qi9H17EEq3PJQIATNMqFNaWi9V031CdKToWqNtwPB/06PXVWq2LEmEzu9GiES3V0990ysXWUjydiqSjRs6zSd2KE+b0SZycX66V8ovjo02Fqz6szcx2Z1fopq2fvXKjqIZsK5V558ylfH2JaObxEzMbNj6omUnXryuEYYxVnXNhl25MO24jHk/2jIwlkxldC6/b+H2fFgiIQiggALDCyYWF1y/n87l0SjU0ygJLOp1QMpTJXLxUKNuQiCQnt2ztGao120GjDBgsSaIbk9r2DRtPXD7WbrDhXhP07OVrczqsDA708r5sNNJ7Zb6CwnJk02bwU8XSTCLd72Lbba11HaVpc4ZyviiGLCLB77rMDZpD46PRTZPNmWMdJ1hbXLoxOz8/t0QpXYeWUmIAAAQEsAiCVDIbi5kM62o4EjBJQYYorTq47sr+XLbjw6Wra6m4QJzX6lq07wEttdlj0VQ07Tqzy7M9CSOSyIhOoKQG9mYye0sLuFxr9eWULVtG+4c2VuqdqS27e3MjqoE9hgSOtzt+biDTdHi17SsqIogSrE9MTG7etGVq4wQmrK9vvOV0Mj25L37xi5TSm3etFIOQgCgggWUkGk/F9YUCcjutkKZUKw09MQhGbKW6tKUvpWIodODV18oPP947tIEVK1LTjPBm1rWLr/207naCQ/vdofGNSE8YSsQpcN9bfvHE27OXgrGdQwOpSNf3yuV8KrY12+seP322XLcIciNR38c+qHoQOAhoqWID6wZEyYZjyXikWGwVq7W9+7apinnrVQxFAAwIlUAojkQiiSiIJY+3vVCkt2I7mX6aTJqV/JJBWV9CaTtw6vJSvnx+7/Ydvblwq52vzBlvHL/skHjWaKRj/WsrIYRDhsUcx0goY2NjpT/7zcfXiv5Xv3E0krNiKaVZL1RuzNaXZIDCYY309oUWinmiGhjbmJOAqRD4c1du5DF94kBmabXWfOvooYfuv/UMgBCiIDEgkByA8lQmuXNqsCDIVEadrTkB5wloaVytY8MR/paR9KvvXrt/Z2rP5i3f/9ZZn6Ql5dJhusUwWdq2PVMt0xu1RiokOmslPTmSz9vY7F6eee9XP/MH1bzzP/76WQ+5Aba79lu9UYTV3VFTy8QSR9+7zkncCAun3O4bGktacuPk+InX3ohGZciMJjJpBkADibR/3p1i4AIApAQOkob0vp5ENKxbGur4olCqqU5pMGPReM+V+aXxoewTjzw4lfGp46uRuJP17IRtJLLUJ7vHQvFYKprK1dq40jxdrd3wRaTeWhxJj/3D1y48/91Tv/UbB/7o3z+BQ3UaZtnU1lYRpqYS/bn44swq801VD8fi2srygusFW7aNbN8+noiHhkd7SpXa1NRmBAr6YLAdSS493lUVFXEKPJhdmv3j//zXp2b83GBqMKHHEE4devTYjaZYKcSXX9r34IG/fSnvM0XiwLKQ7/hY0KEMzkVa5aaxUJ4BFtZleXLr4NwKrTY8k9KeTLTbLfy3P/vzTzyc/ou//OGXn1vARtls9iX7ynFSmV4M4Q37A97KoJWEllVi5sO7+q6uOgsnXtnVA5N79/z6F35HEQwh9dbjOAYJhBAOEjAAIalUat/u7XEDOrZQFbi4VBzy81MpIzvQdyOyGRMrnhBEa4Ro2+w0VL8LGi47QcehshW4FRalSQ202lrFxFHqaYag4RjudPU//69funaj+Cd/+GtTOenX1BKUx7Zsx8mdXjanMPdQdpG6bssK9/b2Tk3taa1dmxhLP/LEY7/5+d8OPIGwCugDB1sMIAgmcn2VQTIajTyyf89QUnG6bHrmxuP7py5Ozz+aFVWGMpM73pl3n9q33cTSlVbdDenQ2TvaycTthhbfcWjgs7/1TKSnP7vhvi7NKMnU0PbeZ75wwAz1a7q3vDT3hd/7qx+/8+ojD29gVWP/wZzwvZNzdRkbk3jN6aA9hw+ObRjYlBDH3jk5FsebxtKPPPU0SBJSqATg4H0QGnEAjIAIAAkSENq6cWT/zuFUOv6vn/xEvh6sra2dmy8/tTGiS1YLD+Yb3acPHzIpNDHVk6En7h/ePZxeLQWx1IArfDORjmc2T24/DGaIhNVGJ1ioNUsLfjYmF/Orv/8nz337xZ8+8yujA2b62JkZMzWUwu2dk9EVGC4HsClNP/2pTzYaazvG0o8e2L9crINk0uswCRiUD0JjuCm+QBhAkmgs8snHHtw9pHJpnL5ayE1tO3H5Sipo7U5hYoVPNL2laulzj2/bMtCJJLU3T1fnZhRSV84fXe5NpDcM6mP92qE9wzsm4ht6+q6/V5vPt2KpYV1J7d+3NaInctkJX3Gef3Ma9281JN6WswMbHji8N6eEdFn73z86vWVTLhbSejIDnisvXDiDNI4RfChQigEABCIAGAIAEByBxNu2b35yR+I7L70OSLmer27oDX33+dcfGO8dsYK+oclFN3702srjD45/7sguqcTfvLCMVHTx2tqbx84gGtIM4+rV65iaa8XW5evLMsAdxV8sRwd7+j/9WDqmp187UbO2bNelN5HzaShJ+7YqAp64f2Ksf7xZWx1I0qntu0vlemDXM5kUYMICH30wHI2YDIikACDBQYgypiAAQgO7UPwvX/3WP7xRjKPCwMate0dHTl+/+ktPPn3hWvmGYzbaNpt/c8hob9998Ox87cbyatDEy+UVVWRHs9roeOaNEwuCIIOyeDTQjYH7d+85c/rv11bLofR+qz8nFLItJWk4iGW3FVslA8V3DiJWLO5/cLxTXDSj2asXzh24b9fQph0cAQEBct0N/hmaE4lBAkAHsCqlIgAAfCLVc5eP/eVXXplt0Kf2b3/33JXB4dTi2ZmnPv3YTJefWQmAx/38ksGWcgkaMi2fBR0Xdct8OFuc3Nz78mttRoy+XggFtAl8Pt9sdB29b4jpuQgPtqWDruyu6ckHh8wHe3rKVvzNt27sz7Qf3p3sH9pc44pXW+oJqxAe8BBojAN1AUK3zNN3kE5A4+ixd7/1wwsksfMnx06MjKbTERVVK9nJyLZt+9483boR6L7niOIq79bC2ONCJC1cL6x22n5/37AncMXhvkvcuEWiUUQiJpE70/Ws5pf9tNGTmGvJIb/9uUf2vTN3fTjMJnQ3unFrLpG4uVz/fLA7QDd9J6oYF868V6g3/+abr0zPOZLQ3l5zeGTz2+8c3dqXe/zwoXZIz7c7C2uiQYcCu8BZF1ib2zVd0YEaLQ9Cqd4uiF7DUZiTRrAh5NS8TjU+5CjWI309lumdbPilwtoXxqi07ZYa/8zjD0hE7x26C2AANFbXrlw9oyRzX/32628cu/ipzzx9+drcC68vg2CjY5H79m4d7wmN9iQLttr0Sd3xa4y6oOgIqdwlwlXBtULcaJeNcLLGdGLGIdK7UitnwvZIOv741JaX3vppxNJ++/D+7zz37XB//+M7dlArfGdiuMOdCxLg+V0zrLsuJr73e59/tC+tBY63Z2Lk1Z9cn9o+sGfv6OW57sJsbag/r8TSG02S0PiEFaaqojG36zOumq16xSAh1rNtzXFlTBGe/1Ca7YiF317lpfLy86/mf+O+gZiBTs6W3r66+u+2jiph424uEm8LbSABusKJisMxLRQC2T2yf2d5xf3yiy8mze5v/NJ9ZlxZKNfLjGupZNtj352x901m22XP99qbe2OrTbdCQn3ZPVmFJyIxO79cYkHU1EbiVAVyKl97tH88EvO5hVg0uTB90uRBT3QUwAMw7x0aoA0sIgjQsFqultKRdDZhxvXqH37+cO2Xk1cuz5cda6Ve3jA8tHcsXZhd9uJaT5iUNavaouFwOKdHqNA10ezS2OGkvX9k9OvHi76Dj18vjKfgs5uFBUGrW41MPLiysFJbvpTU3VRvWgBDd6FEvYMcSPO5IBQbCm60PGzpjbZDFBiImqP9oRQkiJnmrOHyqqEP2zSUjIkd432z+armVg9vnlpsBi9dLii6wN3uUhOiojOGm/eNphXRGtkwko6Z52dnEETdmpu/fmNuNr9n12YuOpKGyM8bYx8Sw93+HpFrRGMYvP5kbvXyqtdtkpDaDnTsW+kefdcDm7xity8xZUXNt09e2zWRbTX87splLhPYys3la003GIlrWahNRiPLvj3VS4Z9d2hjCkLDvm0zFsMtrnFvrrF8rDhbrrZ7e8aIqoEXwMe5/KTAkcAIG7EUZmpQblZTSooK0fGa3VLihu+buiGp2Wnx0Q0jVFPbVjMSSQ81GpGI0e12hkMklUrl887IaO76y+eLUUMxBi7NFzBIHviJmH253DA0nTcbhenrCImBkWEpAKk/X1nzIYe5LfR6AEpKqShKIpHI5/O6rhNC6vW6pmm+61bLNc/zAKFas4Ex1TStOzvXbrcppZ7nEUI0TWu32++dPCkxOXrsHcf3IlYMgwiFTFVR6radyWSuTE8vLc5vndo8MDCAMJJCIPSLxYS3hV4XiQEAxri/v79YLLquyzl3HKdYLAeuxxjzPM/zgtVCPp1OG6a5uLgYBEEQBOtvWI++scCJRGII00Bw3/fXtX6aplKQp+dn283W5MYNf/xHf4AQAinRnSXvd2npdaHchg0bpJT5fH5hYSGQIgiaImDr8lHGWKvVMk2z3W6VSwWMse/7iqJIKRljmqYRKQiSGPF6o15nVcuypJQtKVNRc+fWKcuynnjiCcYYxgBApJR3Iz697Yp4U4h+iw5SYIxffvUn169etW2bB4wx0el2bdue3Dw13N/TbrfXNd2apt0Mchqaadv2yZMnK5WKYRgSYSGE6wWbJob+9E//FN2ib+dc3qUY/PYiFYwZYwCwriIGAM/zVFUlSDZqVdd1QUqMKCUomYipFG8cH6eUEkIQQoQQzvl6KoDT9S5dvDjY39uTTmGMBUhCFKIovX05hEjg+5TSda8ghHApyMfxafgXekRN0zDGmXRycmI8FAp1WramGaYVJoSsrq1979kfrHvFemNCyPo3tzudRDx+5LFHKIJWs0koZYw1Gq1UrgcQoQq+GaETwPBdEN8JWgixrrtcn9jXnZsxlkokjlcrjVoVBFBqLy8vJhKJZrMRTaSllDdFm4ZhrHtL3AzFYpFzFy+4nbauKo7jROPxVsvesmM351IIoShEgEQI4btOBfnISnUm+MWLF9djmKqqUko558ePHz/+7qn1BlLK9Xeu/w0C7/HHH7///vs9z2s0GqZplstlz/OefOLIR+r31vKRleqSi/nZuZmZGU3TfN93XTccDhuGMToy9C/zLgAAIbm6svSNy9Occ9M0HccRQhw5cu/E9wKtKMrg4KDneaZpep6XTCZd111aWup07PUGt65e6971wAMPxONx27bX5xaM8f79+z8O9Ed3Dz/wfb9UKjHGXNfVdV1KaVkWF8GHoNcrhJBut7ueSEQIkVKqqjo4NHRvyUz3CA0SAt8nhGBCpBAIIUBICnH7NBcQnOP1mf5nFSkEumMG0v9n6JuyfcdxDMNYT8rCGN8ug2s9aWc9P0BV1Y+fA3Uv0HALN/xsnb81j+tDxfM8TftnCQHn/P0bqrvbZvzc8pGhb7YWUiCEEPxis3Eu10ckIWg9JUoIIPfODP8P5ESJILBgJpQAAAAASUVORK5CYII=\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAANb0lEQVR4nO1ayY4kS1Y9dzBzj4jMGhE0SCDeUy8QiN9AQnwuv8CCFSxYwGNQI+hBTfWrqhzCw83sDiw8h8jqejQCKRFSnkUozMLM/Ngd7F67HpSZ+P8G/r8m8D/BC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp54JmJhFlJogAOMJgDFZQAIAEwAABjAAQGUIKIJCOIKRAaaudPJRQiIBtSIIemkDcPQWZSaD77wAA2YYYGZACpIOzQGAEg83QB9KU6QCQnBEUBCEkEBvbDXzHAEBuLUYCBJBtcxHsso17mHUHS2YCA5nIBG+DAsyPIxOPBSPuggIQ7mgYQAlylDPStp4gLFrvOG1DE1m2PT0+PoBMBN91cgKEpDua53Z2LvGHBQhPQIlNu3T2QwBiADBodWGCAilIQgrK2VzPzEihQBrg4UosxAoC4m4Hdw/lBCdWQBgFCGSAEiAHy6axrzDks32c98c966e7wWaYDsBBgDKQYczn5hGZAAhxRpEBoGQi7zqRJNvyAgtIgnjTQ1gQgoXSNxuNM6EnQKBNf5RPhEpAPqoEibs934L3yAlEjgjmh8XkbG6zLAICcnRiAtH9dAYTmEB3BozcDNNBuiaYUe953WnlqcwyEbizXbrryc3viSiSH/yQn0xsQMAYELAaA3CBE+ojacsUAJEAQOSExcGCQzaAOmhAMlPhlZKR4eX70T92A9OeaUfMoBSipNiQRER+3zx/2NajzCICHSLCCffBRFWViOCxk4pIEA/BtWPY8rbkZQXo8GhAkg6iTED4JvHXf/8vf/Ov/+bT/Ee/98312v7jZv289kBeTuXdRX09T7/4ZD89Hn++HEfmpcgeJBkG6nNxd7d0JECR6Z4jfJoUgBBlprtHBDOrqhCrKjx6OyFyKsIgs84zSwqzrOanm+sfSf7FH//4z/70mzPrgHaiCibahO1/+d3HX14dlwl/9ZO/XRi/O7+6iXUqMqV+0PTF95UpOB1jvYmZv8/wsh9Zrz9fTeCSxFUaZ/dQEU2a4aN7MrXRt4N1WRYRKZNOdSe1jmGtNXNPRMAl6TBffLz6NKuw8z+M0+Wbn//5n3xzfjwpn7Xc3ZGesa79XSkjRoMv5KtZWY9dZDZ5d3j789vrn11/VvJ3LjX52vuRyoh2qLOCxuqhLFONyOPabgWtNc8Yw1W11trM+rLMXnVYnnh09wympAjzXmsVG448je6rW/bT6F8EbiXchS0wjZ4ioqqjeY/RRpeEc5qPdly6Csv+777/91cy/3491Kqf1tuP3j4fm/CMAl8WYdZSiMiHESBEgzCIEtxitN5RShZZV0OjwgrmE6VHFIDdvftp3Fps3pMD4cjbtfXIeuatCiAziDiBboNYS5nQ+lGMA5L0NtUjVylQMo0//JXZ3D/EerO4Udb9/nKaXGS9WlYfc5mllGR2d4rUaQ7vxAImiViWhU9NRAjCLDrVLAWZPgYjhahKWcaQddVdFaJSipK6u5nV+hhclHGXGwSwjj7CPcLdRWkvc4AziYJKKcxYbPzj6yE5ZMRF5/f7txNVozy29Z+GlanqPDU371lU4X5qqxC7JycVLgLpayulMCDE7GQZ0YeNISTCUoR3WZW4knIaEUFImSctT8wjkXwfbSMTTA4CSVktOH6FwcwZvRZ640QjD/vXNAYqrkt+mPm03r6X8ju7+YNZJ2IVhoQPeIwxRGSeZ6zoNlR1P+9aa0JJhIywvqZoJSnTTpDkPoaBUKTWWiUlAPdO+SSbAKCZDtJIJIFZCGJm7u6ITLklU0gCKSxQzXDdncDNDRA5ES/5qZxOOt7vD/9xvLE+wFJUMTw9RMgzkmBmRMRKbADAzCQEQIh3RTLTrA8fnpZMSTB3VSXJCIBpeEzy6IzKxNuxD+YkWPi6rutqn3dZ4av5JWv0aJK3ESvZ0sauqpKY1qsWdnkx2bIPid7SzXpbuk1cL6bdYF7XtXsQ0UAgnBkgklKUCMJEDMCHtdHHaEEhVUTEIk/L0WstKGAikXwaMzlBwBBiwpCYoh3f7C/e7GQ3zLPv0uS42K68H0VBOw/2tV1/yuNN8fX1HHtpEwWG3wA877s5iFBoGSeP4WYY3k8re8awtLzYX87TnkgnLUCu/cSapFnmCWAY0SCesScdliNOEyvNl0RPSCuBANoyl4eIJbUIoCMX4djx2+CRYy30mvavTdZZ1rBcT5PM73W2SU/eP3265lIpU4jZMz1AxLVkYnu/ul011t6EOCKSIxNbHlJKYVYlJiIGncaSht2rV1XCjv10Ork75DEm6vkOIsLdM5OZsyMiD0xXaDr8xnvx+VQrMREYAWuDKFF9UN76kDo5MiML8awFih4jCJ5Z5omZY5iZiQgx511uicxsNohEhFQ1IjgxlRpt3NzcKFlNJSIzQ30kzRm4P/SQieFhHuYegZudXpR5R0wCFLlwHVVPVUZizvpqOlDRK2+L2SQ7nWdiIUAyOEMIRGThw22e58PhQEQRUUqZ5xnCEeGBCLQ2eu8xLDMjorWmqtM0pUfvfXNWPMW5pCmQEZFIImpCnRMqk0zVoQ4M1+SjNWu9hExzYU5qGcw87w6CaZoygoZ7H633jnABJec93L33HgR3N/PNNgCICDMTESI983Q6zVHevXuHbH7sY4wvbfohy84tdUQmAaJLidL9WJHTvtzanPk5+/uO2u3W/KO3Q8ob5QvIkfgqbJ88hhNCGaRctqtPukhZ1zWGKYuytNO68eZkEdVJNbOUIiBKOEUp5bbf2tr2LFXCzCJCnwr7TtIZgOAue0SOcKLclynqpKAj+353eR0fx2hv5v3ip6MNCwcwFe3JGHl7vFnakhS16CQ6TdMsyuEopZ1W89zPszIv6zrcmHnSSVXLPJn1wtJaQ3rvvXCptUYfx+NxxahQkfO0FAA0E0R3lwgicvfmttpAi3x/SBJc9194+/F84ODv19sf7d8Xx35wZYqCEzxC9g59/bq0YjGG9eOyrOs6zTsI12kiIiREZCpVVU+jNxu11mTaDN0iW2uEiGGDUS7K/s3BWbwfs/nmr08lTUAyFB4xGZrYZxwirOz6hePDhw83b3e/lfu4Wt7xxU+1na5uXiu/fzWtw8aQMZXbMXre7m3qY7XWijLPJRzBREB2O8w7qaW7fz5+bq0Vlt1ux4zjuhyPvtvtjuvp1NZpmpKYSCzcico0K2e3JZCkT206kRQEgbKSqEd45Gl0qtG8W1hfVyKbSQYTJv7lsYt1SQx3LjOBjAmkxFprpYjMdLNkqiLJsis1icjT3SgS5gOeEYf9JXsigOEYrkk7rVBYs956D+4WnB3u1r33vjureygjQRQZ2+UzQFQrmxH1jJhZEaQZymrIIjwuLsba+zADF9EiUoKUVJl0mgCMtVmmkqgqwEqIDBBVFqqTgtxdiI99SSQrO4eRO0eLnpkHnTN7VW2jW7QJmpnn9YMzR8wkou3CTkQkhfsaaTNJCYanMNxMunJQzUJViblMNSJ6X9jHqFxKUWJnnrRM07Tf7dx9PR4dycyiRYirlmAhorolTMwA6pRRgkUysyQFeFeqN/cIIop8WnwANCIYzMyJnEpVluxdMtakDFQGp1jYCTghx/BD3KVswTHSmJnJpiKXhwstxcx7mZoNVZ2S1m5hgwjMSnAkE5IJzDQHwh0+zKxmqqoIkzC0Uo6Z2VKcS6GihSFPjzzirbAIRuyKXlS9amPPelOljeg+atDqnclNGIiEEcxHtjCKIlWIEsrj+spZu1skhVlLb5nLcluViSilSNFIcncAzGyVrQ/K9GHMrFxibVJ07j7G7U0sPZLFXSJdfDSU/ZmkwUJAOBCz6sR0+vSxiDp8+Fhvj7taj30Nplqn9LhOK5DCkkncRhAdl5swq4FIJEmdJ2ZOD1DEunYiIhJVUwVgCQCFZZHtlkVhLiIk3G1IKW+irn41BmeRUklKXpa3b/b7J5IOJAexMJBzBbl9+NlPEZiKmtnVp4/7Wm7WxZCH+RBrb28OYskD3kxKqZOu65o2oDksPDHvdwBaa8jw3hQUBBbhUkEcEUTErFNkW1dKxDARIZXhttvvrxOD1zqI56oFdb5ov/0KFtvFcAP5MFbBfdHrn3/yk++++25d19WltdZaw31W+ZAAPrjsluJs/Q/1LtxXkrZE96FzW+f8c1tHRLbcY8Msycy11lIKgN1u9+233377zR+cR0XKSGzXIWEmDmCYl/ttRID51+qaZ8j7wrN8mYrd/fRF0fEB93W4L/vT72Z9EbzPx9B5hNxYjnBVkfvM/YcJP6X4NNI+TPyh/t8I9+0UBu5l97jIpsGtEciHcjGlP5HSk0L508vxV4fhLEn/GjZz+vV1zEJVcW9jm818MfdR0plpZszMIuZWRPGMeKDxVVXEk0o1Hg/OhwF3q2BztccXJT/8vG3dPHO534wvRj7ogwkPHs/MX1HIg6S3c2B7abQ5NdGXWSx+bcf/G/yQaN39PIH+4ly6m3Ju0+fvpsKdmR8t+MFA/2thftWC//vyB3Cn4a9wfVzv5f/Tz4QX0s+FF9LPhRfSz4UX0s+FF9LPhRfSz4UX0s+F/wRjFnscL9rXQwAAAABJRU5ErkJggg==",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAANb0lEQVR4nO1ayY4kS1Y9dzBzj4jMGhE0SCDeUy8QiN9AQnwuv8CCFSxYwGNQI+hBTfWrqhzCw83sDiw8h8jqejQCKRFSnkUozMLM/Ngd7F67HpSZ+P8G/r8m8D/BC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp58IL6efCC+nnwgvp54JmJhFlJogAOMJgDFZQAIAEwAABjAAQGUIKIJCOIKRAaaudPJRQiIBtSIIemkDcPQWZSaD77wAA2YYYGZACpIOzQGAEg83QB9KU6QCQnBEUBCEkEBvbDXzHAEBuLUYCBJBtcxHsso17mHUHS2YCA5nIBG+DAsyPIxOPBSPuggIQ7mgYQAlylDPStp4gLFrvOG1DE1m2PT0+PoBMBN91cgKEpDua53Z2LvGHBQhPQIlNu3T2QwBiADBodWGCAilIQgrK2VzPzEihQBrg4UosxAoC4m4Hdw/lBCdWQBgFCGSAEiAHy6axrzDks32c98c966e7wWaYDsBBgDKQYczn5hGZAAhxRpEBoGQi7zqRJNvyAgtIgnjTQ1gQgoXSNxuNM6EnQKBNf5RPhEpAPqoEibs934L3yAlEjgjmh8XkbG6zLAICcnRiAtH9dAYTmEB3BozcDNNBuiaYUe953WnlqcwyEbizXbrryc3viSiSH/yQn0xsQMAYELAaA3CBE+ojacsUAJEAQOSExcGCQzaAOmhAMlPhlZKR4eX70T92A9OeaUfMoBSipNiQRER+3zx/2NajzCICHSLCCffBRFWViOCxk4pIEA/BtWPY8rbkZQXo8GhAkg6iTED4JvHXf/8vf/Ov/+bT/Ee/98312v7jZv289kBeTuXdRX09T7/4ZD89Hn++HEfmpcgeJBkG6nNxd7d0JECR6Z4jfJoUgBBlprtHBDOrqhCrKjx6OyFyKsIgs84zSwqzrOanm+sfSf7FH//4z/70mzPrgHaiCibahO1/+d3HX14dlwl/9ZO/XRi/O7+6iXUqMqV+0PTF95UpOB1jvYmZv8/wsh9Zrz9fTeCSxFUaZ/dQEU2a4aN7MrXRt4N1WRYRKZNOdSe1jmGtNXNPRMAl6TBffLz6NKuw8z+M0+Wbn//5n3xzfjwpn7Xc3ZGesa79XSkjRoMv5KtZWY9dZDZ5d3j789vrn11/VvJ3LjX52vuRyoh2qLOCxuqhLFONyOPabgWtNc8Yw1W11trM+rLMXnVYnnh09wympAjzXmsVG448je6rW/bT6F8EbiXchS0wjZ4ioqqjeY/RRpeEc5qPdly6Csv+777/91cy/3491Kqf1tuP3j4fm/CMAl8WYdZSiMiHESBEgzCIEtxitN5RShZZV0OjwgrmE6VHFIDdvftp3Fps3pMD4cjbtfXIeuatCiAziDiBboNYS5nQ+lGMA5L0NtUjVylQMo0//JXZ3D/EerO4Udb9/nKaXGS9WlYfc5mllGR2d4rUaQ7vxAImiViWhU9NRAjCLDrVLAWZPgYjhahKWcaQddVdFaJSipK6u5nV+hhclHGXGwSwjj7CPcLdRWkvc4AziYJKKcxYbPzj6yE5ZMRF5/f7txNVozy29Z+GlanqPDU371lU4X5qqxC7JycVLgLpayulMCDE7GQZ0YeNISTCUoR3WZW4knIaEUFImSctT8wjkXwfbSMTTA4CSVktOH6FwcwZvRZ640QjD/vXNAYqrkt+mPm03r6X8ju7+YNZJ2IVhoQPeIwxRGSeZ6zoNlR1P+9aa0JJhIywvqZoJSnTTpDkPoaBUKTWWiUlAPdO+SSbAKCZDtJIJIFZCGJm7u6ITLklU0gCKSxQzXDdncDNDRA5ES/5qZxOOt7vD/9xvLE+wFJUMTw9RMgzkmBmRMRKbADAzCQEQIh3RTLTrA8fnpZMSTB3VSXJCIBpeEzy6IzKxNuxD+YkWPi6rutqn3dZ4av5JWv0aJK3ESvZ0sauqpKY1qsWdnkx2bIPid7SzXpbuk1cL6bdYF7XtXsQ0UAgnBkgklKUCMJEDMCHtdHHaEEhVUTEIk/L0WstKGAikXwaMzlBwBBiwpCYoh3f7C/e7GQ3zLPv0uS42K68H0VBOw/2tV1/yuNN8fX1HHtpEwWG3wA877s5iFBoGSeP4WYY3k8re8awtLzYX87TnkgnLUCu/cSapFnmCWAY0SCesScdliNOEyvNl0RPSCuBANoyl4eIJbUIoCMX4djx2+CRYy30mvavTdZZ1rBcT5PM73W2SU/eP3265lIpU4jZMz1AxLVkYnu/ul011t6EOCKSIxNbHlJKYVYlJiIGncaSht2rV1XCjv10Ork75DEm6vkOIsLdM5OZsyMiD0xXaDr8xnvx+VQrMREYAWuDKFF9UN76kDo5MiML8awFih4jCJ5Z5omZY5iZiQgx511uicxsNohEhFQ1IjgxlRpt3NzcKFlNJSIzQ30kzRm4P/SQieFhHuYegZudXpR5R0wCFLlwHVVPVUZizvpqOlDRK2+L2SQ7nWdiIUAyOEMIRGThw22e58PhQEQRUUqZ5xnCEeGBCLQ2eu8xLDMjorWmqtM0pUfvfXNWPMW5pCmQEZFIImpCnRMqk0zVoQ4M1+SjNWu9hExzYU5qGcw87w6CaZoygoZ7H633jnABJec93L33HgR3N/PNNgCICDMTESI983Q6zVHevXuHbH7sY4wvbfohy84tdUQmAaJLidL9WJHTvtzanPk5+/uO2u3W/KO3Q8ob5QvIkfgqbJ88hhNCGaRctqtPukhZ1zWGKYuytNO68eZkEdVJNbOUIiBKOEUp5bbf2tr2LFXCzCJCnwr7TtIZgOAue0SOcKLclynqpKAj+353eR0fx2hv5v3ip6MNCwcwFe3JGHl7vFnakhS16CQ6TdMsyuEopZ1W89zPszIv6zrcmHnSSVXLPJn1wtJaQ3rvvXCptUYfx+NxxahQkfO0FAA0E0R3lwgicvfmttpAi3x/SBJc9194+/F84ODv19sf7d8Xx35wZYqCEzxC9g59/bq0YjGG9eOyrOs6zTsI12kiIiREZCpVVU+jNxu11mTaDN0iW2uEiGGDUS7K/s3BWbwfs/nmr08lTUAyFB4xGZrYZxwirOz6hePDhw83b3e/lfu4Wt7xxU+1na5uXiu/fzWtw8aQMZXbMXre7m3qY7XWijLPJRzBREB2O8w7qaW7fz5+bq0Vlt1ux4zjuhyPvtvtjuvp1NZpmpKYSCzcico0K2e3JZCkT206kRQEgbKSqEd45Gl0qtG8W1hfVyKbSQYTJv7lsYt1SQx3LjOBjAmkxFprpYjMdLNkqiLJsis1icjT3SgS5gOeEYf9JXsigOEYrkk7rVBYs956D+4WnB3u1r33vjureygjQRQZ2+UzQFQrmxH1jJhZEaQZymrIIjwuLsba+zADF9EiUoKUVJl0mgCMtVmmkqgqwEqIDBBVFqqTgtxdiI99SSQrO4eRO0eLnpkHnTN7VW2jW7QJmpnn9YMzR8wkou3CTkQkhfsaaTNJCYanMNxMunJQzUJViblMNSJ6X9jHqFxKUWJnnrRM07Tf7dx9PR4dycyiRYirlmAhorolTMwA6pRRgkUysyQFeFeqN/cIIop8WnwANCIYzMyJnEpVluxdMtakDFQGp1jYCTghx/BD3KVswTHSmJnJpiKXhwstxcx7mZoNVZ2S1m5hgwjMSnAkE5IJzDQHwh0+zKxmqqoIkzC0Uo6Z2VKcS6GihSFPjzzirbAIRuyKXlS9amPPelOljeg+atDqnclNGIiEEcxHtjCKIlWIEsrj+spZu1skhVlLb5nLcluViSilSNFIcncAzGyVrQ/K9GHMrFxibVJ07j7G7U0sPZLFXSJdfDSU/ZmkwUJAOBCz6sR0+vSxiDp8+Fhvj7taj30Nplqn9LhOK5DCkkncRhAdl5swq4FIJEmdJ2ZOD1DEunYiIhJVUwVgCQCFZZHtlkVhLiIk3G1IKW+irn41BmeRUklKXpa3b/b7J5IOJAexMJBzBbl9+NlPEZiKmtnVp4/7Wm7WxZCH+RBrb28OYskD3kxKqZOu65o2oDksPDHvdwBaa8jw3hQUBBbhUkEcEUTErFNkW1dKxDARIZXhttvvrxOD1zqI56oFdb5ov/0KFtvFcAP5MFbBfdHrn3/yk++++25d19WltdZaw31W+ZAAPrjsluJs/Q/1LtxXkrZE96FzW+f8c1tHRLbcY8Msycy11lIKgN1u9+233377zR+cR0XKSGzXIWEmDmCYl/ttRID51+qaZ8j7wrN8mYrd/fRF0fEB93W4L/vT72Z9EbzPx9B5hNxYjnBVkfvM/YcJP6X4NNI+TPyh/t8I9+0UBu5l97jIpsGtEciHcjGlP5HSk0L508vxV4fhLEn/GjZz+vV1zEJVcW9jm818MfdR0plpZszMIuZWRPGMeKDxVVXEk0o1Hg/OhwF3q2BztccXJT/8vG3dPHO534wvRj7ogwkPHs/MX1HIg6S3c2B7abQ5NdGXWSx+bcf/G/yQaN39PIH+4ly6m3Ju0+fvpsKdmR8t+MFA/2thftWC//vyB3Cn4a9wfVzv5f/Tz4QX0s+FF9LPhRfSz4UX0s+FF9LPhRfSz4UX0s+F/wRjFnscL9rXQwAAAABJRU5ErkJggg==\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         },
         {
-          "output_type": "display_data",
           "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAY5ElEQVR4nJV7Wa9lx3Xet1ZV7b3PcKceOUhsUhIlKpZMmjKsmE7gGA4kG4kyKEAcIEEA+yHIS4I8BHn1T8h7AiQPAZIXB0mQlwhBlISSEVM0xUE0JVFNsslmD7f79u177xn2ULXWykPtfc653c3uVuHcc/fZ41ervlpjbTKNAAAGAcZGAKDoGwMAyAACDEJoAQEYcAABZGADCEr9+QQ4KCwCEQRDELAHwQABYABACQ6AGrzAAV6Hx+XbPrz59abxZ54+7M83HZCBbH2UN7oKAHD5n4Jz14gAymcpyAOaZUKwfDbn7jwSMkBrSYP7G9wvafQCAm0AM8AyDoAggA1ACHBDf9Kws+9kHjSCQRUKGAOUH6wMAPzZshuaBwDih4i5R0zaozQACjOQwhQAWAEwWMAMtx49AwzEfTdWgtWMEAwwZ8HDYAqTXgS9rB4CehDVZltd1O8m7aVvDOMeNwBIP9xQAhMYCAAcfC92wDEMifKeodeKlQQYYI808EtXvHoo6GHE7DPP0TVfaNUpBgzkwPkE3rjc1v8JMBABpgDnbWc9nVZ3N3hi7e/+OJxWM/3M8dDTusQAZ/nZ/d0VUIMpdJAsOzgHhgICUOZ46q/O3YAHQYZpgNVZw/ejQSdby+g0dAVAp1WCgQV8TycF61mYb+IBN8zF3O9+XmoaVB6BGMT5Wgzd+eVV3r1wAcCMVNXMwOTZKaDQOnUOZfB0coJqCmN0wKe3sOxSOfIXz6LIM88QGAJ4oCBYxNR7WERXIwQkA7GjQOTMrfv8OO2BklYApkpERGQDbfOhVheeKyBkW5GATw7w7/7j//zk5kGYTLbP7jzxxMUnLp49d2Zne1r4gBvX5fDOnQnVz54ff+Mr5wuJ45JgKz3rQB4ENdhjqTsA8JsDvXkBsQegMMmznqACta703KZZ8HuHx3GyU3TAn76+/3/+7P3nvvYSdnaOnL95rZFrHxWBTdKy7ra3nolNPdu/fGnPP/WF339yEkqAI8jE2s7MuKrgiEkhHYQRRo9UeaSDpDcQ9+Q0IGUBbFBb0TLcsuVQ8se38e//0/cP2+qg1pmG8bmLxda0sySQUBCpNk0E75wc3MFif7eoX3p279LZ8Hd+98XdgGBwGGaiRVACBASgAj2QtBugzTY01IbMVUHcK9T8nSdNp/CM1vAn/+317//wrfGZSw1vabWzv4g82Q6TCYUAMjMhqKmLrWeNx/sfXro4euZc+fFP33h6Z/T7v/vbv/r8me0RCoAVJWXT2XaLWTE99xkz7X7Q92hpAjZ0gg2gI9AAr787+5P//N+pmN48mC+Sf+K5F3hr707d1UKJOfiCmVWSU5S+APynVz7YnfqXv/5Fh9knH7x3cmt/d1yd39l75ddf/o1f2zs/BkUEw1aRAAHCo+lh+iCrQjBDtN65yDp3tsTBEv/1//78rfeviWJ79+zhyWLeRS7H1e7eeHd3VndtFx1xwY5EKSmrtXXj2M7sjbo4296pbt++dXBw54Uvf/Xw9mFJdHF362tfeurlF7afO4cSMEkT538pL2+wF6QAlLxRT4mjGr/46OjHb7/zkw9vzsOTsTiztbM7b5rjbl5HufTMxRu39kdbE2epIPFk01AWhUtt1zXL0SRcv3H1c0897/y4Gm8LjuG3OjedXNhansw+vHP86e13fvh6+8yFyV9++YVvfnWXgaLX1uuptbIMlF2Gnh668r8SqDFoRBlR1sD+Av/2P7x28+48McqdM42V5EYppRjjzs7Oq3/6w+9+97sfXvkIwGQy0STOufNnzjrmo8O7dV1/ev3aM898bnd39+Dwzt7ezhtvvPHMc1/o2sTsxuOxpSSp8SSpWTLJ03vhn//By+cLjAGSlh0DLqI38Q5wiLDkN1zijNuABGgHCMq54NUfHV09TOXuJQ58krqymqSUIsyPKg7h3LlzN27cOLt3ZnZ0PDs8OpkdBedZZW9vzxeOOoDt1t07Qry9e6YaT9hXKphsTc1ghFaFfRkmE6m6etHcXC5/8ObB3/jmOa8YOQcRMKlxdgtWZsQrlPuwZYXdAyAEBa7fwo/f/kk0d2Znt2WrZzMwgz17IkcK+/ylS4dHR+cuXDAzOIbjwI7Yi0IU80U9Wy5OFvPYSVEUURJ7ZwRmZnZRBMzkHDkXyiIlVW1fe/vdl770154/C4MnUsAKRrfWyLSyIHBraRPgFEwo54J33v14Vqfdc09Fo1aUfEhqLviiKGKMdRt39vaIqGkaMFfj0fb2tojM5/O6a0XkeD47f/48ERWhSirNyeL8+fN7e3ttijEJM5dlqbCma41QjqqJ8/PbB2+8d+XZv/qstjItyNqaKufXXiQD3lt2aYgHBx8gDwQBDg7x5l/8AmFaTncOm9iSiXHlXEziiuALiEgb097Z84u6DiEYsQJtjIu6LopiPB6fPX9uZ2eLiFJSAGY23dnm4GNTE7ERnPcEizEayDsW5urcUz9+/9orv/bs56YOZkSAiSMI2AABM5gVsDxPs+owhoXM6xu35ndOGnFla0jkKJRG7ELZdV2XYlGOymo8Xyx8EYxAjsn5VjSajqfT7TN70+3t7d09JW7bNqUksHI8MmBZ10QUQlCYwsg5XxRlWQrs8HiB0c6tpbzzwZFm8YWgyxlMeJh0sqHGE5BAmgMZAZYdfnb5mh/ttupaY/hA7NmHpOqLysh1kozJFeWybp0v6qZTM1FVo3I0JvbLpq3bRlUFBsdqNp5MvPdmVlSlCz4HF0QEgL0jx63Y0VJ5fO6nV/bvJiQAxMwAEiHREI/wgHtFjr438xZ/8f41LrZahRIl06bpYLxcLre2tqqqWszrrut2dnaWbZOnYDme+LIwJgOiigGjyRhERVU670/ms7Ztm65dNvV8Ps9wnXNm1sYupRRCqEaTu4uu2r5wcNJevho7oG0jyhKmm/BYYACaugYUKlnMdcJ7v0itldX2XqOY1w0zS+pgUhVlXddR0mgyJua268qqApHzvm4aMIWy6CSxd9Vk3MYopj6Eo5Pjn77/8//1v79/+aMPBaaElFJRFMwcY4Qag0xUVZd1x+Vk/6S9/OlhC1A5HYJu5ewzA96MiKisAiBwAUBnII9ffHwz+RHgxcg5ahfzuFhOww4cDc2ITjsJpJaTPdzPDyOIajLdPXvmxRdfFJHJZFKWparGLhGRmZEZA6nrCOLIS7KTeTPeOvfB9Tt39WLBcPCOEqAEYbAB7MEAE7GmlEO3aLjb4GdXrpsfJ/Jg8kzLkyPqWm/myNhlOjARERuxgQbjDxibsSmpkiqBmOu2adp2NB5v7+ywczFGVXVEnpnMyMCg2HZNXTsyVum6rhhtXztcvH1ZaqDWMLgbSjkqY4KoASA2ZJvu8O7PcbxIkQtlV1Rlapt2drwVnIvdWmEyHCPLHP18UmJj5rzHzACrphUHrwQzMzMRUVUHcs4xKBMjEFtM0nRsKMgKpk6h5fYP3nhvCUiAIWTQDsnlgWQjwMh5Mc3e4Zvvvu8m262yMfuiaJYn3WI2hrbHR4jRUiSVDNQRciqEGYARgZmYs4E1Iqqbhpir8ShUZVEUVVWVZcnMnp2JOgMDse26pkUStO3EGUuXFH68e/n63Z9cQwRiLygBxCFxn0PJbhNTAq4f4ur+7dF0NxorMTOnrpN6vrx79+6NaxLblJKqkgmgK4JnsmSF4JwbdrKIZMFHSV3XiQipQY0MmhKDrEt3bt0+PjiMbRebumTEeuF8Ec1pufXaO59GIPWKI2t2Yc7JK/IGU6Dp8P9+9H6npuzIeXYBwLgqNDbXP/rg4Pr12LWSOtGoqgwwjBjE2Z1gR+YZ7JCJTmxbW1u+LFYsMjNmLopCRFJKAOq6/vSTqzdv3GjrpqvrgpKzpKrJXLVz4YOr++9eidIb8JyIU6YhsVM3FlHOGvzorfc0jGplKysLI0MYTbZN3fXr145P7moSETHRzNG1d5iZvaFccquXy3o277ronA/jETOnlCR10CiSiKhrm6P9qycH12NbxxjN+XI8aWPyReFCmMf05k8/iICgBAIIMGUAsWtT4qLaEuC/fO+1VO7x1lm3faaWUAtFni5qd/FzzybH1WTU1Y031zVxOa9hTMSS1PtgBvJeiaIYjE3JorFhxDzyRUFBErWi6tgTkNqki5gWbZd2p5On98KFLSXEw/mioaIh70IQ6bz3wY9+/O6Hh4oFkGgCBBCzdk01Kr3jusXVG/GjK58KsZGbL2bMYKDwxe7umdnx8XhSLhbHxCYxaUwmaqopqoiISM4kmfUObi94A5k6A4wVLMQ57ceG0aiM2h0dH8Zu+be+/dtP7Y2uXblcVUWYTFBUwlgul/Vicebs+XK89WdvHKQ+Je8A5qQCoGlSWWIUuKtPgjYTF7eDjtFgMePmyHWzyonUx3vbkzL4FR1VNauw9VR+cFsnj4ygxEocVcqyLIri+PDO13/ly9/6nb9ycO0Dp51zbl53BJ5Ot1OSxWKhqrPZbG3GDFyMRgCqkYfhzsG+NLM4O/Dx6GwZt2hRdIeVnNjyzqUL23dufPSlZ58clVllwnufzatnZtBm2pSGdD4R9WniIRtvYAMZWI3APJmMu3aJ1HznW1+rsGxnt0tHDOuaxjGmk3HpmKBZw65wM8BN24gIDL/6wlP/6l/802/8yrP7H7y9uPH+01u4OEo038dyv9CTnUrP740d9xqAmXOab2VNaAjsMwHoVCVCV4eFWImr0bhp2+ViNi7c2KULE/zmi8/Pbn40v7N/bme6PQraLjjWpK12bVcvN+/FIHjvnXNsxoZLF4q/++3f/ON/+YcvPLVjJ5/Wty5/6cnxV57eef0H/+PzF7e/+etfl9SqavYXs0HOynitSU7xRAHbLHoosYGVqE0ynW7XdS2pPbNVBuAP/8Hf9t0Rd8fx5PbJ/ieYH465C2lJ3YJTs65+AN6ALDDv+qTz3gg7W/jH333p1l386M9/9uqrr9az49/6xlf+6B/9wyee3/vem58aCu89gJSSd8zMSZUcZxkPU3GgR07tGtg2E+kc2ziajJ07MZLpiCvgW7/13DvvvvK9P3/t6S9+/dLTT5aFu/7JhxRnLz3/zN/7zm/4Vb7Y2ItYKAqIwpmk5Fwx9VhE7AToCH/wey/8/d974fKHR09f3N2e4Gc3oRKdJ8/OE0eNTOScSzpQdpUZvKdKRYZTRTKEarSslwacO7tXefYAAf/sj/7mB5/8m8XdKx/f+fDM7s6lC2e//Tvf+eoXywnB9Zl8BeBdFjAzoM4xkMh4GliA8xNEhWN87Qu7+ZGTMofPTkQQY2aziDBzTmQOlq/3DdTUZS/ELIc1nJ1AsxRjDmzbu+248g6J4ace//qP/8msgQmqCtMRfJ8IRXAZMQG4Pwdl2Vo6Ygemgb7rOoPBzFSVBumSgWAwy260mRHBBs/a0NvczBCCwowtu7BKRKrati0mROBgvFdgwoAihF5duP5vFWqpv69ANMhJBaQMdSjWaUiDWlJVVbWUmPnUtFMzzjy2oZBgSt5gMDIYqToitnVd1NjFpIvFAmemgDoQjLwbSlyqsASidUk0x5MbIh7S8Lk6CAWBTYFE8JyTqANCVd0kbfZDciQyDFfeT0YwYxgx9VeSwvqBIGLXih6fzNWmTAw2dDGHJTAAAlUwg9a1JEMu760fP9QeSWEGo9V86quFG+OiuvZLVQYVbQDBaP3LwEagnNgicSCn0CE0c1zGpHdnC8t1MwDOE9m6uOtWHl1/Q+3DmIGwq5oA5W6RKfVhGfpKDBGcI3ZEup52UFUb4pcVp3vQRqYEIyYjA5mQGYwUSi6Qd2I8X7RCvs8NOAYAE5iCByNouWjOmQMepkNx91R9iYgYBOqnQO6i5P3MeXauNlSVnLNBgeQNNojBmC0rFDMy6xcuQKEGB++CgpZNp8Nkihk6OYDZhNkBSJocWNGrBF7Rd2NAH9yorwD2IUm/gV7Sq9Ms50OBXGEiqJko+ioZkA+CTBnKzAZfq5MVO60XEDkC5zUP7F2xcj0IYLD2ywLoVDFPJQHKDJhpjKr96gbnnKp2XUdEOQBpmo7Jm+XhIyPOfoYRGwEaCWIE7eFrAglxEUjaWqUrJ5Orh3WXc+ltWxH8UMLgviDKfSw7fPzAC76n9khkyIPIHHwwggI+e0uOyTERQU1VmR0RZQuysVyDe6lDDGRmBjMywCivSVBzrKZKLrSaUh5JsmwiHjzUm7febKsatXMOgIlsHnXuXkN9n7Lr95j10SsZ84MIlz0tVQ0hxCg9bdyjlyBgkPSaLg8mNCFGwIEdABIRgoHZBe8H7QEmMxsq3+u8B2CG4cDQo1xVY3Jm5r3PU0IV7nHqtcMilc883Gs0gRgcIwRkw6sqCviiDwhUexVE2lvEzwZ9akwAMPveU7CHIbkP9AOaZnXbc5SRtacSjAlGImoqKSWS5OCwQY/NlnGfBj0QjCAihMrMQlEAYAYeDzffT+uN52VdyEZ9MezoGI5D8GVRVESu61JTd5KMyGXtAbAZsTEpUU6SWb+obOPWDICIUkrkWETKsswzFA/q+QNB37cFAH3Qlx26vKducefuEkyuCCEE51xUiTEmFR5Ml62J0f80M8v5U7Xe6zAjNbBTBRGJagg9zXB63n9W8/cMB63LjJRiJHLMHIE2oSxx5ZOrXdeV01JEnHnr2rppQln0a0JWouztvoGMwEwwg8AMxj2pTVJy3td1HUIZY4usA1boHwH6QS1XS5m5D8ysLyQtm1aJmYnJsQvwzoA+JuDsdTyAkr3GICYbtkGrMRSRumu7xwH7cNC5sXO9w2bwDAFmJ4uUhETMzHtXlqWZZV4SOSLi7CJtrOTLFsd6VWI0LCHIoA0mInVdL1to8cuBvofPmcQG9N63Uu8tHc9nSUrruk5SoRKKwsw4YxrcutU3BtC5I2RqRAbdBM1ghdVN07aw8Pgq7yGrNfun9hsCNE3n3BTg2Ensal8kIipoyHtQ/pAN8VVe3QYDtLfhMDPttYmqOkc5JRmlXzX3eKDvk809XciDbYAokohzzhVFl1KMMcaY6UFELoRVTIA1aAVZH9jCuFfTBpgpiUjhaRWzPZ6UM+iHn2u29loNRC7G6IlGo5FzLkrK1bScTN8EPWQ8bDVU1lv5NTdyioc5p7nvfdxDQee1hIRVpU5WKydNzbI/Ds1rE9jPF0svGkIg59B1UZIpFFIoiK131PpYM6OAgciiA4gU2muPXEcimIM50yGCBOjRK8YYKkDqCdB/sluWQEImsesALDs4hzDe9dXWyWzRtJHYj0aTne3d4AoGp04kiiY1sWGhJxlYyAsIlqAtJ2UhMxOQWTmp9pqTI23mFbtUSxLAhceTNBTmVmEjVh2Okb2D48IVLeADDpa4e3RSFHvJkWnSSN67wrlyUgFV0zRAv2aXTE3NAIGp80YKjayqYgAJQYhAwQeeTkI67paLu2XhhNBJLPyj7Yu/3/fIXeUQsrhSSo14LnF7X5azo3Jrh63h2JlwGgJbDIxaJ3n7rA0pq5pBkqkoFGAxVXixrp7XFbeVa32pYYycMDYoPWrh1anDtLnfCGJQ8t77AAe0de2ZYoytiBrgvQ8FhWDOCdGibRdtO+/aZYp10kasM4pwbXIx+U581BA1JPOCoHDleMvIKXtXVq261956bwE0RvooxNj0p+mBSoeHKgRw5fLPr1y9cu7FFzTsROLouDXuJHVtilF9sUVElqu45PqkNQcRR8YgMVJHRkRGDkwn886HPeLYdJrS6K33b/71V/5SoCCPsYD6wQ4TAyAHR1lLd511oKriL37+ydvLO4mjMhdFUVTj6aTkaQmm5XIpOf1FAITIiAhGasrGDpJrpAQiggKBpfCIi3mcH49AFZwDFktsjR8p6P6dgH5VsK3X7ytBYCYxumKSgATMEj7ax6tvXz6JWC6bpmlilJhSjClKGo+mAlNQ78oaK4GNrTNWkBmZMrKk2YiTqiMdebm4Vz6541956ctffXYSNiPjxwc9CDu7G0gx+jCKigiA0RiynDpBJzCFGFJCFKQIySvADXk25cfHBk6zyjey7E2xEUIAGZ44j70R2hOc24LVNVUB/JlxySbovCyVN5MeK9CZLDJocQIKw6rsi+HtmM1EGzZU5+boYSNwXt8aCABZgrWwCGLwCHiE1vOnVcbQlfUvRl/gRZ+AzXdf9zrjzREUu9WFBBh5MkFn617QoGT7YGNY6ShAtoXc+zoPbfcHpJtJm3X+b8hl5d9p1bPNvm1KMTcBDDEv7NIeq8eG4DHAX30/TuvXT9O9j8MDiGUbmdX78G2C5lOH8ssOyJW6Taz3P+Mxofv7Xr1Y71jNy+FHfldgnTDijWs2cawCTQeQrdjCa1Lj9MYmzAfbi9OgVzBPC/t0R3rEAiPcl2ijvtjygJbzgT1cyj7N6oYbs3mYBo/BZyDXEU+d95npknWd5n7fYH1FPzqnO08bn/6CNLwGARDndKzA45d/ZUSHVb0PaXrKyp4a4g0a24Nn84A7u+5p0Idm0OGFF3aP4Xv8f4v4aTRb5QZGAAAAAElFTkSuQmCC",
             "text/plain": [
               "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=60x80>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAADwAAABQCAIAAADKqIEEAAAY5ElEQVR4nJV7Wa9lx3Xet1ZV7b3PcKceOUhsUhIlKpZMmjKsmE7gGA4kG4kyKEAcIEEA+yHIS4I8BHn1T8h7AiQPAZIXB0mQlwhBlISSEVM0xUE0JVFNsslmD7f79u177xn2ULXWykPtfc653c3uVuHcc/fZ41ervlpjbTKNAAAGAcZGAKDoGwMAyAACDEJoAQEYcAABZGADCEr9+QQ4KCwCEQRDELAHwQABYABACQ6AGrzAAV6Hx+XbPrz59abxZ54+7M83HZCBbH2UN7oKAHD5n4Jz14gAymcpyAOaZUKwfDbn7jwSMkBrSYP7G9wvafQCAm0AM8AyDoAggA1ACHBDf9Kws+9kHjSCQRUKGAOUH6wMAPzZshuaBwDih4i5R0zaozQACjOQwhQAWAEwWMAMtx49AwzEfTdWgtWMEAwwZ8HDYAqTXgS9rB4CehDVZltd1O8m7aVvDOMeNwBIP9xQAhMYCAAcfC92wDEMifKeodeKlQQYYI808EtXvHoo6GHE7DPP0TVfaNUpBgzkwPkE3rjc1v8JMBABpgDnbWc9nVZ3N3hi7e/+OJxWM/3M8dDTusQAZ/nZ/d0VUIMpdJAsOzgHhgICUOZ46q/O3YAHQYZpgNVZw/ejQSdby+g0dAVAp1WCgQV8TycF61mYb+IBN8zF3O9+XmoaVB6BGMT5Wgzd+eVV3r1wAcCMVNXMwOTZKaDQOnUOZfB0coJqCmN0wKe3sOxSOfIXz6LIM88QGAJ4oCBYxNR7WERXIwQkA7GjQOTMrfv8OO2BklYApkpERGQDbfOhVheeKyBkW5GATw7w7/7j//zk5kGYTLbP7jzxxMUnLp49d2Zne1r4gBvX5fDOnQnVz54ff+Mr5wuJ45JgKz3rQB4ENdhjqTsA8JsDvXkBsQegMMmznqACta703KZZ8HuHx3GyU3TAn76+/3/+7P3nvvYSdnaOnL95rZFrHxWBTdKy7ra3nolNPdu/fGnPP/WF339yEkqAI8jE2s7MuKrgiEkhHYQRRo9UeaSDpDcQ9+Q0IGUBbFBb0TLcsuVQ8se38e//0/cP2+qg1pmG8bmLxda0sySQUBCpNk0E75wc3MFif7eoX3p279LZ8Hd+98XdgGBwGGaiRVACBASgAj2QtBugzTY01IbMVUHcK9T8nSdNp/CM1vAn/+317//wrfGZSw1vabWzv4g82Q6TCYUAMjMhqKmLrWeNx/sfXro4euZc+fFP33h6Z/T7v/vbv/r8me0RCoAVJWXT2XaLWTE99xkz7X7Q92hpAjZ0gg2gI9AAr787+5P//N+pmN48mC+Sf+K5F3hr707d1UKJOfiCmVWSU5S+APynVz7YnfqXv/5Fh9knH7x3cmt/d1yd39l75ddf/o1f2zs/BkUEw1aRAAHCo+lh+iCrQjBDtN65yDp3tsTBEv/1//78rfeviWJ79+zhyWLeRS7H1e7eeHd3VndtFx1xwY5EKSmrtXXj2M7sjbo4296pbt++dXBw54Uvf/Xw9mFJdHF362tfeurlF7afO4cSMEkT538pL2+wF6QAlLxRT4mjGr/46OjHb7/zkw9vzsOTsTiztbM7b5rjbl5HufTMxRu39kdbE2epIPFk01AWhUtt1zXL0SRcv3H1c0897/y4Gm8LjuG3OjedXNhansw+vHP86e13fvh6+8yFyV9++YVvfnWXgaLX1uuptbIMlF2Gnh668r8SqDFoRBlR1sD+Av/2P7x28+48McqdM42V5EYppRjjzs7Oq3/6w+9+97sfXvkIwGQy0STOufNnzjrmo8O7dV1/ev3aM898bnd39+Dwzt7ezhtvvPHMc1/o2sTsxuOxpSSp8SSpWTLJ03vhn//By+cLjAGSlh0DLqI38Q5wiLDkN1zijNuABGgHCMq54NUfHV09TOXuJQ58krqymqSUIsyPKg7h3LlzN27cOLt3ZnZ0PDs8OpkdBedZZW9vzxeOOoDt1t07Qry9e6YaT9hXKphsTc1ghFaFfRkmE6m6etHcXC5/8ObB3/jmOa8YOQcRMKlxdgtWZsQrlPuwZYXdAyAEBa7fwo/f/kk0d2Znt2WrZzMwgz17IkcK+/ylS4dHR+cuXDAzOIbjwI7Yi0IU80U9Wy5OFvPYSVEUURJ7ZwRmZnZRBMzkHDkXyiIlVW1fe/vdl770154/C4MnUsAKRrfWyLSyIHBraRPgFEwo54J33v14Vqfdc09Fo1aUfEhqLviiKGKMdRt39vaIqGkaMFfj0fb2tojM5/O6a0XkeD47f/48ERWhSirNyeL8+fN7e3ttijEJM5dlqbCma41QjqqJ8/PbB2+8d+XZv/qstjItyNqaKufXXiQD3lt2aYgHBx8gDwQBDg7x5l/8AmFaTncOm9iSiXHlXEziiuALiEgb097Z84u6DiEYsQJtjIu6LopiPB6fPX9uZ2eLiFJSAGY23dnm4GNTE7ERnPcEizEayDsW5urcUz9+/9orv/bs56YOZkSAiSMI2AABM5gVsDxPs+owhoXM6xu35ndOGnFla0jkKJRG7ELZdV2XYlGOymo8Xyx8EYxAjsn5VjSajqfT7TN70+3t7d09JW7bNqUksHI8MmBZ10QUQlCYwsg5XxRlWQrs8HiB0c6tpbzzwZFm8YWgyxlMeJh0sqHGE5BAmgMZAZYdfnb5mh/ttupaY/hA7NmHpOqLysh1kozJFeWybp0v6qZTM1FVo3I0JvbLpq3bRlUFBsdqNp5MvPdmVlSlCz4HF0QEgL0jx63Y0VJ5fO6nV/bvJiQAxMwAEiHREI/wgHtFjr438xZ/8f41LrZahRIl06bpYLxcLre2tqqqWszrrut2dnaWbZOnYDme+LIwJgOiigGjyRhERVU670/ms7Ztm65dNvV8Ps9wnXNm1sYupRRCqEaTu4uu2r5wcNJevho7oG0jyhKmm/BYYACaugYUKlnMdcJ7v0itldX2XqOY1w0zS+pgUhVlXddR0mgyJua268qqApHzvm4aMIWy6CSxd9Vk3MYopj6Eo5Pjn77/8//1v79/+aMPBaaElFJRFMwcY4Qag0xUVZd1x+Vk/6S9/OlhC1A5HYJu5ewzA96MiKisAiBwAUBnII9ffHwz+RHgxcg5ahfzuFhOww4cDc2ITjsJpJaTPdzPDyOIajLdPXvmxRdfFJHJZFKWparGLhGRmZEZA6nrCOLIS7KTeTPeOvfB9Tt39WLBcPCOEqAEYbAB7MEAE7GmlEO3aLjb4GdXrpsfJ/Jg8kzLkyPqWm/myNhlOjARERuxgQbjDxibsSmpkiqBmOu2adp2NB5v7+ywczFGVXVEnpnMyMCg2HZNXTsyVum6rhhtXztcvH1ZaqDWMLgbSjkqY4KoASA2ZJvu8O7PcbxIkQtlV1Rlapt2drwVnIvdWmEyHCPLHP18UmJj5rzHzACrphUHrwQzMzMRUVUHcs4xKBMjEFtM0nRsKMgKpk6h5fYP3nhvCUiAIWTQDsnlgWQjwMh5Mc3e4Zvvvu8m262yMfuiaJYn3WI2hrbHR4jRUiSVDNQRciqEGYARgZmYs4E1Iqqbhpir8ShUZVEUVVWVZcnMnp2JOgMDse26pkUStO3EGUuXFH68e/n63Z9cQwRiLygBxCFxn0PJbhNTAq4f4ur+7dF0NxorMTOnrpN6vrx79+6NaxLblJKqkgmgK4JnsmSF4JwbdrKIZMFHSV3XiQipQY0MmhKDrEt3bt0+PjiMbRebumTEeuF8Ec1pufXaO59GIPWKI2t2Yc7JK/IGU6Dp8P9+9H6npuzIeXYBwLgqNDbXP/rg4Pr12LWSOtGoqgwwjBjE2Z1gR+YZ7JCJTmxbW1u+LFYsMjNmLopCRFJKAOq6/vSTqzdv3GjrpqvrgpKzpKrJXLVz4YOr++9eidIb8JyIU6YhsVM3FlHOGvzorfc0jGplKysLI0MYTbZN3fXr145P7moSETHRzNG1d5iZvaFccquXy3o277ronA/jETOnlCR10CiSiKhrm6P9qycH12NbxxjN+XI8aWPyReFCmMf05k8/iICgBAIIMGUAsWtT4qLaEuC/fO+1VO7x1lm3faaWUAtFni5qd/FzzybH1WTU1Y031zVxOa9hTMSS1PtgBvJeiaIYjE3JorFhxDzyRUFBErWi6tgTkNqki5gWbZd2p5On98KFLSXEw/mioaIh70IQ6bz3wY9+/O6Hh4oFkGgCBBCzdk01Kr3jusXVG/GjK58KsZGbL2bMYKDwxe7umdnx8XhSLhbHxCYxaUwmaqopqoiISM4kmfUObi94A5k6A4wVLMQ57ceG0aiM2h0dH8Zu+be+/dtP7Y2uXblcVUWYTFBUwlgul/Vicebs+XK89WdvHKQ+Je8A5qQCoGlSWWIUuKtPgjYTF7eDjtFgMePmyHWzyonUx3vbkzL4FR1VNauw9VR+cFsnj4ygxEocVcqyLIri+PDO13/ly9/6nb9ycO0Dp51zbl53BJ5Ot1OSxWKhqrPZbG3GDFyMRgCqkYfhzsG+NLM4O/Dx6GwZt2hRdIeVnNjyzqUL23dufPSlZ58clVllwnufzatnZtBm2pSGdD4R9WniIRtvYAMZWI3APJmMu3aJ1HznW1+rsGxnt0tHDOuaxjGmk3HpmKBZw65wM8BN24gIDL/6wlP/6l/802/8yrP7H7y9uPH+01u4OEo038dyv9CTnUrP740d9xqAmXOab2VNaAjsMwHoVCVCV4eFWImr0bhp2+ViNi7c2KULE/zmi8/Pbn40v7N/bme6PQraLjjWpK12bVcvN+/FIHjvnXNsxoZLF4q/++3f/ON/+YcvPLVjJ5/Wty5/6cnxV57eef0H/+PzF7e/+etfl9SqavYXs0HOynitSU7xRAHbLHoosYGVqE0ynW7XdS2pPbNVBuAP/8Hf9t0Rd8fx5PbJ/ieYH465C2lJ3YJTs65+AN6ALDDv+qTz3gg7W/jH333p1l386M9/9uqrr9az49/6xlf+6B/9wyee3/vem58aCu89gJSSd8zMSZUcZxkPU3GgR07tGtg2E+kc2ziajJ07MZLpiCvgW7/13DvvvvK9P3/t6S9+/dLTT5aFu/7JhxRnLz3/zN/7zm/4Vb7Y2ItYKAqIwpmk5Fwx9VhE7AToCH/wey/8/d974fKHR09f3N2e4Gc3oRKdJ8/OE0eNTOScSzpQdpUZvKdKRYZTRTKEarSslwacO7tXefYAAf/sj/7mB5/8m8XdKx/f+fDM7s6lC2e//Tvf+eoXywnB9Zl8BeBdFjAzoM4xkMh4GliA8xNEhWN87Qu7+ZGTMofPTkQQY2aziDBzTmQOlq/3DdTUZS/ELIc1nJ1AsxRjDmzbu+248g6J4ace//qP/8msgQmqCtMRfJ8IRXAZMQG4Pwdl2Vo6Ygemgb7rOoPBzFSVBumSgWAwy260mRHBBs/a0NvczBCCwowtu7BKRKrati0mROBgvFdgwoAihF5duP5vFWqpv69ANMhJBaQMdSjWaUiDWlJVVbWUmPnUtFMzzjy2oZBgSt5gMDIYqToitnVd1NjFpIvFAmemgDoQjLwbSlyqsASidUk0x5MbIh7S8Lk6CAWBTYFE8JyTqANCVd0kbfZDciQyDFfeT0YwYxgx9VeSwvqBIGLXih6fzNWmTAw2dDGHJTAAAlUwg9a1JEMu760fP9QeSWEGo9V86quFG+OiuvZLVQYVbQDBaP3LwEagnNgicSCn0CE0c1zGpHdnC8t1MwDOE9m6uOtWHl1/Q+3DmIGwq5oA5W6RKfVhGfpKDBGcI3ZEup52UFUb4pcVp3vQRqYEIyYjA5mQGYwUSi6Qd2I8X7RCvs8NOAYAE5iCByNouWjOmQMepkNx91R9iYgYBOqnQO6i5P3MeXauNlSVnLNBgeQNNojBmC0rFDMy6xcuQKEGB++CgpZNp8Nkihk6OYDZhNkBSJocWNGrBF7Rd2NAH9yorwD2IUm/gV7Sq9Ms50OBXGEiqJko+ioZkA+CTBnKzAZfq5MVO60XEDkC5zUP7F2xcj0IYLD2ywLoVDFPJQHKDJhpjKr96gbnnKp2XUdEOQBpmo7Jm+XhIyPOfoYRGwEaCWIE7eFrAglxEUjaWqUrJ5Orh3WXc+ltWxH8UMLgviDKfSw7fPzAC76n9khkyIPIHHwwggI+e0uOyTERQU1VmR0RZQuysVyDe6lDDGRmBjMywCivSVBzrKZKLrSaUh5JsmwiHjzUm7febKsatXMOgIlsHnXuXkN9n7Lr95j10SsZ84MIlz0tVQ0hxCg9bdyjlyBgkPSaLg8mNCFGwIEdABIRgoHZBe8H7QEmMxsq3+u8B2CG4cDQo1xVY3Jm5r3PU0IV7nHqtcMilc883Gs0gRgcIwRkw6sqCviiDwhUexVE2lvEzwZ9akwAMPveU7CHIbkP9AOaZnXbc5SRtacSjAlGImoqKSWS5OCwQY/NlnGfBj0QjCAihMrMQlEAYAYeDzffT+uN52VdyEZ9MezoGI5D8GVRVESu61JTd5KMyGXtAbAZsTEpUU6SWb+obOPWDICIUkrkWETKsswzFA/q+QNB37cFAH3Qlx26vKducefuEkyuCCEE51xUiTEmFR5Ml62J0f80M8v5U7Xe6zAjNbBTBRGJagg9zXB63n9W8/cMB63LjJRiJHLMHIE2oSxx5ZOrXdeV01JEnHnr2rppQln0a0JWouztvoGMwEwwg8AMxj2pTVJy3td1HUIZY4usA1boHwH6QS1XS5m5D8ysLyQtm1aJmYnJsQvwzoA+JuDsdTyAkr3GICYbtkGrMRSRumu7xwH7cNC5sXO9w2bwDAFmJ4uUhETMzHtXlqWZZV4SOSLi7CJtrOTLFsd6VWI0LCHIoA0mInVdL1to8cuBvofPmcQG9N63Uu8tHc9nSUrruk5SoRKKwsw4YxrcutU3BtC5I2RqRAbdBM1ghdVN07aw8Pgq7yGrNfun9hsCNE3n3BTg2Ensal8kIipoyHtQ/pAN8VVe3QYDtLfhMDPttYmqOkc5JRmlXzX3eKDvk809XciDbYAokohzzhVFl1KMMcaY6UFELoRVTIA1aAVZH9jCuFfTBpgpiUjhaRWzPZ6UM+iHn2u29loNRC7G6IlGo5FzLkrK1bScTN8EPWQ8bDVU1lv5NTdyioc5p7nvfdxDQee1hIRVpU5WKydNzbI/Ds1rE9jPF0svGkIg59B1UZIpFFIoiK131PpYM6OAgciiA4gU2muPXEcimIM50yGCBOjRK8YYKkDqCdB/sluWQEImsesALDs4hzDe9dXWyWzRtJHYj0aTne3d4AoGp04kiiY1sWGhJxlYyAsIlqAtJ2UhMxOQWTmp9pqTI23mFbtUSxLAhceTNBTmVmEjVh2Okb2D48IVLeADDpa4e3RSFHvJkWnSSN67wrlyUgFV0zRAv2aXTE3NAIGp80YKjayqYgAJQYhAwQeeTkI67paLu2XhhNBJLPyj7Yu/3/fIXeUQsrhSSo14LnF7X5azo3Jrh63h2JlwGgJbDIxaJ3n7rA0pq5pBkqkoFGAxVXixrp7XFbeVa32pYYycMDYoPWrh1anDtLnfCGJQ8t77AAe0de2ZYoytiBrgvQ8FhWDOCdGibRdtO+/aZYp10kasM4pwbXIx+U581BA1JPOCoHDleMvIKXtXVq261956bwE0RvooxNj0p+mBSoeHKgRw5fLPr1y9cu7FFzTsROLouDXuJHVtilF9sUVElqu45PqkNQcRR8YgMVJHRkRGDkwn886HPeLYdJrS6K33b/71V/5SoCCPsYD6wQ4TAyAHR1lLd511oKriL37+ydvLO4mjMhdFUVTj6aTkaQmm5XIpOf1FAITIiAhGasrGDpJrpAQiggKBpfCIi3mcH49AFZwDFktsjR8p6P6dgH5VsK3X7ytBYCYxumKSgATMEj7ax6tvXz6JWC6bpmlilJhSjClKGo+mAlNQ78oaK4GNrTNWkBmZMrKk2YiTqiMdebm4Vz6541956ctffXYSNiPjxwc9CDu7G0gx+jCKigiA0RiynDpBJzCFGFJCFKQIySvADXk25cfHBk6zyjey7E2xEUIAGZ44j70R2hOc24LVNVUB/JlxySbovCyVN5MeK9CZLDJocQIKw6rsi+HtmM1EGzZU5+boYSNwXt8aCABZgrWwCGLwCHiE1vOnVcbQlfUvRl/gRZ+AzXdf9zrjzREUu9WFBBh5MkFn617QoGT7YGNY6ShAtoXc+zoPbfcHpJtJm3X+b8hl5d9p1bPNvm1KMTcBDDEv7NIeq8eG4DHAX30/TuvXT9O9j8MDiGUbmdX78G2C5lOH8ssOyJW6Taz3P+Mxofv7Xr1Y71jNy+FHfldgnTDijWs2cawCTQeQrdjCa1Lj9MYmzAfbi9OgVzBPC/t0R3rEAiPcl2ijvtjygJbzgT1cyj7N6oYbs3mYBo/BZyDXEU+d95npknWd5n7fYH1FPzqnO08bn/6CNLwGARDndKzA45d/ZUSHVb0PaXrKyp4a4g0a24Nn84A7u+5p0Idm0OGFF3aP4Xv8f4v4aTRb5QZGAAAAAElFTkSuQmCC\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "from IPython.display import display\n",
+        "\n",
+        "for (score, im_idx) in x:\n",
+        "    display(images[im_idx])"
       ]
     },
     {
       "cell_type": "code",
-      "source": [],
+      "execution_count": null,
       "metadata": {
         "id": "Vo_1V653g6nK"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [
+        "D3MQHKeixw4b"
+      ],
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "00618ab3c8064ead9c5e36c36f15b9f5": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_ba3cab9e1105440299aaecf75b533468",
+            "max": 44072,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_1a8d331fc5944af788491ae42cc2631d",
+            "value": 44072
+          }
+        },
+        "020b30456ac04d02b0d511a9780e0169": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "023c6c4ed3b446188eeaaa8151649fd2": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "109cf29003f8412ba5d9ea731f95ec3f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "13e4be26528b4d1dbb5f3a8be1458635": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "165cd045e8f144ecb7d0c3901964259e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_6997b6fb2bac419d85adc36f415587ea",
+            "placeholder": "​",
+            "style": "IPY_MODEL_648fc8fc6c804aae9faf02f09a64e2b4",
+            "value": "Extracting data files: 100%"
+          }
+        },
+        "1a4295168897427eb269166acf54b014": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_165cd045e8f144ecb7d0c3901964259e",
+              "IPY_MODEL_1f5e7e234d544e5e8637b67f876d7397",
+              "IPY_MODEL_be7fceea155642f5b983df24bdd7ca3f"
+            ],
+            "layout": "IPY_MODEL_c892d6a91ccd41b9b2a34831dd566555"
+          }
+        },
+        "1a8d331fc5944af788491ae42cc2631d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "1b763c56ae2d46829e53e18cbd6ae7ef": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "1f5e7e234d544e5e8637b67f876d7397": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_a1670f5b5fc3434985acbe1f5cb61f0e",
+            "max": 1,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_8739d5ebc54a41529741cc43b91ade67",
+            "value": 1
+          }
+        },
+        "2242e5ca5f5943efb9d6cc6158954c8e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "252bc9f78759418c91bcc7a162fed88f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_020b30456ac04d02b0d511a9780e0169",
+            "placeholder": "​",
+            "style": "IPY_MODEL_9b88d8521b964d829c0ff02e53983197",
+            "value": "Downloading data: 100%"
+          }
+        },
+        "2701f0097b2e40f58d3d2933c40f5ad1": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_fcd94e1dc1bb41e2a9e26e9eff76c540",
+            "max": 1,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_d0596dc4deb247a8b3af85c619adec7d",
+            "value": 1
+          }
+        },
+        "2b76a7691c33466a908d23d8c5698867": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "3088b25b28d843888b3ed4443a43cd4a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "31dcc7dd63af4947a793f9adc4a43846": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "40bbfc78bd494552ba6f9a17ea1aa9bf": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "412e57470bae42609ff839adf0e2f802": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "41ad3ca4daa74aa494de4d4b56d166fb": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "4482e1cbf57c4a64886843cf0945ceac": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_31dcc7dd63af4947a793f9adc4a43846",
+            "placeholder": "​",
+            "style": "IPY_MODEL_40bbfc78bd494552ba6f9a17ea1aa9bf",
+            "value": " 44072/44072 [00:04&lt;00:00, 8122.41 examples/s]"
+          }
+        },
+        "4a81afcd4c2e4b9e9973600c21a6a03f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "4ae67bba152f4240adbe501402f70e8e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_7c5d5c25159343e2ad0756ec6346bc6d",
+              "IPY_MODEL_7525713bf9434a8e83ccdd1bc94792a8",
+              "IPY_MODEL_746a421cfd89487585007264cc316536"
+            ],
+            "layout": "IPY_MODEL_8d4f2cea3f02404ea5aed908d6e7ac38"
+          }
+        },
+        "58a9d43ad9654e39aa3a022b6c7bcfcf": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "5abc9e4f2eb6438e86dd127f9f96d08a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "61e755addc4c4fe6920be4081155c766": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "648fc8fc6c804aae9faf02f09a64e2b4": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "6632fa54917a4a66949ac64be2405eae": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_252bc9f78759418c91bcc7a162fed88f",
+              "IPY_MODEL_74e10b36274d45adb9ddf63f10824b86",
+              "IPY_MODEL_974691f61e5846efaa42e118cd87ff72"
+            ],
+            "layout": "IPY_MODEL_989e22e99798474089ed8c55d9adf74f"
+          }
+        },
+        "6857472d8e4b4dd68278597963525e1a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "68711a15d3454c6da258d61210b6fff5": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "6997b6fb2bac419d85adc36f415587ea": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "6d1630037e604e83b8b37b13221c0113": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_f5f4d0cc28d64341b290eef632dfd6c6",
+            "placeholder": "​",
+            "style": "IPY_MODEL_4a81afcd4c2e4b9e9973600c21a6a03f",
+            "value": "Downloading data files: 100%"
+          }
+        },
+        "6e9e8d05043a4b1cb30af96f34ab2d97": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "746a421cfd89487585007264cc316536": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_1b763c56ae2d46829e53e18cbd6ae7ef",
+            "placeholder": "​",
+            "style": "IPY_MODEL_5abc9e4f2eb6438e86dd127f9f96d08a",
+            "value": " 867/867 [00:00&lt;00:00, 22.6kB/s]"
+          }
+        },
+        "7486b22826a74aae85071f33f0fc3a17": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "74e10b36274d45adb9ddf63f10824b86": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_3088b25b28d843888b3ed4443a43cd4a",
+            "max": 136091680,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_2b76a7691c33466a908d23d8c5698867",
+            "value": 136091680
+          }
+        },
+        "7525713bf9434a8e83ccdd1bc94792a8": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_023c6c4ed3b446188eeaaa8151649fd2",
+            "max": 867,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_6e9e8d05043a4b1cb30af96f34ab2d97",
+            "value": 867
+          }
+        },
+        "7607d0df712a45499051e8ab1e7a1cc3": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "7c5d5c25159343e2ad0756ec6346bc6d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_b1d89c5c59ab4c169ba53e5b01602590",
+            "placeholder": "​",
+            "style": "IPY_MODEL_ef1c0a8257434468bb70636ac049035a",
+            "value": "Downloading readme: 100%"
+          }
+        },
+        "8233eea0e1404d59960253f136c7c098": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_2242e5ca5f5943efb9d6cc6158954c8e",
+            "max": 135404761,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_f27f0685c73944b794af96df74fd36bc",
+            "value": 135404761
+          }
+        },
+        "8739d5ebc54a41529741cc43b91ade67": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "8d4f2cea3f02404ea5aed908d6e7ac38": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "974691f61e5846efaa42e118cd87ff72": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_f9e253e85ff942b4b7025fa80bcd43c9",
+            "placeholder": "​",
+            "style": "IPY_MODEL_109cf29003f8412ba5d9ea731f95ec3f",
+            "value": " 136M/136M [00:05&lt;00:00, 24.3MB/s]"
+          }
+        },
+        "989e22e99798474089ed8c55d9adf74f": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "9b88d8521b964d829c0ff02e53983197": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "9e8b1fba499b4333b460022371ec51cd": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "a1670f5b5fc3434985acbe1f5cb61f0e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "a58c4bf3ff87443bb130154914fd6d30": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_d59eb2b6f7a34c828cb732a8ac86febf",
+              "IPY_MODEL_8233eea0e1404d59960253f136c7c098",
+              "IPY_MODEL_f8a61b8bab194518a303bd620c244186"
+            ],
+            "layout": "IPY_MODEL_f598bcca46204914b14767473fefd867"
+          }
+        },
+        "b1d89c5c59ab4c169ba53e5b01602590": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "ba3cab9e1105440299aaecf75b533468": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "be7fceea155642f5b983df24bdd7ca3f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_7607d0df712a45499051e8ab1e7a1cc3",
+            "placeholder": "​",
+            "style": "IPY_MODEL_c50b5960a4614bdd9ce3c940e3207a35",
+            "value": " 1/1 [00:00&lt;00:00, 11.84it/s]"
+          }
+        },
+        "c50b5960a4614bdd9ce3c940e3207a35": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "c892d6a91ccd41b9b2a34831dd566555": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "d0596dc4deb247a8b3af85c619adec7d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "d0e7e6ae228e4eca92d1c29bd51e281d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_da665853f8144b7caa80a54034499bc9",
+            "placeholder": "​",
+            "style": "IPY_MODEL_58a9d43ad9654e39aa3a022b6c7bcfcf",
+            "value": "Generating train split: 100%"
+          }
+        },
+        "d59eb2b6f7a34c828cb732a8ac86febf": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_412e57470bae42609ff839adf0e2f802",
+            "placeholder": "​",
+            "style": "IPY_MODEL_41ad3ca4daa74aa494de4d4b56d166fb",
+            "value": "Downloading data: 100%"
+          }
+        },
+        "da665853f8144b7caa80a54034499bc9": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "dfc716ebacef49e1aeb4de6a22303aa2": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_d0e7e6ae228e4eca92d1c29bd51e281d",
+              "IPY_MODEL_00618ab3c8064ead9c5e36c36f15b9f5",
+              "IPY_MODEL_4482e1cbf57c4a64886843cf0945ceac"
+            ],
+            "layout": "IPY_MODEL_9e8b1fba499b4333b460022371ec51cd"
+          }
+        },
+        "eca90f32fc9248769e710913f60b9b7c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_6d1630037e604e83b8b37b13221c0113",
+              "IPY_MODEL_2701f0097b2e40f58d3d2933c40f5ad1",
+              "IPY_MODEL_fc6e9db41ffa469d8c968afe968f8333"
+            ],
+            "layout": "IPY_MODEL_68711a15d3454c6da258d61210b6fff5"
+          }
+        },
+        "ef1c0a8257434468bb70636ac049035a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "f27f0685c73944b794af96df74fd36bc": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "f598bcca46204914b14767473fefd867": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "f5f4d0cc28d64341b290eef632dfd6c6": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "f8a61b8bab194518a303bd620c244186": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_13e4be26528b4d1dbb5f3a8be1458635",
+            "placeholder": "​",
+            "style": "IPY_MODEL_7486b22826a74aae85071f33f0fc3a17",
+            "value": " 135M/135M [00:06&lt;00:00, 31.3MB/s]"
+          }
+        },
+        "f9e253e85ff942b4b7025fa80bcd43c9": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "fc6e9db41ffa469d8c968afe968f8333": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_module_version": "1.5.0",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_6857472d8e4b4dd68278597963525e1a",
+            "placeholder": "​",
+            "style": "IPY_MODEL_61e755addc4c4fe6920be4081155c766",
+            "value": " 1/1 [00:11&lt;00:00, 11.52s/it]"
+          }
+        },
+        "fcd94e1dc1bb41e2a9e26e9eff76c540": {
+          "model_module": "@jupyter-widgets/base",
+          "model_module_version": "1.2.0",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        }
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
Adding a colab notebook to demonstrate the basic usages of `python_bindings` along 
with real use case examples **fashion dataset with usearch vector store**
file changed:
- added `examples\python_bindings\notebooks\clipcpp_demo.ipynb`
- edit `README.md` file for <a href="https://colab.research.google.com/github/Yossef-Dawoad/clip.cpp/blob/add_colab_notebook_example/examples/python_bindings/notebooks/clipcpp_demo.ipynb" target="_blank"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> button