### PR TITLE
Fix memory leak from new ImageDataRange

### DIFF
--- a/clip.cpp
+++ b/clip.cpp
@@ -1002,6 +1002,8 @@ void clip_image_batch_preprocess(const clip_ctx * ctx, const int n_threads, cons
         for (t = 0; t < num_threads; t++) {
             pthread_join(threads[t], NULL);
         }
+
+        delete[] imageDataRange;
     }
 }
 


### PR DESCRIPTION
I built the library with asan and noticed a small memory leak (32 bytes) that I think was caused by a missing `delete` here.