### PR TITLE
Fix clip.py for Mac

### DIFF
--- a/examples/python_bindings/clip_cpp/clip.py
+++ b/examples/python_bindings/clip_cpp/clip.py
@@ -16,7 +16,7 @@ def find_library(name):
         return f"./lib{name}.so"
     elif os_name == "Windows":
         return f"{name}.dll"
-    elif os_name == "Mac":
+    elif os_name == "Darwin":
         return f"lib{name}.dylib"
 
 


### PR DESCRIPTION
Fixed reference to Mac in [platform](https://docs.python.org/3/library/platform.html#platform.system) check.