### PR TITLE
fix: use find_library instead of assuming library extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,9 @@ if (BUILD_SHARED_LIBS)
     set_target_properties(ggml PROPERTIES POSITION_INDEPENDENT_CODE ON)
     set_target_properties(clip PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_compile_definitions(clip PRIVATE CLIP_SHARED CLIP_BUILD)
+    set(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR})
+    install(TARGETS ggml clip
+    LIBRARY DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/examples/python_bindings/clip_cpp)
 endif()
 
 add_subdirectory(models)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,8 @@ if (MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+
 add_subdirectory(ggml)
 
 add_library(clip

--- a/examples/python_bindings/clip_cpp/clip.py
+++ b/examples/python_bindings/clip_cpp/clip.py
@@ -1,4 +1,5 @@
 import ctypes
+from ctypes.util import find_library
 import os
 from typing import List, Dict, Any
 
@@ -8,11 +9,13 @@ cur_dir = os.getcwd()
 this_dir = os.path.abspath(os.path.dirname(__file__))
 
 # Load the shared library
-path_to_dll = os.environ.get("CLIP_DLL", this_dir)
-os.chdir(path_to_dll)
-ggml_lib = ctypes.CDLL("./libggml.so")
-clip_lib = ctypes.CDLL("./libclip.so")
-os.chdir(cur_dir)
+ggml_lib_path, clip_lib_path = find_library("ggml"), find_library("clip")
+if ggml_lib_path is None or clip_lib_path is None:
+    raise RuntimeError(f"Could not find shared libraries. Please copy to the current working directory or supply the "
+                       f"correct LD_LIBRARY_PATH/DYLD_LIBRARY_PATH.")
+
+ggml_lib = ctypes.CDLL(ggml_lib_path)
+clip_lib = ctypes.CDLL(clip_lib_path)
 
 
 # Define the ctypes structures

--- a/scripts/build-python-linux.sh
+++ b/scripts/build-python-linux.sh
@@ -1,0 +1,16 @@
+#/bin/bash
+
+# Change to the project directory
+cd "$(dirname "$0")"/..
+
+rm -rf ./build
+
+mkdir build
+
+cd build
+
+cmake -DBUILD_SHARED_LIBS=ON -DCLIP_NATIVE=OFF ..
+
+make
+
+cp ./*.so ../examples/python_bindings/clip_cpp/

--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -13,4 +13,4 @@ cmake -DBUILD_SHARED_LIBS=ON -DCLIP_NATIVE=OFF ..
 
 make
 
-cp ./*.so ../examples/python_bindings/clip_cpp/
+make install

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,2 +1,6 @@
 #/bin/bash
+
+# Change to the project directory
+cd "$(dirname "$0")"/..
+
 find . -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.c' -o -name '*.h' \) ! -path "./ggml/*" ! -path "./build/*" -exec clang-format -i {} +


### PR DESCRIPTION
The output library filenames are not necessarily `libggml.so` and `libclip.so`. For example, on macOS their extensions are `dylib`.

This change outputs libggml in the same directory as libclip, and uses `find_library` as a more standard way of finding the correct filenames.