### PR TITLE
Don't crash if model can't be loaded.

### DIFF
--- a/clip.cpp
+++ b/clip.cpp
@@ -341,6 +341,7 @@ struct clip_ctx * clip_model_load(const char * fname, const int verbosity = 1) {
     };
 
     struct gguf_context * ctx = gguf_init_from_file(fname, params);
+    if ( !ctx ){ return NULL; };
 
     if (verbosity >= 1) {
         const int n_tensors = gguf_get_n_tensors(ctx);


### PR DESCRIPTION
`clip_model_load` model crashes if the path to the model can't be loaded (eg. file does not exist or is in the wrong format). This change will have `clip_model_load` return NULL if the model can't be loaded.