### PR TITLE
image-search : rollback usearch and other fixes

### DIFF
--- a/examples/image-search/CMakeLists.txt
+++ b/examples/image-search/CMakeLists.txt
@@ -5,7 +5,8 @@ set(CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(usearch
     GIT_REPOSITORY https://github.com/unum-cloud/usearch.git
-    GIT_TAG v2.5.0
+    #GIT_TAG v2.5.0
+    GIT_TAG v0.22.3
 )
 FetchContent_MakeAvailable(usearch)
 

--- a/examples/image-search/build.cpp
+++ b/examples/image-search/build.cpp
@@ -13,7 +13,7 @@ struct my_app_params {
 
 void my_print_help(int argc, char ** argv, my_app_params & params) {
     printf("Usage: %s [options] dir/with/pictures [more/dirs]\n", argv[0]);
-    printf("\nOptions:");
+    printf("\nOptions:\n");
     printf("  -h, --help: Show this message and exit\n");
     printf("  -m <path>, --model <path>: path to model. Default: %s\n", params.model.c_str());
     printf("  -t N, --threads N: Number of threads to use for inference. Default: %d\n", params.n_threads);

--- a/examples/image-search/build.cpp
+++ b/examples/image-search/build.cpp
@@ -90,11 +90,11 @@ int main(int argc, char ** argv) {
 
     // search for images in path and write embedding to database
     for (const auto & base_dir : params.image_directories) {
-        fprintf(stdout, "%s: starting base dir scan of '%s'\n", __func__, base_dir.c_str());
+        printf("%s: starting base dir scan of '%s'\n", __func__, base_dir.c_str());
         auto results = get_dir_keyed_files(base_dir, 0);
 
         for (auto & entry : results) {
-            printf("\n%s: processing %d files in '%s'\n", __func__, entry.second.size(), entry.first.c_str());
+            printf("\n%s: processing %zu files in '%s'\n", __func__, entry.second.size(), entry.first.c_str());
 
             size_t n_batched = (entry.second.size() / batch_size) * batch_size;
             img_inputs.resize(batch_size);

--- a/examples/image-search/search.cpp
+++ b/examples/image-search/search.cpp
@@ -18,7 +18,7 @@ struct my_app_params {
 
 void my_print_help(int argc, char ** argv, my_app_params & params) {
     printf("Usage: %s [options] <search string or /path/to/query/image>\n", argv[0]);
-    printf("\nOptions:");
+    printf("\nOptions:\n");
     printf("  -h, --help: Show this message and exit\n");
     printf("  -m <path>, --model <path>: overwrite path to model. Read from images.paths by default.\n");
     printf("  -t N, --threads N: Number of threads to use for inference. Default: %d\n", params.n_threads);

--- a/examples/image-search/search.cpp
+++ b/examples/image-search/search.cpp
@@ -157,8 +157,10 @@ int main(int argc, char ** argv) {
 
     auto results = embd_index.search({vec.data(), vec.size()}, params.n_results);
 
-    printf("search results:\n");
-    printf("distance path\n");
+    if (params.verbose > 0) {
+        printf("search results:\n");
+        printf("distance path\n");
+    }
     for (std::size_t i = 0; i != results.size(); ++i) {
         printf("  %f %s\n", results[i].distance, image_file_index.at(results[i].member.label).c_str());
     }


### PR DESCRIPTION
~with version [1.0.0 usearch](https://github.com/unum-cloud/usearch/releases/tag/v1.0.0) changed the file format, so i will change the file extension of the db.~

turns out the new versions rely way more on the other headers, which pull in more dependencies, which are [marked private in the cmake target](https://github.com/unum-cloud/usearch/blob/c5fd107b398acc995d6fcf19f59a5f2e3d7a1899/CMakeLists.txt#L262C5-L262C5).

i dont see an elegant way to use newer versions, so this will only set usearch to the latest version before it breaks.